### PR TITLE
a small leak fix.

### DIFF
--- a/Classes/NSAttributedString+HTML.m
+++ b/Classes/NSAttributedString+HTML.m
@@ -875,6 +875,7 @@ NSString *DTDefaultLinkDecoration = @"DTDefaultLinkDecoration";
 	
     // returning the temporary mutable string is faster
 	//return [self initWithAttributedString:tmpString];
+    [self release];
     return tmpString;
 }
 


### PR DESCRIPTION
Hi,

Thanks you for the lovely useful lib.

Method initWithHTML returns tmpString, while self is left without reference, and creates a leak 

Thanks again,
Mohammed O. Tilawy
