### PR TITLE
missing handler for "color" attribute of "font" tag 

### DIFF
--- a/Classes/NSAttributedString+HTML.m
+++ b/Classes/NSAttributedString+HTML.m
@@ -708,6 +708,13 @@ NSString *DTDefaultLinkDecoration = @"DTDefaultLinkDecoration";
 					{
 						currentTag.fontDescriptor.fontName = face;
 					}
+                    
+                    NSString *color = [tagAttributesDict objectForKey:@"color"];
+                    
+                    if (color)
+                    {
+                        currentTag.textColor = [UIColor colorWithHTMLName:color];       
+                    }
 				}
 			}
 			else if ([tagName isEqualToString:@"p"])


### PR DESCRIPTION
Hello ,

This fix will enable "color" attribute inside "font" tag, so text inside font will be colored.

Thanks.
