### PR TITLE
Fix memory leak.

### DIFF
--- a/Classes/DTHTMLElement.m
+++ b/Classes/DTHTMLElement.m
@@ -81,6 +81,7 @@
         // need run delegate for sizing
         CTRunDelegateRef embeddedObjectRunDelegate = createEmbeddedObjectRunDelegate(textAttachment);
         [tmpDict setObject:(id)embeddedObjectRunDelegate forKey:(id)kCTRunDelegateAttributeName];
+        CFRelease(embeddedObjectRunDelegate);
         
         // add attachment
         [tmpDict setObject:textAttachment forKey:@"DTTextAttachment"];


### PR DESCRIPTION
Add a `CFRelease()` so the `CTRunDelegate` isn't leaked.
