### PR TITLE
Indentation Normalization

### DIFF
--- a/Classes/CGUtils.m
+++ b/Classes/CGUtils.m
@@ -93,5 +93,5 @@ CGSize sizeThatFitsKeepingAspectRatio(CGSize originalSize, CGSize sizeToFit)
 
 CGPoint CGRectCenter(CGRect rect)
 {
-    return (CGPoint){ CGRectGetMidX(rect), CGRectGetMidY(rect) };
+	return (CGPoint){ CGRectGetMidX(rect), CGRectGetMidY(rect) };
 }

--- a/Classes/DTAttributedTextContentView.m
+++ b/Classes/DTAttributedTextContentView.m
@@ -38,17 +38,17 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 + (void)setLayerClass:(Class)layerClass
 {
-    _layerClassToUseForDTAttributedTextContentView = layerClass;
+	_layerClassToUseForDTAttributedTextContentView = layerClass;
 }
 
 + (Class)layerClass
 {
-    if (_layerClassToUseForDTAttributedTextContentView)
-    {
-        return _layerClassToUseForDTAttributedTextContentView;
-    }
-    
-    return [CALayer class];
+	if (_layerClassToUseForDTAttributedTextContentView)
+	{
+		return _layerClassToUseForDTAttributedTextContentView;
+	}
+	
+	return [CALayer class];
 }
 
 @end
@@ -58,7 +58,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 - (void)setup
 {
 	self.contentMode = UIViewContentModeTopLeft; // to avoid bitmap scaling effect on resize
-    shouldLayoutCustomSubviews = YES;
+	shouldLayoutCustomSubviews = YES;
 	
 	// possibly already set in NIB
 	if (!self.backgroundColor)
@@ -79,17 +79,17 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (id)initWithFrame:(CGRect)frame 
 {
-    if ((self = [super initWithFrame:frame])) 
+	if ((self = [super initWithFrame:frame])) 
 	{
 		[self setup];
-    }
-    return self;
+	}
+	return self;
 }
 
 - (id)initWithAttributedString:(NSAttributedString *)attributedString width:(CGFloat)width
 {
-    self = [super initWithFrame:CGRectMake(0, 0, width, 0)];
-    
+	self = [super initWithFrame:CGRectMake(0, 0, width, 0)];
+	
 	if (self)
 	{
 		[self setup];
@@ -113,7 +113,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	[customViews release];
 	[customViewsForLinksIndex release];
 	[customViewsForAttachmentsIndex release];
-    
+	
 	[_layouter release];
 	[_layoutFrame release];
 	[_attributedString release];
@@ -123,12 +123,12 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)layoutSubviewsInRect:(CGRect)rect
 {
-    // if we are called for partial (non-infinate) we remove unneeded custom subviews first
-    if (!CGRectIsInfinite(rect))
-    {
-        [self removeSubviewsOutsideRect:rect];
-    }
-    
+	// if we are called for partial (non-infinate) we remove unneeded custom subviews first
+	if (!CGRectIsInfinite(rect))
+	{
+		[self removeSubviewsOutsideRect:rect];
+	}
+	
 	[CATransaction begin];
 	[CATransaction setDisableActions:YES];
 	
@@ -152,48 +152,48 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	
 	for (DTCoreTextLayoutLine *oneLine in lines)
 	{
-        NSRange lineRange = [oneLine stringRange];
-        
-        NSInteger skipRunsBeforeLocation = 0;
-        
+		NSRange lineRange = [oneLine stringRange];
+		
+		NSInteger skipRunsBeforeLocation = 0;
+		
 		for (DTCoreTextGlyphRun *oneRun in oneLine.glyphRuns)
 		{
 			// add custom views if necessary
-            NSRange stringRange = [oneRun stringRange];
-            CGRect frameForSubview = CGRectZero;
-            
-            
-            if (stringRange.location>=skipRunsBeforeLocation)
-            {
-                // see if it's a link
-                NSRange effectiveRange;
+			NSRange stringRange = [oneRun stringRange];
+			CGRect frameForSubview = CGRectZero;
+			
+			
+			if (stringRange.location>=skipRunsBeforeLocation)
+			{
+				// see if it's a link
+				NSRange effectiveRange;
 				
-                NSURL *linkURL = [layoutString attribute:@"DTLink" atIndex:stringRange.location longestEffectiveRange:&effectiveRange inRange:lineRange];
-                
-                if (linkURL)
-                {
-                    // compute bounding frame over potentially multiple (chinese) glyphs
-                    
-                    // make one link view for all glyphruns in this line
-                    frameForSubview = [oneLine frameOfGlyphsWithRange:effectiveRange];
-                    stringRange = effectiveRange;
-                    
-                    skipRunsBeforeLocation = effectiveRange.location+effectiveRange.length;
-                }
-                else
-                {
-                    // individual glyph run
-                    frameForSubview = oneRun.frame;
-                }
+				NSURL *linkURL = [layoutString attribute:@"DTLink" atIndex:stringRange.location longestEffectiveRange:&effectiveRange inRange:lineRange];
+				
+				if (linkURL)
+				{
+					// compute bounding frame over potentially multiple (chinese) glyphs
+					
+					// make one link view for all glyphruns in this line
+					frameForSubview = [oneLine frameOfGlyphsWithRange:effectiveRange];
+					stringRange = effectiveRange;
+					
+					skipRunsBeforeLocation = effectiveRange.location+effectiveRange.length;
+				}
+				else
+				{
+					// individual glyph run
+					frameForSubview = oneRun.frame;
+				}
 				
 				if (CGRectIsEmpty(frameForSubview))
 				{
 					continue;
 				}
-                
+				
 				NSNumber *indexKey = [NSNumber numberWithInteger:stringRange.location];
-                
-   				// offset layout if necessary
+				
+				// offset layout if necessary
 				if (!CGPointEqualToPoint(_layoutOffset, CGPointZero))
 				{
 					frameForSubview.origin.x += _layoutOffset.x;
@@ -206,12 +206,12 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 				frameForSubview.size.width = roundf(frameForSubview.size.width);
 				frameForSubview.size.height = roundf(frameForSubview.size.height);
 				
-                
-                if (CGRectGetMinY(frameForSubview)> CGRectGetMaxY(rect) || CGRectGetMaxY(frameForSubview) < CGRectGetMinY(rect))
-                {
-                    // is still outside even though the bounds of the line already intersect visible area
-                    continue;
-                }
+				
+				if (CGRectGetMinY(frameForSubview)> CGRectGetMaxY(rect) || CGRectGetMaxY(frameForSubview) < CGRectGetMinY(rect))
+				{
+					// is still outside even though the bounds of the line already intersect visible area
+					continue;
+				}
 				
 				if (_delegateSupportsCustomViewsForAttachments || _delegateSupportsGenericCustomViews)
 				{
@@ -322,14 +322,14 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	// needs clearing of background
 	CGRect rect = CGContextGetClipBoundingBox(ctx);
 	
-    if (_backgroundOffset.height || _backgroundOffset.width)
-    {
-        CGContextSetPatternPhase(ctx, _backgroundOffset);
-    }
-    
+	if (_backgroundOffset.height || _backgroundOffset.width)
+	{
+		CGContextSetPatternPhase(ctx, _backgroundOffset);
+	}
+	
 	CGContextSetFillColorWithColor(ctx, [self.backgroundColor CGColor]);
 	CGContextFillRect(ctx, rect);
-    
+	
 	// offset layout if necessary
 	if (!CGPointEqualToPoint(_layoutOffset, CGPointZero))
 	{
@@ -337,13 +337,13 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		CGContextConcatCTM(ctx, transform);
 	}
 	
-    [self.layoutFrame drawInContext:ctx drawImages:shouldDrawImages];
+	[self.layoutFrame drawInContext:ctx drawImages:shouldDrawImages];
 }
 
 - (void)drawRect:(CGRect)rect
 {
 	CGContextRef context = UIGraphicsGetCurrentContext();
-    [self.layoutFrame drawInContext:context];
+	[self.layoutFrame drawInContext:context];
 }
 
 - (CGSize)sizeThatFits:(CGSize)size
@@ -356,21 +356,21 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	CGSize neededSize = CGSizeMake(size.width, CGRectGetMaxY(self.layoutFrame.frame) + edgeInsets.bottom);
 	
 	// this returns an incorrect size before 4.2
-    //	CGSize neededSize = [self.layouter suggestedFrameSizeToFitEntireStringConstraintedToWidth:size.width-edgeInsets.left-edgeInsets.right];
+	//	CGSize neededSize = [self.layouter suggestedFrameSizeToFitEntireStringConstraintedToWidth:size.width-edgeInsets.left-edgeInsets.right];
 	
 	return neededSize;
 }
 
 - (NSString *)description
 {
-    NSString *extract = [[_layoutFrame.layouter.attributedString string] substringFromIndex:[self.layoutFrame visibleStringRange].location];
+	NSString *extract = [[_layoutFrame.layouter.attributedString string] substringFromIndex:[self.layoutFrame visibleStringRange].location];
 	
-    if ([extract length]>10)
-    {
-        extract = [extract substringToIndex:10];
-    }
+	if ([extract length]>10)
+	{
+		extract = [extract substringToIndex:10];
+	}
 	
-    return [NSString stringWithFormat:@"<%@ %@ range:%@ '%@...'>", [self class], NSStringFromCGRect(self.frame),NSStringFromRange([self.layoutFrame visibleStringRange]), extract];
+	return [NSString stringWithFormat:@"<%@ %@ range:%@ '%@...'>", [self class], NSStringFromCGRect(self.frame),NSStringFromRange([self.layoutFrame visibleStringRange]), extract];
 }
 
 - (void)relayoutText
@@ -378,7 +378,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	// need new layouter
 	self.layouter = nil;
 	self.layoutFrame = nil;
-    
+	
 	// remove custom views
 	[self removeAllCustomViewsForLinks];
 	
@@ -386,7 +386,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	{
 		// triggers new layout
 		CGSize neededSize = [self sizeThatFits:self.bounds.size];
-        
+		
 		// set frame to fit text preserving origin
 		self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, neededSize.width, neededSize.height);
 	}
@@ -455,7 +455,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	if (_attributedString != string)
 	{
 		[_attributedString release];
-        
+		
 		_attributedString = [string copy];
 		
 		// need new layouter
@@ -472,7 +472,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 - (void)setFrame:(CGRect)frame
 {
 	[super setFrame:frame];
-    
+	
 	if (!_layoutFrame) 
 	{
 		return;	
@@ -547,7 +547,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		{
 			CGRect rect = UIEdgeInsetsInsetRect(self.bounds, edgeInsets);
 			rect.size.height = CGFLOAT_OPEN_HEIGHT; // necessary height set as soon as we know it.
-            
+			
 			_layoutFrame = [self.layouter layoutFrameWithRect:rect range:NSMakeRange(0, 0)];
 			[_layoutFrame retain];
 		}
@@ -557,13 +557,13 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)setLayoutFrame:(DTCoreTextLayoutFrame *)layoutFrame
 {
-    if (_layoutFrame != layoutFrame)
-    {
-        [_layoutFrame release];
+	if (_layoutFrame != layoutFrame)
+	{
+		[_layoutFrame release];
 		
-        _layoutFrame = [layoutFrame retain];
+		_layoutFrame = [layoutFrame retain];
 		
-        //		[self sizeToFit];
+		//		[self sizeToFit];
 		
 		[self removeAllCustomViewsForLinks];
 		
@@ -572,7 +572,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 			[self setNeedsLayout];
 			[self setNeedsDisplay];
 		}
-    }
+	}
 }
 
 - (NSMutableSet *)customViews

--- a/Classes/DTAttributedTextView.m
+++ b/Classes/DTAttributedTextView.m
@@ -23,8 +23,8 @@
 
 - (id)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-    
+	self = [super initWithFrame:frame];
+	
 	if (self)
 	{
 		[self setup];
@@ -36,20 +36,20 @@
 - (void)dealloc 
 {
 	[contentView release];
-    [super dealloc];
+	[super dealloc];
 }
 
 - (void)layoutSubviews
 {
 	[super layoutSubviews];
 	
-    if (!contentView)
-    {
-        [self addSubview:self.contentView];
-    }
+	if (!contentView)
+	{
+		[self addSubview:self.contentView];
+	}
 	
-    // layout custom subviews for visible area
-    [contentView layoutSubviewsInRect:self.bounds];
+	// layout custom subviews for visible area
+	[contentView layoutSubviewsInRect:self.bounds];
 }
 
 - (void)awakeFromNib
@@ -93,8 +93,8 @@
 		contentView.userInteractionEnabled = YES;
 		contentView.backgroundColor = self.backgroundColor;
 		contentView.shouldLayoutCustomSubviews = NO; // we call layout when scrolling
-        
-        [self addSubview:contentView];
+		
+		[self addSubview:contentView];
 	}		
 	
 	return contentView;
@@ -185,9 +185,9 @@
 		{
 			contentView.frame = CGRectMake(0,0,frame.size.width, frame.size.height);
 		}
-
+		
 		[super setFrame:frame];
-
+		
 		// always set the content size
 		self.contentSize = contentView.bounds.size;
 	}
@@ -195,12 +195,12 @@
 
 - (void)setTextDelegate:(id<DTAttributedTextContentViewDelegate>)textDelegate
 {
-    self.contentView.delegate = textDelegate;
+	self.contentView.delegate = textDelegate;
 }
 
 - (id<DTAttributedTextContentViewDelegate>)textDelegate
 {
-    return contentView.delegate;
+	return contentView.delegate;
 }
 
 @synthesize attributedString;

--- a/Classes/DTCoreTextFontCollection.m
+++ b/Classes/DTCoreTextFontCollection.m
@@ -41,7 +41,7 @@ static DTCoreTextFontCollection *_availableFontsCollection = nil;
 	
 	if (self)
 	{
-        
+		
 	}
 	
 	return self;
@@ -58,7 +58,7 @@ static DTCoreTextFontCollection *_availableFontsCollection = nil;
 {
 	DTCoreTextFontDescriptor *firstMatch = nil;
 	NSNumber *cacheKey = [NSString stringWithFormat:@"fontFamily BEGINSWITH[cd] %@ and boldTrait == %d and italicTrait == %d", descriptor.fontFamily, descriptor.boldTrait, descriptor.italicTrait];
-    
+	
 	// try cache
 	firstMatch = [self.fontMatchCache objectForKey:cacheKey];
 	
@@ -74,8 +74,8 @@ static DTCoreTextFontCollection *_availableFontsCollection = nil;
 	
 	NSArray *matchingDescriptors = [self.fontDescriptors filteredArrayUsingPredicate:predicate];
 	
-    NSLog(@"%@", matchingDescriptors);
-    
+	NSLog(@"%@", matchingDescriptors);
+	
 	if ([matchingDescriptors count])
 	{
 		firstMatch = [matchingDescriptors objectAtIndex:0];
@@ -107,35 +107,35 @@ static DTCoreTextFontCollection *_availableFontsCollection = nil;
 			CTFontCollectionRef fonts = CTFontCollectionCreateFromAvailableFonts(NULL);
 			
 			CFArrayRef matchingFonts = CTFontCollectionCreateMatchingFontDescriptors(fonts);
-            
-            if (matchingFonts)
-            {
-                
-                // convert all to our objects
-                NSMutableArray *tmpArray = [[NSMutableArray alloc] init];
-                
-                for (NSInteger i=0; i<CFArrayGetCount(matchingFonts); i++)
-                {
-                    CTFontDescriptorRef fontDesc = CFArrayGetValueAtIndex(matchingFonts, i);
-                    
-                    DTCoreTextFontDescriptor *desc = [[DTCoreTextFontDescriptor alloc] initWithCTFontDescriptor:fontDesc];
-                    [tmpArray addObject:desc];
-                    [desc release];
-                }
-                
-                
-                CFRelease(matchingFonts);
-                
-                self.fontDescriptors = tmpArray;
-                [tmpArray release];
-            }
-        }
-        
-        // cache that
-        [NSKeyedArchiver archiveRootObject:self.fontDescriptors toFile:cachesPath];
-    }
-    
-    return _fontDescriptors;
+			
+			if (matchingFonts)
+			{
+				
+				// convert all to our objects
+				NSMutableArray *tmpArray = [[NSMutableArray alloc] init];
+				
+				for (NSInteger i=0; i<CFArrayGetCount(matchingFonts); i++)
+				{
+					CTFontDescriptorRef fontDesc = CFArrayGetValueAtIndex(matchingFonts, i);
+					
+					DTCoreTextFontDescriptor *desc = [[DTCoreTextFontDescriptor alloc] initWithCTFontDescriptor:fontDesc];
+					[tmpArray addObject:desc];
+					[desc release];
+				}
+				
+				
+				CFRelease(matchingFonts);
+				
+				self.fontDescriptors = tmpArray;
+				[tmpArray release];
+			}
+		}
+		
+		// cache that
+		[NSKeyedArchiver archiveRootObject:self.fontDescriptors toFile:cachesPath];
+	}
+	
+	return _fontDescriptors;
 }
 
 - (NSCache *)fontMatchCache

--- a/Classes/DTCoreTextFontDescriptor.m
+++ b/Classes/DTCoreTextFontDescriptor.m
@@ -28,64 +28,64 @@ static NSMutableDictionary *_fontOverrides = nil;
 
 + (NSMutableDictionary *)fontOverrides
 {
-    if (!_fontOverrides)
-    {
-        _fontOverrides = [[NSMutableDictionary alloc] init];
-        
-        
-        // see if there is an overrides table to preload
-        
-        NSString *path = [[NSBundle mainBundle] pathForResource:@"DTCoreTextFontOverrides" ofType:@"plist"];
-        NSArray *fileArray = [NSArray arrayWithContentsOfFile:path];
-        
-        for (NSDictionary *oneOverride in fileArray)
-        {
-            NSString *fontFamily = [oneOverride objectForKey:@"FontFamily"];
-            NSString *overrideFontName = [oneOverride objectForKey:@"OverrideFontName"];
-            BOOL bold = [[oneOverride objectForKey:@"Bold"] boolValue];
-            BOOL italic = [[oneOverride objectForKey:@"Italic"] boolValue];
-            BOOL smallcaps = [[oneOverride objectForKey:@"SmallCaps"] boolValue];
-            
-            if (smallcaps)
-            {
-                [DTCoreTextFontDescriptor setSmallCapsFontName:overrideFontName forFontFamily:fontFamily bold:bold italic:italic];
-            }
-            else
-            {
-                [DTCoreTextFontDescriptor setOverrideFontName:overrideFontName forFontFamily:fontFamily bold:bold italic:italic];
-            }
-        }
-    }
-
-    return _fontOverrides;
+	if (!_fontOverrides)
+	{
+		_fontOverrides = [[NSMutableDictionary alloc] init];
+		
+		
+		// see if there is an overrides table to preload
+		
+		NSString *path = [[NSBundle mainBundle] pathForResource:@"DTCoreTextFontOverrides" ofType:@"plist"];
+		NSArray *fileArray = [NSArray arrayWithContentsOfFile:path];
+		
+		for (NSDictionary *oneOverride in fileArray)
+		{
+			NSString *fontFamily = [oneOverride objectForKey:@"FontFamily"];
+			NSString *overrideFontName = [oneOverride objectForKey:@"OverrideFontName"];
+			BOOL bold = [[oneOverride objectForKey:@"Bold"] boolValue];
+			BOOL italic = [[oneOverride objectForKey:@"Italic"] boolValue];
+			BOOL smallcaps = [[oneOverride objectForKey:@"SmallCaps"] boolValue];
+			
+			if (smallcaps)
+			{
+				[DTCoreTextFontDescriptor setSmallCapsFontName:overrideFontName forFontFamily:fontFamily bold:bold italic:italic];
+			}
+			else
+			{
+				[DTCoreTextFontDescriptor setOverrideFontName:overrideFontName forFontFamily:fontFamily bold:bold italic:italic];
+			}
+		}
+	}
+	
+	return _fontOverrides;
 }
 
 + (void)setSmallCapsFontName:(NSString *)fontName forFontFamily:(NSString *)fontFamily bold:(BOOL)bold italic:(BOOL)italic
 {
-    NSString *key = [NSString stringWithFormat:@"%@-%d-%d-smallcaps", fontFamily, bold, italic];
-    
-    [[DTCoreTextFontDescriptor fontOverrides] setObject:fontName forKey:key];
+	NSString *key = [NSString stringWithFormat:@"%@-%d-%d-smallcaps", fontFamily, bold, italic];
+	
+	[[DTCoreTextFontDescriptor fontOverrides] setObject:fontName forKey:key];
 }
 
 + (NSString *)smallCapsFontNameforFontFamily:(NSString *)fontFamily bold:(BOOL)bold italic:(BOOL)italic
 {
-    NSString *key = [NSString stringWithFormat:@"%@-%d-%d-smallcaps", fontFamily, bold, italic];
-    
-    return [[DTCoreTextFontDescriptor fontOverrides] objectForKey:key];
+	NSString *key = [NSString stringWithFormat:@"%@-%d-%d-smallcaps", fontFamily, bold, italic];
+	
+	return [[DTCoreTextFontDescriptor fontOverrides] objectForKey:key];
 }
 
 + (void)setOverrideFontName:(NSString *)fontName forFontFamily:(NSString *)fontFamily bold:(BOOL)bold italic:(BOOL)italic
 {
-    NSString *key = [NSString stringWithFormat:@"%@-%d-%d-override", fontFamily, bold, italic];
-    
-    [[DTCoreTextFontDescriptor fontOverrides] setObject:fontName forKey:key];
+	NSString *key = [NSString stringWithFormat:@"%@-%d-%d-override", fontFamily, bold, italic];
+	
+	[[DTCoreTextFontDescriptor fontOverrides] setObject:fontName forKey:key];
 }
 
 + (NSString *)overrideFontNameforFontFamily:(NSString *)fontFamily bold:(BOOL)bold italic:(BOOL)italic
 {
-    NSString *key = [NSString stringWithFormat:@"%@-%d-%d-override", fontFamily, bold, italic];
-    
-    return [[DTCoreTextFontDescriptor fontOverrides] objectForKey:key];
+	NSString *key = [NSString stringWithFormat:@"%@-%d-%d-override", fontFamily, bold, italic];
+	
+	return [[DTCoreTextFontDescriptor fontOverrides] objectForKey:key];
 }
 
 + (DTCoreTextFontDescriptor *)fontDescriptorWithFontAttributes:(NSDictionary *)attributes
@@ -100,7 +100,7 @@ static NSMutableDictionary *_fontOverrides = nil;
 
 - (id)initWithFontAttributes:(NSDictionary *)attributes
 {
-    self = [super init];
+	self = [super init];
 	if (self)
 	{
 		[self setFontAttributes:attributes];
@@ -114,17 +114,17 @@ static NSMutableDictionary *_fontOverrides = nil;
 	self = [super init];
 	if (self)
 	{
-        CFDictionaryRef dict = CTFontDescriptorCopyAttributes(ctFontDescriptor);
-        
-        CFDictionaryRef traitsDict = CTFontDescriptorCopyAttribute(ctFontDescriptor, kCTFontTraitsAttribute);
-        CTFontSymbolicTraits traitsValue = [[(NSDictionary *)traitsDict objectForKey:(id)kCTFontSymbolicTrait] unsignedIntValue];
-        
-        self.symbolicTraits = traitsValue;
-        
-        [self setFontAttributes:(id)dict];
+		CFDictionaryRef dict = CTFontDescriptorCopyAttributes(ctFontDescriptor);
 		
-        CFRelease(dict);
-        CFRelease(traitsDict);
+		CFDictionaryRef traitsDict = CTFontDescriptorCopyAttribute(ctFontDescriptor, kCTFontTraitsAttribute);
+		CTFontSymbolicTraits traitsValue = [[(NSDictionary *)traitsDict objectForKey:(id)kCTFontSymbolicTrait] unsignedIntValue];
+		
+		self.symbolicTraits = traitsValue;
+		
+		[self setFontAttributes:(id)dict];
+		
+		CFRelease(dict);
+		CFRelease(traitsDict);
 		
 		// also get family name
 		
@@ -138,25 +138,25 @@ static NSMutableDictionary *_fontOverrides = nil;
 
 - (id)initWithCTFont:(CTFontRef)ctFont
 {
-    self = [super init];
-    if (self)
-    {
-        CTFontDescriptorRef fd = CTFontCopyFontDescriptor(ctFont);
-        CFDictionaryRef dict = CTFontDescriptorCopyAttributes(fd);
-        
-        CFDictionaryRef traitsDict = CTFontDescriptorCopyAttribute(fd, kCTFontTraitsAttribute);
-        CTFontSymbolicTraits traitsValue = [[(NSDictionary *)traitsDict objectForKey:(id)kCTFontSymbolicTrait] unsignedIntValue];
-        
-        self.symbolicTraits = traitsValue;
-        
-        [self setFontAttributes:(id)dict];
-        
-        CFRelease(dict);
-        CFRelease(traitsDict);
-        CFRelease(fd);
-    }
-    
-    return self;
+	self = [super init];
+	if (self)
+	{
+		CTFontDescriptorRef fd = CTFontCopyFontDescriptor(ctFont);
+		CFDictionaryRef dict = CTFontDescriptorCopyAttributes(fd);
+		
+		CFDictionaryRef traitsDict = CTFontDescriptorCopyAttribute(fd, kCTFontTraitsAttribute);
+		CTFontSymbolicTraits traitsValue = [[(NSDictionary *)traitsDict objectForKey:(id)kCTFontSymbolicTrait] unsignedIntValue];
+		
+		self.symbolicTraits = traitsValue;
+		
+		[self setFontAttributes:(id)dict];
+		
+		CFRelease(dict);
+		CFRelease(traitsDict);
+		CFRelease(fd);
+	}
+	
+	return self;
 }
 
 
@@ -196,17 +196,17 @@ static NSMutableDictionary *_fontOverrides = nil;
 	{
 		[tmpTraits addObject:@"italic"];
 	}
-    
+	
 	if (monospaceTrait)
 	{
 		[tmpTraits addObject:@"monospace"];
 	}
-    
+	
 	if (condensedTrait)
 	{
 		[tmpTraits addObject:@"condensed"];
 	}
-    
+	
 	if (expandedTrait)
 	{
 		[tmpTraits addObject:@"expanded"];
@@ -216,13 +216,13 @@ static NSMutableDictionary *_fontOverrides = nil;
 	{
 		[tmpTraits addObject:@"vertical"];
 	}
-    
+	
 	if (UIoptimizedTrait)
 	{
 		[tmpTraits addObject:@"UI optimized"];
 	}
-    
-    
+	
+	
 	if ([tmpTraits count])
 	{
 		[string appendString:@"attributes:"];
@@ -231,7 +231,7 @@ static NSMutableDictionary *_fontOverrides = nil;
 	
 	
 	[string appendString:@">"];
-    
+	
 	return string;
 }
 
@@ -309,39 +309,39 @@ static NSMutableDictionary *_fontOverrides = nil;
 		[tmpDict setObject:fontName forKey:(id)kCTFontNameAttribute];
 	}
 	
-    // we need size because that's what makes a font unique, for searching it's ignored anyway
+	// we need size because that's what makes a font unique, for searching it's ignored anyway
 	[tmpDict setObject:[NSNumber numberWithFloat:pointSize] forKey:(id)kCTFontSizeAttribute];
-    
 	
-    if (smallCapsFeature)
-    {
-        NSNumber *typeNum = [NSNumber numberWithInteger:3];
-        NSNumber *selNum = [NSNumber numberWithInteger:3];
-        
-        NSDictionary *setting = [NSDictionary dictionaryWithObjectsAndKeys:selNum, (id)kCTFontFeatureSelectorIdentifierKey,
-                                 typeNum, (id)kCTFontFeatureTypeIdentifierKey, nil];
-        
-        NSArray *featureSettings = [NSArray arrayWithObject:setting];
-        
-        [tmpDict setObject:featureSettings forKey:(id)kCTFontFeatureSettingsAttribute];
-    }
-    
+	
+	if (smallCapsFeature)
+	{
+		NSNumber *typeNum = [NSNumber numberWithInteger:3];
+		NSNumber *selNum = [NSNumber numberWithInteger:3];
+		
+		NSDictionary *setting = [NSDictionary dictionaryWithObjectsAndKeys:selNum, (id)kCTFontFeatureSelectorIdentifierKey,
+														 typeNum, (id)kCTFontFeatureTypeIdentifierKey, nil];
+		
+		NSArray *featureSettings = [NSArray arrayWithObject:setting];
+		
+		[tmpDict setObject:featureSettings forKey:(id)kCTFontFeatureSettingsAttribute];
+	}
+	
 	//return [NSDictionary dictionaryWithDictionary:tmpDict];
-    
-    // converting to non-mutable costs 42% of entire method
-    return tmpDict;
+	
+	// converting to non-mutable costs 42% of entire method
+	return tmpDict;
 }
 
 - (BOOL)supportsNativeSmallCaps
 {
-    if ([DTCoreTextFontDescriptor smallCapsFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait])
-    {
-        return YES;
-    }
-    
-    CTFontRef tmpFont = [self newMatchingFont];
-    
-    BOOL smallCapsSupported = NO;
+	if ([DTCoreTextFontDescriptor smallCapsFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait])
+	{
+		return YES;
+	}
+	
+	CTFontRef tmpFont = [self newMatchingFont];
+	
+	BOOL smallCapsSupported = NO;
 	
 	// check if this font supports small caps
 	CFArrayRef fontFeatures = CTFontCopyFeatures(tmpFont);
@@ -351,7 +351,7 @@ static NSMutableDictionary *_fontOverrides = nil;
 		for (NSDictionary *oneFeature in (NSArray *)fontFeatures)
 		{
 			NSInteger featureTypeIdentifier = [[oneFeature objectForKey:(id)kCTFontFeatureTypeIdentifierKey] integerValue];
-            
+			
 			if (featureTypeIdentifier == 3) // Letter Case
 			{
 				NSArray *featureSelectors = [oneFeature objectForKey:(id)kCTFontFeatureTypeSelectorsKey];
@@ -375,18 +375,18 @@ static NSMutableDictionary *_fontOverrides = nil;
 		
 		CFRelease(fontFeatures);
 	}
-    
-    CFRelease(tmpFont);
-    
-    return smallCapsSupported;
+	
+	CFRelease(tmpFont);
+	
+	return smallCapsSupported;
 }
 
 #pragma mark Finding Font
 
 - (CTFontRef)newMatchingFont
 {
-    NSDictionary *attributes = [self fontAttributes];
-    
+	NSDictionary *attributes = [self fontAttributes];
+	
 	NSCache *fontCache = [DTCoreTextFontDescriptor fontCache];
 	NSString *cacheKey = [attributes description];
 	
@@ -398,172 +398,172 @@ static NSMutableDictionary *_fontOverrides = nil;
 		return cachedFont;
 	}
 	
-    CTFontDescriptorRef fontDesc = NULL;
+	CTFontDescriptorRef fontDesc = NULL;
+	
+	CTFontRef matchingFont;
+	
+	NSString *usedName = fontName;
+	
+	
+	// override fontName if a small caps or regular override is registered
+	if (fontFamily)
+	{
+		NSString *overrideFontName = nil;
+		if (smallCapsFeature)
+		{
+			overrideFontName = [DTCoreTextFontDescriptor smallCapsFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait];
+		}
+		else
+		{
+			overrideFontName = [DTCoreTextFontDescriptor overrideFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait];
+		}
     
-    CTFontRef matchingFont;
-    
-    NSString *usedName = fontName;
-    
-    
-    // override fontName if a small caps or regular override is registered
-    if (fontFamily)
-    {
-        NSString *overrideFontName = nil;
-        if (smallCapsFeature)
-        {
-            overrideFontName = [DTCoreTextFontDescriptor smallCapsFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait];
-        }
-        else
-        {
-            overrideFontName = [DTCoreTextFontDescriptor overrideFontNameforFontFamily:fontFamily bold:boldTrait italic:italicTrait];
-        }
-    
-        if (overrideFontName)
-        {
-            usedName = overrideFontName;
-        }
-    }
-    
-    if (usedName)
-    {
-        matchingFont = CTFontCreateWithName((CFStringRef)usedName, pointSize, NULL);
-    }
-    else
-    {
-        fontDesc = CTFontDescriptorCreateWithAttributes((CFDictionaryRef)attributes);
-        
-        if (fontFamily)
-        {
-            // fast font creation
-            matchingFont = CTFontCreateWithFontDescriptor(fontDesc, pointSize, NULL);
-        }
-        else
-        {
-            // without font name or family we need to do expensive search
-            // otherwise we always get Helvetica
-            
-            NSMutableSet *set = [NSMutableSet setWithObject:(id)kCTFontTraitsAttribute];
-            
-            if (fontFamily)
-            {
-                [set addObject:(id)kCTFontFamilyNameAttribute];
-            }
-            
-            if (smallCapsFeature)
-            {
-                [set addObject:(id)kCTFontFeaturesAttribute];
-            }
-            
-            CTFontDescriptorRef matchingDesc = CTFontDescriptorCreateMatchingFontDescriptor(fontDesc, (CFSetRef)set);
-            
-            if (matchingDesc)
-            {
-                matchingFont = CTFontCreateWithFontDescriptor(matchingDesc, pointSize, NULL);
-                CFRelease(matchingDesc);
-            }
-            else 
-            {
-                NSLog(@"No matches for %@", (id)fontDesc);
-                matchingFont = nil;
-            }
-        }
-        CFRelease(fontDesc);
-        
-    }
-    
+		if (overrideFontName)
+		{
+			usedName = overrideFontName;
+		}
+	}
+	
+	if (usedName)
+	{
+		matchingFont = CTFontCreateWithName((CFStringRef)usedName, pointSize, NULL);
+	}
+	else
+	{
+		fontDesc = CTFontDescriptorCreateWithAttributes((CFDictionaryRef)attributes);
+		
+		if (fontFamily)
+		{
+			// fast font creation
+			matchingFont = CTFontCreateWithFontDescriptor(fontDesc, pointSize, NULL);
+		}
+		else
+		{
+			// without font name or family we need to do expensive search
+			// otherwise we always get Helvetica
+			
+			NSMutableSet *set = [NSMutableSet setWithObject:(id)kCTFontTraitsAttribute];
+			
+			if (fontFamily)
+			{
+				[set addObject:(id)kCTFontFamilyNameAttribute];
+			}
+			
+			if (smallCapsFeature)
+			{
+				[set addObject:(id)kCTFontFeaturesAttribute];
+			}
+			
+			CTFontDescriptorRef matchingDesc = CTFontDescriptorCreateMatchingFontDescriptor(fontDesc, (CFSetRef)set);
+			
+			if (matchingDesc)
+			{
+				matchingFont = CTFontCreateWithFontDescriptor(matchingDesc, pointSize, NULL);
+				CFRelease(matchingDesc);
+			}
+			else 
+			{
+				NSLog(@"No matches for %@", (id)fontDesc);
+				matchingFont = nil;
+			}
+		}
+		CFRelease(fontDesc);
+		
+	}
+	
 	if (matchingFont)
 	{
 		// cache it
 		[fontCache setObject:(id)matchingFont forKey:cacheKey];	
-  	}
-    
-    return matchingFont;
+	}
+	
+	return matchingFont;
 }
 
 - (void)normalizeSlow
 {
-    NSDictionary *attributes = [self fontAttributes];
-    
-    CTFontDescriptorRef fontDesc = nil; CTFontDescriptorCreateWithAttributes((CFDictionaryRef)attributes);
-    
-    if (fontDesc)
-    {
-        NSSet *set;
-        
-        if (self.fontFamily)
-        {
-            set = [NSSet setWithObjects:(id)kCTFontTraitsAttribute, (id)kCTFontFamilyNameAttribute, nil];
-        }
-        else 
-        {
-            set = [NSSet setWithObjects:(id)kCTFontTraitsAttribute, nil];
-        }
-        
-        CTFontDescriptorRef matchingDesc = CTFontDescriptorCreateMatchingFontDescriptor(fontDesc, (CFSetRef)set);
-        
-        if (matchingDesc)
-        {
-            //		CFArrayRef matches = CTFontDescriptorCreateMatchingFontDescriptors(fontDesc, (CFSetRef)set);
-            //		
-            //		if (matches)
-            //		{
-            //			if (CFArrayGetCount(matches))
-            //			{
-            //				CTFontDescriptorRef matchingDesc = CFArrayGetValueAtIndex(matches, 0);
-            
-            CFDictionaryRef attributes = CTFontDescriptorCopyAttributes(matchingDesc);
-            
-            CFStringRef family = CTFontDescriptorCopyAttribute(matchingDesc, kCTFontFamilyNameAttribute);
-            if (family)
-            {
-                self.fontFamily = (id)family;
-                CFRelease(family);
-            }
-            
-            if (attributes)
-            {
-                [self setFontAttributes:(id)attributes];
-                CFRelease(attributes);
-            }
-        }
-        else 
-        {
-            NSLog(@"No matches for %@", (id)fontDesc);
-        }
-        
-        CFRelease(fontDesc);
-    }
-    else 
-    {
-        NSLog(@"No matches for %@", [self fontAttributes]);
-    }
-    
-    
+	NSDictionary *attributes = [self fontAttributes];
+	
+	CTFontDescriptorRef fontDesc = nil; CTFontDescriptorCreateWithAttributes((CFDictionaryRef)attributes);
+	
+	if (fontDesc)
+	{
+		NSSet *set;
+		
+		if (self.fontFamily)
+		{
+			set = [NSSet setWithObjects:(id)kCTFontTraitsAttribute, (id)kCTFontFamilyNameAttribute, nil];
+		}
+		else 
+		{
+			set = [NSSet setWithObjects:(id)kCTFontTraitsAttribute, nil];
+		}
+		
+		CTFontDescriptorRef matchingDesc = CTFontDescriptorCreateMatchingFontDescriptor(fontDesc, (CFSetRef)set);
+		
+		if (matchingDesc)
+		{
+			//		CFArrayRef matches = CTFontDescriptorCreateMatchingFontDescriptors(fontDesc, (CFSetRef)set);
+			//		
+			//		if (matches)
+			//		{
+			//			if (CFArrayGetCount(matches))
+			//			{
+			//				CTFontDescriptorRef matchingDesc = CFArrayGetValueAtIndex(matches, 0);
+			
+			CFDictionaryRef attributes = CTFontDescriptorCopyAttributes(matchingDesc);
+			
+			CFStringRef family = CTFontDescriptorCopyAttribute(matchingDesc, kCTFontFamilyNameAttribute);
+			if (family)
+			{
+				self.fontFamily = (id)family;
+				CFRelease(family);
+			}
+			
+			if (attributes)
+			{
+				[self setFontAttributes:(id)attributes];
+				CFRelease(attributes);
+			}
+		}
+		else 
+		{
+			NSLog(@"No matches for %@", (id)fontDesc);
+		}
+		
+		CFRelease(fontDesc);
+	}
+	else 
+	{
+		NSLog(@"No matches for %@", [self fontAttributes]);
+	}
+	
+	
 }
 
 
 - (CTFontRef)newMatchingFontSlow
 {
-    NSDictionary *fontAttributes = [self fontAttributes];
-    
-    CTFontDescriptorRef fontDesc = CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes);
-    CTFontRef font = CTFontCreateWithFontDescriptor(fontDesc, self.pointSize, NULL);
-    CFRelease(fontDesc);
-    
-    return font;
+	NSDictionary *fontAttributes = [self fontAttributes];
+	
+	CTFontDescriptorRef fontDesc = CTFontDescriptorCreateWithAttributes((CFDictionaryRef)fontAttributes);
+	CTFontRef font = CTFontCreateWithFontDescriptor(fontDesc, self.pointSize, NULL);
+	CFRelease(fontDesc);
+	
+	return font;
 }
 
 - (NSUInteger)hash
 {
-    // two font descriptors are equal if their attribute dictionary are the same
-    NSString *attributesDesc = [[self fontAttributes] description];
-    
-    return [attributesDesc hash];
+	// two font descriptors are equal if their attribute dictionary are the same
+	NSString *attributesDesc = [[self fontAttributes] description];
+	
+	return [attributesDesc hash];
 }
 
 - (BOOL)isEqual:(id)object
 {
-    return ([self hash] == [object hash]);
+	return ([self hash] == [object hash]);
 }
 
 
@@ -597,110 +597,110 @@ static NSMutableDictionary *_fontOverrides = nil;
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    DTCoreTextFontDescriptor *newDesc = [[DTCoreTextFontDescriptor allocWithZone:zone] initWithFontAttributes:[self fontAttributes]];
-    newDesc.pointSize = self.pointSize;
-    if (stylisticClass)
-    {
-        newDesc.stylisticClass = self.stylisticClass;
-    }
-    
-    return newDesc;
+	DTCoreTextFontDescriptor *newDesc = [[DTCoreTextFontDescriptor allocWithZone:zone] initWithFontAttributes:[self fontAttributes]];
+	newDesc.pointSize = self.pointSize;
+	if (stylisticClass)
+	{
+		newDesc.stylisticClass = self.stylisticClass;
+	}
+	
+	return newDesc;
 }
 
 
 #pragma mark Properties
 - (void)setStylisticClass:(CTFontStylisticClass)newClass
 {
-    self.fontFamily = nil;
-    
-    stylisticClass = newClass;
+	self.fontFamily = nil;
+	
+	stylisticClass = newClass;
 }
 
 
 - (void)setFontAttributes:(NSDictionary *)attributes
 {
-    if (!attributes) 
-    {
-        self.fontFamily = nil;
-        self.pointSize = 12;
-        
-        boldTrait = NO;
-        italicTrait = NO;
-        expandedTrait = NO;
-        condensedTrait = NO;
-        monospaceTrait = NO;
-        verticalTrait = NO;
-        UIoptimizedTrait = NO;
-    }
-    
-    NSDictionary *traitsDict = [attributes objectForKey:(id)kCTFontTraitsAttribute];
-    
-    if (traitsDict)
-    {
-        CTFontSymbolicTraits traitsValue = [[traitsDict objectForKey:(id)kCTFontSymbolicTrait ] unsignedIntValue];
-        self.symbolicTraits = traitsValue;
-    }
-    
-    NSNumber *pointNum = [attributes objectForKey:(id)kCTFontSizeAttribute];
-    if (pointNum)
-    {
-        pointSize = [pointNum floatValue];
-    }
-    
-    NSString *family = [attributes objectForKey:(id)kCTFontFamilyNameAttribute];
-    
-    if (family)
-    {
-        self.fontFamily = family;
-    }
-    
-    NSString *name = [attributes objectForKey:(id)kCTFontNameAttribute];
-    
-    if (name)
-    {
-        self.fontName = name;
-    }
+	if (!attributes) 
+	{
+		self.fontFamily = nil;
+		self.pointSize = 12;
+		
+		boldTrait = NO;
+		italicTrait = NO;
+		expandedTrait = NO;
+		condensedTrait = NO;
+		monospaceTrait = NO;
+		verticalTrait = NO;
+		UIoptimizedTrait = NO;
+	}
+	
+	NSDictionary *traitsDict = [attributes objectForKey:(id)kCTFontTraitsAttribute];
+	
+	if (traitsDict)
+	{
+		CTFontSymbolicTraits traitsValue = [[traitsDict objectForKey:(id)kCTFontSymbolicTrait ] unsignedIntValue];
+		self.symbolicTraits = traitsValue;
+	}
+	
+	NSNumber *pointNum = [attributes objectForKey:(id)kCTFontSizeAttribute];
+	if (pointNum)
+	{
+		pointSize = [pointNum floatValue];
+	}
+	
+	NSString *family = [attributes objectForKey:(id)kCTFontFamilyNameAttribute];
+	
+	if (family)
+	{
+		self.fontFamily = family;
+	}
+	
+	NSString *name = [attributes objectForKey:(id)kCTFontNameAttribute];
+	
+	if (name)
+	{
+		self.fontName = name;
+	}
 }
 
 - (void)setSymbolicTraits:(CTFontSymbolicTraits)symbolicTraits
 {
-    if (symbolicTraits & kCTFontBoldTrait)
-    {
-        boldTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontItalicTrait)
-    {
-        italicTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontExpandedTrait)
-    {
-        expandedTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontCondensedTrait)
-    {
-        condensedTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontMonoSpaceTrait)
-    {
-        monospaceTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontVerticalTrait)
-    {
-        verticalTrait = YES;
-    }
-    
-    if (symbolicTraits & kCTFontUIOptimizedTrait)
-    {
-        UIoptimizedTrait = YES;
-    }
-    
-    // stylistic class is bundled in the traits
-    stylisticClass = symbolicTraits & kCTFontClassMaskTrait;   
+	if (symbolicTraits & kCTFontBoldTrait)
+	{
+		boldTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontItalicTrait)
+	{
+		italicTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontExpandedTrait)
+	{
+		expandedTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontCondensedTrait)
+	{
+		condensedTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontMonoSpaceTrait)
+	{
+		monospaceTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontVerticalTrait)
+	{
+		verticalTrait = YES;
+	}
+	
+	if (symbolicTraits & kCTFontUIOptimizedTrait)
+	{
+		UIoptimizedTrait = YES;
+	}
+	
+	// stylistic class is bundled in the traits
+	stylisticClass = symbolicTraits & kCTFontClassMaskTrait;   
 }
 
 //- (NSString *)fontName

--- a/Classes/DTCoreTextGlyphRun.m
+++ b/Classes/DTCoreTextGlyphRun.m
@@ -26,7 +26,7 @@
 - (id)initWithRun:(CTRunRef)run layoutLine:(DTCoreTextLayoutLine *)layoutLine offset:(CGFloat)offset
 {
 	self = [super init];
-    
+	
 	if (self)
 	{
 		_run = run;
@@ -43,7 +43,7 @@
 {
 	CFRelease(_run);
 	[_attachment release];
-    [stringIndices release];
+	[stringIndices release];
 	
 	[super dealloc];
 }
@@ -69,30 +69,30 @@
 	CGPoint glyphPosition = glyphPositionPoints[index];
 	
 	CGRect rect = CGRectMake(_line.frame.origin.x + glyphPosition.x, _line.frame.origin.y, CGRectGetMaxX(_frame) - _line.frame.origin.x - glyphPosition.x, _line.frame.size.height);
-    
-    if (index < self.numberOfGlyphs-1)
-    {
-        rect.size.width = glyphPositionPoints[index+1].x - glyphPosition.x;
-    }
+	
+	if (index < self.numberOfGlyphs-1)
+	{
+		rect.size.width = glyphPositionPoints[index+1].x - glyphPosition.x;
+	}
 	
 	return rect;
 }
 
 - (NSArray *)stringIndices 
 {
-    if (!stringIndices) 
+	if (!stringIndices) 
 	{
-        const CFIndex *indices = CTRunGetStringIndicesPtr(_run);
-        NSInteger count = self.numberOfGlyphs;
-        NSMutableArray *array = [NSMutableArray arrayWithCapacity:count];
-        NSInteger i;
-        for (i = 0; i < count; i++) 
+		const CFIndex *indices = CTRunGetStringIndicesPtr(_run);
+		NSInteger count = self.numberOfGlyphs;
+		NSMutableArray *array = [NSMutableArray arrayWithCapacity:count];
+		NSInteger i;
+		for (i = 0; i < count; i++) 
 		{
-            [array addObject:[NSNumber numberWithInteger:indices[i]]];
-        }
-        stringIndices = [array retain];
-    }
-    return stringIndices;
+			[array addObject:[NSNumber numberWithInteger:indices[i]]];
+		}
+		stringIndices = [array retain];
+	}
+	return stringIndices;
 }
 
 // bounds of an image encompassing the entire run
@@ -188,7 +188,7 @@
 	{
 		[self calculateMetrics];
 	}
-
+	
 	return CGRectMake(_line.baselineOrigin.x + _offset, _line.baselineOrigin.y - ascent, width, ascent + descent);
 }
 

--- a/Classes/DTCoreTextLayoutFrame.m
+++ b/Classes/DTCoreTextLayoutFrame.m
@@ -27,14 +27,14 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 + (void)setShouldDrawDebugFrames:(BOOL)debugFrames
 {
-    _DTCoreTextLayoutFramesShouldDrawDebugFrames = debugFrames;
+	_DTCoreTextLayoutFramesShouldDrawDebugFrames = debugFrames;
 }
 
 // makes a frame for a specific part of the attributed string of the layouter
 - (id)initWithFrame:(CGRect)frame layouter:(DTCoreTextLayouter *)layouter range:(NSRange)range
 {
-    self = [super init];
-    
+	self = [super init];
+	
 	if (self)
 	{
 		_frame = frame;
@@ -43,29 +43,29 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		
 		
 		CFRange cfRange = CFRangeMake(range.location, range.length);
-        _framesetter = layouter.framesetter;
-        
-        if (_framesetter)
-        {
-            CFRetain(_framesetter);
+		_framesetter = layouter.framesetter;
+		
+		if (_framesetter)
+		{
+			CFRetain(_framesetter);
 			
-            CGMutablePathRef path = CGPathCreateMutable();
-            CGPathAddRect(path, NULL, frame);
+			CGMutablePathRef path = CGPathCreateMutable();
+			CGPathAddRect(path, NULL, frame);
 			
-            _textFrame = CTFramesetterCreateFrame(_framesetter, cfRange, path, NULL);
-            
-            CGPathRelease(path);
-        }
-        else
-        {
-            NSLog(@"Strange, should have gotten a valid framesetter");
-            
-            
-            [_layouter release];
-            [self release];
-            return nil;
-        }
-        
+			_textFrame = CTFramesetterCreateFrame(_framesetter, cfRange, path, NULL);
+			
+			CGPathRelease(path);
+		}
+		else
+		{
+			NSLog(@"Strange, should have gotten a valid framesetter");
+			
+			
+			[_layouter release];
+			[self release];
+			return nil;
+		}
+		
 	}
 	
 	return self;
@@ -82,16 +82,16 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	if (_textFrame)
 	{
 		CFRelease(_textFrame);
-        _textFrame = NULL;
+		_textFrame = NULL;
 	}
 	[_lines release];
-    [_layouter release];
-    
-    if (_framesetter)
-    {
-        CFRelease(_framesetter);
-        _framesetter = NULL;
-    }
+	[_layouter release];
+	
+	if (_framesetter)
+	{
+		CFRelease(_framesetter);
+		_framesetter = NULL;
+	}
 	
 	[super dealloc];
 }
@@ -103,47 +103,47 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (void)buildLines
 {
-    // get lines
-    CFArrayRef lines = CTFrameGetLines(_textFrame);
-    
-    if (!lines)
-    {
-        // probably no string set
-        return;
-    }
-    
-    CGPoint *origins = malloc(sizeof(CGPoint)*[(NSArray *)lines count]);
-    CTFrameGetLineOrigins(_textFrame, CFRangeMake(0, 0), origins);
-    
-    NSMutableArray *tmpLines = [[NSMutableArray alloc] initWithCapacity:CFArrayGetCount(lines)];;
-    
-    NSInteger lineIndex = 0;
-    
-    for (id oneLine in (NSArray *)lines)
-    {
-        CGPoint lineOrigin = origins[lineIndex];
-        lineOrigin.y = _frame.size.height - lineOrigin.y + _frame.origin.y;
-        lineOrigin.x += _frame.origin.x;
-        
-        DTCoreTextLayoutLine *newLine = [[DTCoreTextLayoutLine alloc] initWithLine:(CTLineRef)oneLine layoutFrame:self origin:lineOrigin];
-        [tmpLines addObject:newLine];
-        [newLine release];
-        
-        lineIndex++;
-    }
-    
-    _lines = tmpLines;
-    
-    free(origins);
-    
-    // at this point we can correct the frame if it is open-ended
-    if ([_lines count] && _frame.size.height == CGFLOAT_OPEN_HEIGHT)
-    {
-        // actual frame is spanned between first and last lines
-        DTCoreTextLayoutLine *lastLine = [_lines lastObject];
-        
-        _frame.size.height = ceilf((CGRectGetMaxY(lastLine.frame) - _frame.origin.y + 1.5));
-    }
+	// get lines
+	CFArrayRef lines = CTFrameGetLines(_textFrame);
+	
+	if (!lines)
+	{
+		// probably no string set
+		return;
+	}
+	
+	CGPoint *origins = malloc(sizeof(CGPoint)*[(NSArray *)lines count]);
+	CTFrameGetLineOrigins(_textFrame, CFRangeMake(0, 0), origins);
+	
+	NSMutableArray *tmpLines = [[NSMutableArray alloc] initWithCapacity:CFArrayGetCount(lines)];;
+	
+	NSInteger lineIndex = 0;
+	
+	for (id oneLine in (NSArray *)lines)
+	{
+		CGPoint lineOrigin = origins[lineIndex];
+		lineOrigin.y = _frame.size.height - lineOrigin.y + _frame.origin.y;
+		lineOrigin.x += _frame.origin.x;
+		
+		DTCoreTextLayoutLine *newLine = [[DTCoreTextLayoutLine alloc] initWithLine:(CTLineRef)oneLine layoutFrame:self origin:lineOrigin];
+		[tmpLines addObject:newLine];
+		[newLine release];
+		
+		lineIndex++;
+	}
+	
+	_lines = tmpLines;
+	
+	free(origins);
+	
+	// at this point we can correct the frame if it is open-ended
+	if ([_lines count] && _frame.size.height == CGFLOAT_OPEN_HEIGHT)
+	{
+		// actual frame is spanned between first and last lines
+		DTCoreTextLayoutLine *lastLine = [_lines lastObject];
+		
+		_frame.size.height = ceilf((CGRectGetMaxY(lastLine.frame) - _frame.origin.y + 1.5));
+	}
 	
 	// --- begin workaround for image squishing bug in iOS < 4.2
 	
@@ -159,7 +159,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 {
 	if (!_lines)
 	{
-        [self buildLines];
+		[self buildLines];
 	}
 	
 	return _lines;
@@ -167,52 +167,52 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (NSArray *)linesVisibleInRect:(CGRect)rect
 {
-    NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self.lines count]];
-    
-    BOOL earlyBreakPossible = NO;
-    
+	NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self.lines count]];
+	
+	BOOL earlyBreakPossible = NO;
+	
 	for (DTCoreTextLayoutLine *oneLine in self.lines)
 	{
-        if (CGRectIntersectsRect(rect, oneLine.frame))
-        {
-            [tmpArray addObject:oneLine];
-            earlyBreakPossible = YES;
-        }
-        else
-        {
-            if (earlyBreakPossible)
-            {
-                break;
-            }
-        }
-    }
-    
-    return tmpArray;
+		if (CGRectIntersectsRect(rect, oneLine.frame))
+		{
+			[tmpArray addObject:oneLine];
+			earlyBreakPossible = YES;
+		}
+		else
+		{
+			if (earlyBreakPossible)
+			{
+				break;
+			}
+		}
+	}
+	
+	return tmpArray;
 }
 
 - (NSArray *)linesContainedInRect:(CGRect)rect
 {
-    NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self.lines count]];
-    
-    BOOL earlyBreakPossible = NO;
-    
+	NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self.lines count]];
+	
+	BOOL earlyBreakPossible = NO;
+	
 	for (DTCoreTextLayoutLine *oneLine in self.lines)
 	{
-        if (CGRectContainsRect(rect, oneLine.frame))
-        {
-            [tmpArray addObject:oneLine];
-            earlyBreakPossible = YES;
-        }
-        else
-        {
-            if (earlyBreakPossible)
-            {
-                break;
-            }
-        }
-    }
-    
-    return tmpArray;
+		if (CGRectContainsRect(rect, oneLine.frame))
+		{
+			[tmpArray addObject:oneLine];
+			earlyBreakPossible = YES;
+		}
+		else
+		{
+			if (earlyBreakPossible)
+			{
+				break;
+			}
+		}
+	}
+	
+	return tmpArray;
 }
 
 - (CGPathRef)path
@@ -252,80 +252,80 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (void)drawInContext:(CGContextRef)context drawImages:(BOOL)drawImages
 {
-    CGContextSaveGState(context);
-    
-    CGRect rect = CGContextGetClipBoundingBox(context);
-    
+	CGContextSaveGState(context);
+	
+	CGRect rect = CGContextGetClipBoundingBox(context);
+	
 	if (!_textFrame || !context)
 	{
 		return;
 	}
 	
-    CFRetain(_textFrame);
-    
-    [self retain];
-    [_layouter retain];
-    
+	CFRetain(_textFrame);
+	
+	[self retain];
+	[_layouter retain];
+	
 	// any of these settings make sense?
-    //	CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
-    //	CGContextSetAllowsAntialiasing(context, YES);
-    //	CGContextSetShouldAntialias(context, YES);
-    //	
-    //	CGContextSetAllowsFontSubpixelQuantization(context, YES);
-    //	CGContextSetShouldSubpixelQuantizeFonts(context, YES);
-    //	
-    //	CGContextSetShouldSmoothFonts(context, YES);
-    //	CGContextSetAllowsFontSmoothing(context, YES);
-    //	
-    //	CGContextSetShouldSubpixelPositionFonts(context,YES);
-    //	CGContextSetAllowsFontSubpixelPositioning(context, YES);
+	//	CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+	//	CGContextSetAllowsAntialiasing(context, YES);
+	//	CGContextSetShouldAntialias(context, YES);
+	//	
+	//	CGContextSetAllowsFontSubpixelQuantization(context, YES);
+	//	CGContextSetShouldSubpixelQuantizeFonts(context, YES);
+	//	
+	//	CGContextSetShouldSmoothFonts(context, YES);
+	//	CGContextSetAllowsFontSmoothing(context, YES);
+	//	
+	//	CGContextSetShouldSubpixelPositionFonts(context,YES);
+	//	CGContextSetAllowsFontSubpixelPositioning(context, YES);
 	
 	
 	if (_DTCoreTextLayoutFramesShouldDrawDebugFrames)
 	{
-        // stroke the frame because the layout frame might be open ended
-        CGContextSaveGState(context);
+		// stroke the frame because the layout frame might be open ended
+		CGContextSaveGState(context);
 		CGFloat dashes[] = {10.0, 2.0};
 		CGContextSetLineDash(context, 0, dashes, 2);
-        CGContextStrokeRect(context, self.frame);
-        CGContextRestoreGState(context);
+		CGContextStrokeRect(context, self.frame);
+		CGContextRestoreGState(context);
 	}
-    
-    NSArray *visibleLines = [self linesVisibleInRect:rect];
-    
+	
+	NSArray *visibleLines = [self linesVisibleInRect:rect];
+	
 	
 	for (DTCoreTextLayoutLine *oneLine in visibleLines)
 	{
-        if (_DTCoreTextLayoutFramesShouldDrawDebugFrames)
-        {
-            // draw line bounds
-            CGContextSetRGBStrokeColor(context, 0, 0, 1.0f, 1.0f);
-            CGContextStrokeRect(context, oneLine.frame);
-            
-            // draw baseline
-            CGContextMoveToPoint(context, oneLine.baselineOrigin.x-5.0, oneLine.baselineOrigin.y);
-            CGContextAddLineToPoint(context, oneLine.baselineOrigin.x + oneLine.frame.size.width + 5.0, oneLine.baselineOrigin.y);
-            CGContextStrokePath(context);
-        }
-        
-        NSInteger runIndex = 0;
-        
-        for (DTCoreTextGlyphRun *oneRun in oneLine.glyphRuns)
-        {
-            if (_DTCoreTextLayoutFramesShouldDrawDebugFrames)
-            {
-                if (runIndex%2)
-                {
-                    CGContextSetRGBFillColor(context, 1, 0, 0, 0.2);
-                }
-                else 
-                {
-                    CGContextSetRGBFillColor(context, 0, 1, 0, 0.2);
-                }
-                
-                CGContextFillRect(context, oneRun.frame);
-                runIndex ++;
-            }
+		if (_DTCoreTextLayoutFramesShouldDrawDebugFrames)
+		{
+			// draw line bounds
+			CGContextSetRGBStrokeColor(context, 0, 0, 1.0f, 1.0f);
+			CGContextStrokeRect(context, oneLine.frame);
+			
+			// draw baseline
+			CGContextMoveToPoint(context, oneLine.baselineOrigin.x-5.0, oneLine.baselineOrigin.y);
+			CGContextAddLineToPoint(context, oneLine.baselineOrigin.x + oneLine.frame.size.width + 5.0, oneLine.baselineOrigin.y);
+			CGContextStrokePath(context);
+		}
+		
+		NSInteger runIndex = 0;
+		
+		for (DTCoreTextGlyphRun *oneRun in oneLine.glyphRuns)
+		{
+			if (_DTCoreTextLayoutFramesShouldDrawDebugFrames)
+			{
+				if (runIndex%2)
+				{
+					CGContextSetRGBFillColor(context, 1, 0, 0, 0.2);
+				}
+				else 
+				{
+					CGContextSetRGBFillColor(context, 0, 1, 0, 0.2);
+				}
+				
+				CGContextFillRect(context, oneRun.frame);
+				runIndex ++;
+			}
 			
 			
 			CGColorRef backgroundColor = (CGColorRef)[oneRun.attributes objectForKey:@"DTBackgroundColor"];
@@ -363,27 +363,27 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 				continue;
 			}
 			
-            // -------------- Line-Out, Underline, Background-Color
-            BOOL lastRunInLine = (oneRun == [oneLine.glyphRuns lastObject]);
-            
-            BOOL drawStrikeOut = [[oneRun.attributes objectForKey:@"DTStrikeOut"] boolValue];
-            BOOL drawUnderline = [[oneRun.attributes objectForKey:(id)kCTUnderlineStyleAttributeName] boolValue];
-            
-            if (drawStrikeOut||drawUnderline||backgroundColor)
-            {
-                // get text color or use black
-                id color = [oneRun.attributes objectForKey:(id)kCTForegroundColorAttributeName];
-                
-                if (color)
-                {
-                    CGContextSetStrokeColorWithColor(context, (CGColorRef)color);
-                }
-                else
-                {
-                    CGContextSetGrayStrokeColor(context, 0, 1.0);
-                }
-                
-                CGRect runStrokeBounds = oneRun.frame;
+			// -------------- Line-Out, Underline, Background-Color
+			BOOL lastRunInLine = (oneRun == [oneLine.glyphRuns lastObject]);
+			
+			BOOL drawStrikeOut = [[oneRun.attributes objectForKey:@"DTStrikeOut"] boolValue];
+			BOOL drawUnderline = [[oneRun.attributes objectForKey:(id)kCTUnderlineStyleAttributeName] boolValue];
+			
+			if (drawStrikeOut||drawUnderline||backgroundColor)
+			{
+				// get text color or use black
+				id color = [oneRun.attributes objectForKey:(id)kCTForegroundColorAttributeName];
+				
+				if (color)
+				{
+					CGContextSetStrokeColorWithColor(context, (CGColorRef)color);
+				}
+				else
+				{
+					CGContextSetGrayStrokeColor(context, 0, 1.0);
+				}
+				
+				CGRect runStrokeBounds = oneRun.frame;
 				
 				NSInteger superscriptStyle = [[oneRun.attributes objectForKey:(id)kCTSuperscriptAttributeName] integerValue];
 				
@@ -404,51 +404,51 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 				}
 				
 				
-                if (lastRunInLine)
-                {
-                    runStrokeBounds.size.width -= [oneLine trailingWhitespaceWidth];
-                }
+				if (lastRunInLine)
+				{
+					runStrokeBounds.size.width -= [oneLine trailingWhitespaceWidth];
+				}
 				
 				if (backgroundColor)
 				{
 					CGContextSetFillColorWithColor(context, backgroundColor);
 					CGContextFillRect(context, runStrokeBounds);
 				}
-                
-                if (drawStrikeOut)
-                {
-                    runStrokeBounds.origin.y = roundf(runStrokeBounds.origin.y + oneRun.frame.size.height/2.0 + 1)+0.5;
-                    
-                    CGContextMoveToPoint(context, runStrokeBounds.origin.x, runStrokeBounds.origin.y);
-                    CGContextAddLineToPoint(context, runStrokeBounds.origin.x + runStrokeBounds.size.width, runStrokeBounds.origin.y);
-                    
-                    CGContextStrokePath(context);
-                }
-                
-                if (drawUnderline)
-                {
-                    runStrokeBounds.origin.y = roundf(runStrokeBounds.origin.y + oneRun.frame.size.height - oneRun.descent + 1)+0.5;
-                    
-                    CGContextMoveToPoint(context, runStrokeBounds.origin.x, runStrokeBounds.origin.y);
-                    CGContextAddLineToPoint(context, runStrokeBounds.origin.x + runStrokeBounds.size.width, runStrokeBounds.origin.y);
-                    
-                    CGContextStrokePath(context);
-                }
-            }
-        }
+				
+				if (drawStrikeOut)
+				{
+					runStrokeBounds.origin.y = roundf(runStrokeBounds.origin.y + oneRun.frame.size.height/2.0 + 1)+0.5;
+					
+					CGContextMoveToPoint(context, runStrokeBounds.origin.x, runStrokeBounds.origin.y);
+					CGContextAddLineToPoint(context, runStrokeBounds.origin.x + runStrokeBounds.size.width, runStrokeBounds.origin.y);
+					
+					CGContextStrokePath(context);
+				}
+				
+				if (drawUnderline)
+				{
+					runStrokeBounds.origin.y = roundf(runStrokeBounds.origin.y + oneRun.frame.size.height - oneRun.descent + 1)+0.5;
+					
+					CGContextMoveToPoint(context, runStrokeBounds.origin.x, runStrokeBounds.origin.y);
+					CGContextAddLineToPoint(context, runStrokeBounds.origin.x + runStrokeBounds.size.width, runStrokeBounds.origin.y);
+					
+					CGContextStrokePath(context);
+				}
+			}
+		}
 	}
 	
 	// Flip the coordinate system
 	CGContextSetTextMatrix(context, CGAffineTransformIdentity);
 	CGContextScaleCTM(context, 1.0, -1.0);
 	CGContextTranslateCTM(context, 0, -self.frame.size.height);
-    
+	
 	// instead of using the convenience method to draw the entire frame, we draw individual glyph runs
-    
+	
 	for (DTCoreTextLayoutLine *oneLine in visibleLines)
 	{
-        for (DTCoreTextGlyphRun *oneRun in oneLine.glyphRuns)
-        {
+		for (DTCoreTextGlyphRun *oneRun in oneLine.glyphRuns)
+		{
 			CGPoint textPosition = CGPointMake(oneLine.frame.origin.x, self.frame.size.height - oneRun.frame.origin.y - oneRun.ascent);
 			
 			NSInteger superscriptStyle = [[oneRun.attributes objectForKey:(id)kCTSuperscriptAttributeName] integerValue];
@@ -469,26 +469,26 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 					break;
 			}
 			
-            CGContextSetTextPosition(context, textPosition.x, textPosition.y);
-            
-            NSArray *shadows = [oneRun.attributes objectForKey:@"DTShadows"];
-            
-            if (shadows)
-            {
-                CGContextSaveGState(context);
-                
-                for (NSDictionary *shadowDict in shadows)
-                {
+			CGContextSetTextPosition(context, textPosition.x, textPosition.y);
+			
+			NSArray *shadows = [oneRun.attributes objectForKey:@"DTShadows"];
+			
+			if (shadows)
+			{
+				CGContextSaveGState(context);
+				
+				for (NSDictionary *shadowDict in shadows)
+				{
 					[self setShadowInContext:context fromDictionary:shadowDict];
-                    
-                    // draw once per shadow
-                    [oneRun drawInContext:context];
-                }
-                
-                CGContextRestoreGState(context);
-            }
-            else
-            {
+					
+					// draw once per shadow
+					[oneRun drawInContext:context];
+				}
+				
+				CGContextRestoreGState(context);
+			}
+			else
+			{
 				DTTextAttachment *attachment = oneRun.attachment;
 				
 				if (attachment)
@@ -512,19 +512,19 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 					// regular text
 					[oneRun drawInContext:context];
 				}
-            }
+			}
 		}
 	}
 	
-    [self release];
-    [_layouter release];
-    
-    if (_textFrame)
-    {
-        CFRelease(_textFrame);
-    }
-    
-    CGContextRestoreGState(context);
+	[self release];
+	[_layouter release];
+	
+	if (_textFrame)
+	{
+		CFRelease(_textFrame);
+	}
+	
+	CGContextRestoreGState(context);
 }
 
 // assume we want to draw images statically
@@ -536,11 +536,11 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (NSRange)visibleStringRange
 {
-    if (!_textFrame)
-    {
-        return NSMakeRange(0, 0);
-    }
-    
+	if (!_textFrame)
+	{
+		return NSMakeRange(0, 0);
+	}
+	
 	CFRange range = CTFrameGetVisibleStringRange(_textFrame);
 	
 	return NSMakeRange(range.location, range.length);
@@ -549,11 +549,11 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 #pragma mark Calculations
 - (NSArray *)stringIndices {
-    NSMutableArray *array = [NSMutableArray array];
-    for (DTCoreTextLayoutLine *oneLine in self.lines) {
-        [array addObjectsFromArray:[oneLine stringIndices]];
-    }
-    return array;
+	NSMutableArray *array = [NSMutableArray array];
+	for (DTCoreTextLayoutLine *oneLine in self.lines) {
+		[array addObjectsFromArray:[oneLine stringIndices]];
+	}
+	return array;
 }
 
 - (NSInteger)lineIndexForGlyphIndex:(NSInteger)index
@@ -597,16 +597,16 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (CGRect)frame
 {
-    if (_frame.size.height == CGFLOAT_OPEN_HEIGHT && !_lines)
-    {
-        [self buildLines]; // corrects frame if open-ended
-    }
-    
-    if (![self.lines count])
-    {
-        return CGRectZero;
-    }
-    
+	if (_frame.size.height == CGFLOAT_OPEN_HEIGHT && !_lines)
+	{
+		[self buildLines]; // corrects frame if open-ended
+	}
+	
+	if (![self.lines count])
+	{
+		return CGRectZero;
+	}
+	
 	return _frame;
 	//	
 	//    // actual frame is spanned between first and last lines
@@ -621,15 +621,15 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 - (DTCoreTextLayoutLine *)lineContainingIndex:(NSUInteger)index
 {
-    for (DTCoreTextLayoutLine *oneLine in self.lines)
-    {
-        if (NSLocationInRange(index, [oneLine stringRange]))
-        {
-            return oneLine;
-        }
-    }
-    
-    return nil;
+	for (DTCoreTextLayoutLine *oneLine in self.lines)
+	{
+		if (NSLocationInRange(index, [oneLine stringRange]))
+		{
+			return oneLine;
+		}
+	}
+	
+	return nil;
 }
 
 - (void)correctAttachmentHeights

--- a/Classes/DTCoreTextLayoutLine.m
+++ b/Classes/DTCoreTextLayoutLine.m
@@ -24,8 +24,8 @@
 
 - (id)initWithLine:(CTLineRef)line layoutFrame:(DTCoreTextLayoutFrame *)layoutFrame origin:(CGPoint)origin;
 {
-    self = [super init];
-    
+	self = [super init];
+	
 	if (self)
 	{
 		_layoutFrame = layoutFrame;
@@ -52,13 +52,13 @@
 
 - (NSString *)description
 {
-    NSString *extract = [[_layoutFrame.layouter.attributedString string] substringFromIndex:[self stringRange].location];
-    
-    if ([extract length]>20)
-    {
-        extract = [extract substringToIndex:20];
-    }
-    
+	NSString *extract = [[_layoutFrame.layouter.attributedString string] substringFromIndex:[self stringRange].location];
+	
+	if ([extract length]>20)
+	{
+		extract = [extract substringToIndex:20];
+	}
+	
 	return [NSString stringWithFormat:@"<%@ '%@'>", [self class], extract];
 }
 
@@ -89,11 +89,11 @@
 
 #pragma mark Calculations
 - (NSArray *)stringIndices {
-    NSMutableArray *array = [NSMutableArray array];
-    for (DTCoreTextGlyphRun *oneRun in self.glyphRuns) {
-        [array addObjectsFromArray:[oneRun stringIndices]];
-    }
-    return array;
+	NSMutableArray *array = [NSMutableArray array];
+	for (DTCoreTextGlyphRun *oneRun in self.glyphRuns) {
+		[array addObjectsFromArray:[oneRun stringIndices]];
+	}
+	return array;
 }
 
 - (CGRect)frameOfGlyphAtIndex:(NSInteger)index
@@ -116,57 +116,57 @@
 
 - (NSArray *)glyphRunsWithRange:(NSRange)range
 {
-    NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self numberOfGlyphs]];
-    
-    for (DTCoreTextGlyphRun *oneRun in self.glyphRuns)
-    {
-        NSRange runRange = [oneRun stringRange];
+	NSMutableArray *tmpArray = [NSMutableArray arrayWithCapacity:[self numberOfGlyphs]];
+	
+	for (DTCoreTextGlyphRun *oneRun in self.glyphRuns)
+	{
+		NSRange runRange = [oneRun stringRange];
 		
-        // we only care about locations, assume that number of glyphs >= indexes
-        if (NSLocationInRange(runRange.location, range))
-        {
-            [tmpArray addObject:oneRun];
-        }
-    }
-    
-    return tmpArray;
+		// we only care about locations, assume that number of glyphs >= indexes
+		if (NSLocationInRange(runRange.location, range))
+		{
+			[tmpArray addObject:oneRun];
+		}
+	}
+	
+	return tmpArray;
 }
 
 - (CGRect)frameOfGlyphsWithRange:(NSRange)range
 {
-    NSArray *glyphRuns = [self glyphRunsWithRange:range];
-    
-    CGRect tmpRect = CGRectMake(CGFLOAT_MAX, CGFLOAT_MAX, 0, 0);
-    
-    for (DTCoreTextGlyphRun *oneRun in glyphRuns)
-    {
-        CGRect glyphFrame = oneRun.frame;
-        
-        if (glyphFrame.origin.x < tmpRect.origin.x)
-        {
-            tmpRect.origin.x = glyphFrame.origin.x;
-        }
-		
-        if (glyphFrame.origin.y < tmpRect.origin.y)
-        {
-            tmpRect.origin.y = glyphFrame.origin.y;
-        }
-		
-        if (glyphFrame.size.height > tmpRect.size.height)
-        {
-            tmpRect.size.height = glyphFrame.size.height;
-        }
-        
-        tmpRect.size.width = glyphFrame.origin.x + glyphFrame.size.width - tmpRect.origin.x;
-    }
+	NSArray *glyphRuns = [self glyphRunsWithRange:range];
 	
-    CGFloat maxX = CGRectGetMaxX(self.frame) - trailingWhitespaceWidth;
-    if (CGRectGetMaxX(tmpRect) > maxX)
-    {
-        tmpRect.size.width = maxX - tmpRect.origin.x;
-    }
-    
-    return tmpRect;
+	CGRect tmpRect = CGRectMake(CGFLOAT_MAX, CGFLOAT_MAX, 0, 0);
+	
+	for (DTCoreTextGlyphRun *oneRun in glyphRuns)
+	{
+		CGRect glyphFrame = oneRun.frame;
+		
+		if (glyphFrame.origin.x < tmpRect.origin.x)
+		{
+			tmpRect.origin.x = glyphFrame.origin.x;
+		}
+		
+		if (glyphFrame.origin.y < tmpRect.origin.y)
+		{
+			tmpRect.origin.y = glyphFrame.origin.y;
+		}
+		
+		if (glyphFrame.size.height > tmpRect.size.height)
+		{
+			tmpRect.size.height = glyphFrame.size.height;
+		}
+		
+		tmpRect.size.width = glyphFrame.origin.x + glyphFrame.size.width - tmpRect.origin.x;
+	}
+	
+	CGFloat maxX = CGRectGetMaxX(self.frame) - trailingWhitespaceWidth;
+	if (CGRectGetMaxX(tmpRect) > maxX)
+	{
+		tmpRect.size.width = maxX - tmpRect.origin.x;
+	}
+	
+	return tmpRect;
 }
 
 // bounds of an image encompassing the entire run
@@ -177,7 +177,7 @@
 
 - (void)drawInContext:(CGContextRef)context
 {
-    CTLineDraw(_line, context);
+	CTLineDraw(_line, context);
 }
 
 // fix for image squishing bug < iOS 4.2

--- a/Classes/DTCoreTextLayouter.m
+++ b/Classes/DTCoreTextLayouter.m
@@ -41,8 +41,8 @@
 {
 	[_attributedString release];
 	[frames release];
-    
-    [self discardFramesetter];
+	
+	[self discardFramesetter];
 	
 	[super dealloc];
 }
@@ -60,8 +60,8 @@
 - (CGSize)suggestedFrameSizeToFitEntireStringConstraintedToWidth:(CGFloat)width
 {
 	CGSize neededSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, CFRangeMake(0, 0), NULL, 
-																	 CGSizeMake(width, CGFLOAT_MAX),
-																	 NULL);
+																																	 CGSizeMake(width, CGFLOAT_MAX),
+																																	 NULL);
 	
 	// for unknown reasons suddenly 1 needs to be added to fit
 	neededSize.height = ceilf(neededSize.height)+1.0;
@@ -94,21 +94,21 @@
 #pragma mark Properties
 - (CTFramesetterRef) framesetter
 {
-//    if (!framesetter)
-    {
-        @synchronized(self)
-        {
-            if (!framesetter)
-            {
-                framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)self.attributedString);
-                
-                if (!framesetter)
-                {
-                    NSLog(@"No Framesetter!");
-                }
-            }
-        }
-    }
+	//    if (!framesetter)
+	{
+		@synchronized(self)
+		{
+			if (!framesetter)
+			{
+				framesetter = CTFramesetterCreateWithAttributedString((CFAttributedStringRef)self.attributedString);
+				
+				if (!framesetter)
+				{
+					NSLog(@"No Framesetter!");
+				}
+			}
+		}
+	}
 	
 	return framesetter;
 }
@@ -116,36 +116,36 @@
 
 - (void)discardFramesetter
 {
-    @synchronized(self)
-    {
-        // framesetter needs to go
-        if (framesetter)
-        {
-            CFRelease(framesetter);
-            framesetter = NULL;
-        }
-    }
+	@synchronized(self)
+	{
+		// framesetter needs to go
+		if (framesetter)
+		{
+			CFRelease(framesetter);
+			framesetter = NULL;
+		}
+	}
 }
 
 
 - (void)setAttributedString:(NSAttributedString *)attributedString
 {
-    @synchronized(self)
-    {
-        if (_attributedString != attributedString)
-        {
-            [_attributedString release];
-            
-            _attributedString = [attributedString retain];
-            
-            [self discardFramesetter];
-        }
-    }
+	@synchronized(self)
+	{
+		if (_attributedString != attributedString)
+		{
+			[_attributedString release];
+			
+			_attributedString = [attributedString retain];
+			
+			[self discardFramesetter];
+		}
+	}
 }
 
 - (NSAttributedString *)attributedString
 {
-    return _attributedString;
+	return _attributedString;
 }
 
 - (NSMutableArray *)frames

--- a/Classes/DTCoreTextParagraphStyle.m
+++ b/Classes/DTCoreTextParagraphStyle.m
@@ -13,7 +13,7 @@
 
 + (DTCoreTextParagraphStyle *)defaultParagraphStyle
 {
-    return [[[DTCoreTextParagraphStyle alloc] init] autorelease];
+	return [[[DTCoreTextParagraphStyle alloc] init] autorelease];
 }
 
 + (DTCoreTextParagraphStyle *)paragraphStyleWithCTParagraphStyle:(CTParagraphStyleRef)ctParagraphStyle
@@ -23,21 +23,21 @@
 
 - (id)init
 {
-    self = [super init];
-    
-    if (self)
-    {
-        // defaults
-        firstLineIndent = 0.0;
-        defaultTabInterval = 36.0;
-        writingDirection = kCTWritingDirectionNatural;
-        textAlignment = kCTNaturalTextAlignment;
-        lineHeightMultiple = 0.0;
-        minimumLineHeight = 0.0;
+	self = [super init];
+	
+	if (self)
+	{
+		// defaults
+		firstLineIndent = 0.0;
+		defaultTabInterval = 36.0;
+		writingDirection = kCTWritingDirectionNatural;
+		textAlignment = kCTNaturalTextAlignment;
+		lineHeightMultiple = 0.0;
+		minimumLineHeight = 0.0;
 		maximumLineHeight = 0.0;
-    }
-
-    return self;
+	}
+	
+	return self;
 }
 
 
@@ -50,7 +50,7 @@
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierAlignment,sizeof(textAlignment), &textAlignment);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierFirstLineHeadIndent, sizeof(firstLineIndent), &firstLineIndent);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierDefaultTabInterval, sizeof(defaultTabInterval), &defaultTabInterval);
-
+		
 		NSArray *tabStops;
 		if (CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierTabStops, sizeof(tabStops), &tabStops))
 		{
@@ -58,27 +58,27 @@
 		}
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierParagraphSpacing, sizeof(paragraphSpacing), &paragraphSpacing);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierParagraphSpacingBefore,sizeof(paragraphSpacingBefore), &paragraphSpacingBefore);
-
+		
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierHeadIndent, sizeof(headIndent), &headIndent);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(writingDirection), &writingDirection);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierLineHeightMultiple, sizeof(lineHeightMultiple), &lineHeightMultiple);
-
+		
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierMinimumLineHeight, sizeof(minimumLineHeight), &minimumLineHeight);
 		CTParagraphStyleGetValueForSpecifier(ctParagraphStyle, kCTParagraphStyleSpecifierMaximumLineHeight, sizeof(maximumLineHeight), &maximumLineHeight);
-        
-        if (lineHeightMultiple)
-        {
-            // paragraph space is pre-multiplied
-            if (paragraphSpacing)
-            {
-                paragraphSpacing /= lineHeightMultiple;
-            }
-            
-            if (paragraphSpacingBefore)
-            {
-                paragraphSpacingBefore /= lineHeightMultiple;
-            }
-        }
+		
+		if (lineHeightMultiple)
+		{
+			// paragraph space is pre-multiplied
+			if (paragraphSpacing)
+			{
+				paragraphSpacing /= lineHeightMultiple;
+			}
+			
+			if (paragraphSpacingBefore)
+			{
+				paragraphSpacingBefore /= lineHeightMultiple;
+			}
+		}
 	}
 	
 	return self;
@@ -86,41 +86,41 @@
 
 - (void)dealloc
 {
-    [_tabStops release];
-    
-    [super dealloc];
+	[_tabStops release];
+	
+	[super dealloc];
 }
 
 
 - (CTParagraphStyleRef)createCTParagraphStyle
 {
-    // need to multiple paragraph spacing with line height multiplier
-    float tmpParagraphSpacing = paragraphSpacing;
-    float tmpParagraphSpacingBefore = paragraphSpacingBefore;
-    
-    if (lineHeightMultiple&&(lineHeightMultiple!=1.0))
-    {
-        tmpParagraphSpacing *= lineHeightMultiple;
-        tmpParagraphSpacingBefore *= lineHeightMultiple;
-    }
-    
+	// need to multiple paragraph spacing with line height multiplier
+	float tmpParagraphSpacing = paragraphSpacing;
+	float tmpParagraphSpacingBefore = paragraphSpacingBefore;
+	
+	if (lineHeightMultiple&&(lineHeightMultiple!=1.0))
+	{
+		tmpParagraphSpacing *= lineHeightMultiple;
+		tmpParagraphSpacingBefore *= lineHeightMultiple;
+	}
+	
 	CTParagraphStyleSetting settings[] = 
-    {
+	{
 		{kCTParagraphStyleSpecifierAlignment, sizeof(textAlignment), &textAlignment},
 		{kCTParagraphStyleSpecifierFirstLineHeadIndent, sizeof(firstLineIndent), &firstLineIndent},
 		{kCTParagraphStyleSpecifierDefaultTabInterval, sizeof(defaultTabInterval), &defaultTabInterval},
 		
 		{kCTParagraphStyleSpecifierTabStops, sizeof(_tabStops), &_tabStops},
-        
+		
 		{kCTParagraphStyleSpecifierParagraphSpacing, sizeof(tmpParagraphSpacing), &tmpParagraphSpacing},
 		{kCTParagraphStyleSpecifierParagraphSpacingBefore, sizeof(tmpParagraphSpacingBefore), &tmpParagraphSpacingBefore},
 		
 		{kCTParagraphStyleSpecifierHeadIndent, sizeof(headIndent), &headIndent},
 		{kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(writingDirection), &writingDirection},
-        {kCTParagraphStyleSpecifierLineHeightMultiple, sizeof(lineHeightMultiple), &lineHeightMultiple},
-        
+		{kCTParagraphStyleSpecifierLineHeightMultiple, sizeof(lineHeightMultiple), &lineHeightMultiple},
+		
 		{kCTParagraphStyleSpecifierMinimumLineHeight, sizeof(minimumLineHeight), &minimumLineHeight},
-        {kCTParagraphStyleSpecifierMaximumLineHeight, sizeof(maximumLineHeight), &maximumLineHeight}
+		{kCTParagraphStyleSpecifierMaximumLineHeight, sizeof(maximumLineHeight), &maximumLineHeight}
 	};	
 	
 	return CTParagraphStyleCreate(settings, 11);
@@ -128,35 +128,35 @@
 
 - (void)addTabStopAtPosition:(CGFloat)position alignment:(CTTextAlignment)alignment
 {
-    if (!_tabStops)
-    {
-        _tabStops = [[NSMutableArray alloc] init];
-    }
-    
-    CTTextTabRef tab = CTTextTabCreate(alignment, position, NULL);
-    [_tabStops addObject:(id)tab];
-    CFRelease(tab);
+	if (!_tabStops)
+	{
+		_tabStops = [[NSMutableArray alloc] init];
+	}
+	
+	CTTextTabRef tab = CTTextTabCreate(alignment, position, NULL);
+	[_tabStops addObject:(id)tab];
+	CFRelease(tab);
 }
 
 #pragma mark Copying
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    DTCoreTextParagraphStyle *newObject = [[DTCoreTextParagraphStyle allocWithZone:zone] init];
-    
-    newObject.firstLineIndent = self.firstLineIndent;
-    newObject.defaultTabInterval = self.defaultTabInterval;
-    newObject.paragraphSpacing = self.paragraphSpacing;
-    newObject.paragraphSpacingBefore = self.paragraphSpacingBefore;
-    newObject.lineHeightMultiple = self.lineHeightMultiple;
+	DTCoreTextParagraphStyle *newObject = [[DTCoreTextParagraphStyle allocWithZone:zone] init];
+	
+	newObject.firstLineIndent = self.firstLineIndent;
+	newObject.defaultTabInterval = self.defaultTabInterval;
+	newObject.paragraphSpacing = self.paragraphSpacing;
+	newObject.paragraphSpacingBefore = self.paragraphSpacingBefore;
+	newObject.lineHeightMultiple = self.lineHeightMultiple;
 	newObject.minimumLineHeight = self.minimumLineHeight;
 	newObject.maximumLineHeight = self.maximumLineHeight;
-    newObject.headIndent = self.headIndent;
-    newObject.textAlignment = self.textAlignment;
-    newObject.writingDirection = self.writingDirection;
-    newObject.tabStops = self.tabStops; // copy
-    
-    return newObject;
+	newObject.headIndent = self.headIndent;
+	newObject.textAlignment = self.textAlignment;
+	newObject.writingDirection = self.writingDirection;
+	newObject.tabStops = self.tabStops; // copy
+	
+	return newObject;
 }
 
 #pragma mark Properties

--- a/Classes/DTHTMLElement.m
+++ b/Classes/DTHTMLElement.m
@@ -27,118 +27,118 @@
 
 - (id)init
 {
-    self = [super init];
-    if (self)
-    {
-        _isInline = -1;
-        _isMeta = -1;
-        _listDepth = -1;
-        _listCounter = NSIntegerMin;
-        children = [NSMutableArray array];
-    }
-    
-    return self;
-    
+	self = [super init];
+	if (self)
+	{
+		_isInline = -1;
+		_isMeta = -1;
+		_listDepth = -1;
+		_listCounter = NSIntegerMin;
+		children = [NSMutableArray array];
+	}
+	
+	return self;
+	
 }
 
 
 
 - (void)dealloc
 {
-    [fontDescriptor release];
-    [paragraphStyle release];
-    [textAttachment release];
-    
-    [_textColor release];
+	[fontDescriptor release];
+	[paragraphStyle release];
+	[textAttachment release];
+	
+	[_textColor release];
 	[backgroundColor release];
 	
-    [tagName release];
-    [text release];
-    [link release];
-    
-    [shadows release];
-    
-    [_fontCache release];
+	[tagName release];
+	[text release];
+	[link release];
+	
+	[shadows release];
+	
+	[_fontCache release];
 	[_additionalAttributes release];
-    
-    [super dealloc];
+	
+	[super dealloc];
 }
 
 
 - (NSDictionary *)attributesDictionary
 {
-    NSMutableDictionary *tmpDict = [NSMutableDictionary dictionary];
+	NSMutableDictionary *tmpDict = [NSMutableDictionary dictionary];
 	
 	// copy additional attributes
 	if (_additionalAttributes)
 	{
 		[tmpDict setDictionary:_additionalAttributes];
 	}
-    
-    // add text attachment
-    if (textAttachment)
-    {
-        // need run delegate for sizing
-        CTRunDelegateRef embeddedObjectRunDelegate = createEmbeddedObjectRunDelegate(textAttachment);
-        [tmpDict setObject:(id)embeddedObjectRunDelegate forKey:(id)kCTRunDelegateAttributeName];
-        CFRelease(embeddedObjectRunDelegate);
-        
-        // add attachment
-        [tmpDict setObject:textAttachment forKey:@"DTTextAttachment"];
-    }
-    else
-    {
-        // otherwise we have a font
-        
-        // try font cache first
-        NSNumber *key = [NSNumber numberWithInt:[fontDescriptor hash]];
-        CTFontRef font = (CTFontRef)[self.fontCache objectForKey:key];
-        
-        if (!font)
-        {
-            font = [fontDescriptor newMatchingFont];
+	
+	// add text attachment
+	if (textAttachment)
+	{
+		// need run delegate for sizing
+		CTRunDelegateRef embeddedObjectRunDelegate = createEmbeddedObjectRunDelegate(textAttachment);
+		[tmpDict setObject:(id)embeddedObjectRunDelegate forKey:(id)kCTRunDelegateAttributeName];
+		CFRelease(embeddedObjectRunDelegate);
+		
+		// add attachment
+		[tmpDict setObject:textAttachment forKey:@"DTTextAttachment"];
+	}
+	else
+	{
+		// otherwise we have a font
+		
+		// try font cache first
+		NSNumber *key = [NSNumber numberWithInt:[fontDescriptor hash]];
+		CTFontRef font = (CTFontRef)[self.fontCache objectForKey:key];
+		
+		if (!font)
+		{
+			font = [fontDescriptor newMatchingFont];
 			
-            if (font)
-            {
-                [self.fontCache setObject:(id)font forKey:key];
-                CFRelease(font);
-            }
-        }
-        
-        if (font)
-        {
-            [tmpDict setObject:(id)font forKey:(id)kCTFontAttributeName];
-        }
-    }
-    
-    // add hyperlink
-    if (link)
-    {
-        [tmpDict setObject:link forKey:@"DTLink"];
-        
-        // add a GUID to group multiple glyph runs belonging to same link
-        [tmpDict setObject:[NSString guid] forKey:@"DTGUID"];
-    }
-    
-    // add strikout if applicable
-    if (strikeOut)
-    {
-        [tmpDict setObject:[NSNumber numberWithBool:YES] forKey:@"DTStrikeOut"];
-    }
-    
-    // set underline style
-    if (underlineStyle)
-    {
-        [tmpDict setObject:[NSNumber numberWithInteger:underlineStyle] forKey:(id)kCTUnderlineStyleAttributeName];
-        
-        // we could set an underline color as well if we wanted, but not supported by HTML
-        //      [attributes setObject:(id)[UIColor redColor].CGColor forKey:(id)kCTUnderlineColorAttributeName];
-    }
-    
-    if (_textColor)
-    {
-        [tmpDict setObject:(id)[_textColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
-    }
+			if (font)
+			{
+				[self.fontCache setObject:(id)font forKey:key];
+				CFRelease(font);
+			}
+		}
+		
+		if (font)
+		{
+			[tmpDict setObject:(id)font forKey:(id)kCTFontAttributeName];
+		}
+	}
+	
+	// add hyperlink
+	if (link)
+	{
+		[tmpDict setObject:link forKey:@"DTLink"];
+		
+		// add a GUID to group multiple glyph runs belonging to same link
+		[tmpDict setObject:[NSString guid] forKey:@"DTGUID"];
+	}
+	
+	// add strikout if applicable
+	if (strikeOut)
+	{
+		[tmpDict setObject:[NSNumber numberWithBool:YES] forKey:@"DTStrikeOut"];
+	}
+	
+	// set underline style
+	if (underlineStyle)
+	{
+		[tmpDict setObject:[NSNumber numberWithInteger:underlineStyle] forKey:(id)kCTUnderlineStyleAttributeName];
+		
+		// we could set an underline color as well if we wanted, but not supported by HTML
+		//      [attributes setObject:(id)[UIColor redColor].CGColor forKey:(id)kCTUnderlineColorAttributeName];
+	}
+	
+	if (_textColor)
+	{
+		[tmpDict setObject:(id)[_textColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
+	}
 	
 	if (backgroundColor)
 	{
@@ -149,218 +149,218 @@
 	{
 		[tmpDict setObject:(id)[NSNumber numberWithInt:superscriptStyle] forKey:(id)kCTSuperscriptAttributeName];
 	}
-
-    // correct spacing to match current font size
-    if (self.paragraphStyle.paragraphSpacing>0)
-    {
-        self.paragraphStyle.paragraphSpacing = self.fontDescriptor.pointSize;
-    }
-
-    // correct spacing to match current font size
-    if (self.paragraphStyle.paragraphSpacingBefore>0)
-    {
-        self.paragraphStyle.paragraphSpacingBefore = self.fontDescriptor.pointSize;
-    }
-
-    // add paragraph style
+	
+	// correct spacing to match current font size
+	if (self.paragraphStyle.paragraphSpacing>0)
+	{
+		self.paragraphStyle.paragraphSpacing = self.fontDescriptor.pointSize;
+	}
+	
+	// correct spacing to match current font size
+	if (self.paragraphStyle.paragraphSpacingBefore>0)
+	{
+		self.paragraphStyle.paragraphSpacingBefore = self.fontDescriptor.pointSize;
+	}
+	
+	// add paragraph style
 	CTParagraphStyleRef newParagraphStyle = [self.paragraphStyle createCTParagraphStyle];
-    [tmpDict setObject:(id)newParagraphStyle forKey:(id)kCTParagraphStyleAttributeName];
+	[tmpDict setObject:(id)newParagraphStyle forKey:(id)kCTParagraphStyleAttributeName];
 	CFRelease(newParagraphStyle);
-    
-    // add shadow array if applicable
-    if (shadows)
-    {
-        [tmpDict setObject:shadows forKey:@"DTShadows"];
-    }
-    
-    return tmpDict;
+	
+	// add shadow array if applicable
+	if (shadows)
+	{
+		[tmpDict setObject:shadows forKey:@"DTShadows"];
+	}
+	
+	return tmpDict;
 }
 
 - (NSAttributedString *)attributedString
 {
-    NSDictionary *attributes = [self attributesDictionary];
-    
-    if (textAttachment)
-    {
-        // ignore text, use unicode object placeholder
-        return [[[NSAttributedString alloc] initWithString:UNICODE_OBJECT_PLACEHOLDER attributes:attributes] autorelease];
-    }
-    else
-    {
+	NSDictionary *attributes = [self attributesDictionary];
+	
+	if (textAttachment)
+	{
+		// ignore text, use unicode object placeholder
+		return [[[NSAttributedString alloc] initWithString:UNICODE_OBJECT_PLACEHOLDER attributes:attributes] autorelease];
+	}
+	else
+	{
 		if (self.fontVariant == DTHTMLElementFontVariantNormal)
 		{
 			return [[[NSAttributedString alloc] initWithString:text attributes:attributes] autorelease];
 		}
 		else
 		{
-            if ([self.fontDescriptor supportsNativeSmallCaps])
-            {
-                DTCoreTextFontDescriptor *smallDesc = [self.fontDescriptor copy];
-                smallDesc.smallCapsFeature = YES;
-                
-                CTFontRef smallerFont = [smallDesc newMatchingFont];
-                
-                NSMutableDictionary *smallAttributes = [[attributes mutableCopy] autorelease];
-                [smallAttributes setObject:(id)smallerFont forKey:(id)kCTFontAttributeName];
-                CFRelease(smallerFont);
-                
-                [smallDesc release];
-                
-                return [[[NSAttributedString alloc] initWithString:text attributes:smallAttributes] autorelease];
-            }
-            
+			if ([self.fontDescriptor supportsNativeSmallCaps])
+			{
+				DTCoreTextFontDescriptor *smallDesc = [self.fontDescriptor copy];
+				smallDesc.smallCapsFeature = YES;
+				
+				CTFontRef smallerFont = [smallDesc newMatchingFont];
+				
+				NSMutableDictionary *smallAttributes = [[attributes mutableCopy] autorelease];
+				[smallAttributes setObject:(id)smallerFont forKey:(id)kCTFontAttributeName];
+				CFRelease(smallerFont);
+				
+				[smallDesc release];
+				
+				return [[[NSAttributedString alloc] initWithString:text attributes:smallAttributes] autorelease];
+			}
+			
 			return [NSAttributedString synthesizedSmallCapsAttributedStringWithText:text attributes:attributes];
 		}
-    }
+	}
 }
 
 - (NSAttributedString *)prefixForListItemWithCounter:(NSInteger)counter
 {
-    // make a font without italic or bold
-    DTCoreTextFontDescriptor *fontDesc = [self.fontDescriptor copy];
-    fontDesc.boldTrait = NO;
-    fontDesc.italicTrait = NO;
-    
-    CTFontRef font = [fontDesc newMatchingFont];
-    [fontDesc release];
-    
-    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
-    [attributes setObject:(id)font forKey:(id)kCTFontAttributeName];
-    CFRelease(font);
-    
-    // text color for bullet same as text
-    if (_textColor)
-    {
-        [attributes setObject:(id)[_textColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
-    }
-    // add paragraph style (this has the tabs)
+	// make a font without italic or bold
+	DTCoreTextFontDescriptor *fontDesc = [self.fontDescriptor copy];
+	fontDesc.boldTrait = NO;
+	fontDesc.italicTrait = NO;
+	
+	CTFontRef font = [fontDesc newMatchingFont];
+	[fontDesc release];
+	
+	NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+	[attributes setObject:(id)font forKey:(id)kCTFontAttributeName];
+	CFRelease(font);
+	
+	// text color for bullet same as text
+	if (_textColor)
+	{
+		[attributes setObject:(id)[_textColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
+	}
+	// add paragraph style (this has the tabs)
 	CTParagraphStyleRef newParagraphStyle = [self.paragraphStyle createCTParagraphStyle];
-    [attributes setObject:(id)newParagraphStyle forKey:(id)kCTParagraphStyleAttributeName];
+	[attributes setObject:(id)newParagraphStyle forKey:(id)kCTParagraphStyleAttributeName];
 	CFRelease(newParagraphStyle);
-    
-    switch (self.listStyle) 
-    {
-        case DTHTMLElementListStyleNone:
-        {
-            return nil;
-        }
-        case DTHTMLElementListStyleCircle:
-        {
-            return [[[NSAttributedString alloc] initWithString:@"\x09\u25e6\x09" attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleDecimal:
-        {
-            NSString *string = [NSString stringWithFormat:@"\x09%d.\x09", counter];
-            return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleDecimalLeadingZero:
-        {
-            NSString *string = [NSString stringWithFormat:@"\x09%02d.\x09", counter];
-            return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleDisc:
-        {
-            return [[[NSAttributedString alloc] initWithString:@"\x09\u2022\x09" attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleUpperAlpha:
-        case DTHTMLElementListStyleUpperLatin:
-        {
+	
+	switch (self.listStyle) 
+	{
+		case DTHTMLElementListStyleNone:
+		{
+			return nil;
+		}
+		case DTHTMLElementListStyleCircle:
+		{
+			return [[[NSAttributedString alloc] initWithString:@"\x09\u25e6\x09" attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleDecimal:
+		{
+			NSString *string = [NSString stringWithFormat:@"\x09%d.\x09", counter];
+			return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleDecimalLeadingZero:
+		{
+			NSString *string = [NSString stringWithFormat:@"\x09%02d.\x09", counter];
+			return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleDisc:
+		{
+			return [[[NSAttributedString alloc] initWithString:@"\x09\u2022\x09" attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleUpperAlpha:
+		case DTHTMLElementListStyleUpperLatin:
+		{
 			char letter = 'A' + counter-1;
 			NSString *string = [NSString stringWithFormat:@"\x09%c.\x09", letter];
 			
-            return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleLowerAlpha:
-        case DTHTMLElementListStyleLowerLatin:
-        {
+			return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleLowerAlpha:
+		case DTHTMLElementListStyleLowerLatin:
+		{
 			char letter = 'a' + counter-1;
 			NSString *string = [NSString stringWithFormat:@"\x09%c.\x09", letter];
-            
-            return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStylePlus:
-        {
-            return [[[NSAttributedString alloc] initWithString:@"\x09+\x09" attributes:attributes] autorelease];
-        }
-        case DTHTMLElementListStyleUnderscore:
-        {
-            return [[[NSAttributedString alloc] initWithString:@"\x09_\x09" attributes:attributes] autorelease];
-        }
-        default:
-            return nil;
-    }
-    
-    return nil;
+			
+			return [[[NSAttributedString alloc] initWithString:string attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStylePlus:
+		{
+			return [[[NSAttributedString alloc] initWithString:@"\x09+\x09" attributes:attributes] autorelease];
+		}
+		case DTHTMLElementListStyleUnderscore:
+		{
+			return [[[NSAttributedString alloc] initWithString:@"\x09_\x09" attributes:attributes] autorelease];
+		}
+		default:
+			return nil;
+	}
+	
+	return nil;
 }
 
 
 - (void)parseStyleString:(NSString *)styleString
 {
-    NSDictionary *styles = [styleString dictionaryOfCSSStyles];
-    
-    NSString *fontSize = [styles objectForKey:@"font-size"];
-    if (fontSize)
-    {
-        // absolute sizes based on 12.0 CoreText default size, Safari has 16.0
-        
-        if ([fontSize isEqualToString:@"smaller"])
-        {
-            fontDescriptor.pointSize /= 1.2f;
-        }
-        else if ([fontSize isEqualToString:@"larger"])
-        {
-            fontDescriptor.pointSize *= 1.2f;
-        }
-        else if ([fontSize isEqualToString:@"xx-small"])
-        {
-            fontDescriptor.pointSize = 9.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"x-small"])
-        {
-            fontDescriptor.pointSize = 10.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"small"])
-        {
-            fontDescriptor.pointSize = 13.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"medium"])
-        {
-            fontDescriptor.pointSize = 16.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"large"])
-        {
-            fontDescriptor.pointSize = 22.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"x-large"])
-        {
-            fontDescriptor.pointSize = 24.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"xx-large"])
-        {
-            fontDescriptor.pointSize = 37.0f/1.3333f * textScale;
-        }
-        else if ([fontSize isEqualToString:@"inherit"])
-        {
-            fontDescriptor.pointSize = parent.fontDescriptor.pointSize;
-        }
-        else
-        {
-            fontDescriptor.pointSize = [fontSize pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize]; // already multiplied with textScale
-        }
-    }
-    
-    NSString *color = [styles objectForKey:@"color"];
-    if (color)
-    {
-        self.textColor = [UIColor colorWithHTMLName:color];       
-    }
+	NSDictionary *styles = [styleString dictionaryOfCSSStyles];
+	
+	NSString *fontSize = [styles objectForKey:@"font-size"];
+	if (fontSize)
+	{
+		// absolute sizes based on 12.0 CoreText default size, Safari has 16.0
+		
+		if ([fontSize isEqualToString:@"smaller"])
+		{
+			fontDescriptor.pointSize /= 1.2f;
+		}
+		else if ([fontSize isEqualToString:@"larger"])
+		{
+			fontDescriptor.pointSize *= 1.2f;
+		}
+		else if ([fontSize isEqualToString:@"xx-small"])
+		{
+			fontDescriptor.pointSize = 9.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"x-small"])
+		{
+			fontDescriptor.pointSize = 10.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"small"])
+		{
+			fontDescriptor.pointSize = 13.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"medium"])
+		{
+			fontDescriptor.pointSize = 16.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"large"])
+		{
+			fontDescriptor.pointSize = 22.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"x-large"])
+		{
+			fontDescriptor.pointSize = 24.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"xx-large"])
+		{
+			fontDescriptor.pointSize = 37.0f/1.3333f * textScale;
+		}
+		else if ([fontSize isEqualToString:@"inherit"])
+		{
+			fontDescriptor.pointSize = parent.fontDescriptor.pointSize;
+		}
+		else
+		{
+			fontDescriptor.pointSize = [fontSize pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize]; // already multiplied with textScale
+		}
+	}
+	
+	NSString *color = [styles objectForKey:@"color"];
+	if (color)
+	{
+		self.textColor = [UIColor colorWithHTMLName:color];       
+	}
 	
 	NSString *bgColor = [styles objectForKey:@"background-color"];
-    if (bgColor)
-    {
-        self.backgroundColor = [UIColor colorWithHTMLName:bgColor];       
-    }
-    
+	if (bgColor)
+	{
+		self.backgroundColor = [UIColor colorWithHTMLName:bgColor];       
+	}
+	
 	NSString *floatString = [styles objectForKey:@"float"];
 	
 	if (floatString)
@@ -379,195 +379,195 @@
 		}
 	}
 	
-    NSString *fontFamily = [[styles objectForKey:@"font-family"] stringByTrimmingCharactersInSet:[NSCharacterSet quoteCharacterSet]];
-    
-    if (fontFamily)
-    {
-        NSString *lowercaseFontFamily = [fontFamily lowercaseString];
-        
-        if ([lowercaseFontFamily rangeOfString:@"helvetica"].length || [lowercaseFontFamily rangeOfString:@"arial"].length || [lowercaseFontFamily rangeOfString:@"geneva"].length)
-        {
-            fontDescriptor.fontFamily = @"Helvetica";
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"courier"].length)
-        {
-            fontDescriptor.fontFamily = @"Courier";
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"cursive"].length)
-        {
-            fontDescriptor.stylisticClass = kCTFontScriptsClass;
-            fontDescriptor.fontFamily = nil;
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"sans-serif"].length)
-        {
-            // too many matches (24)
-            // fontDescriptor.stylisticClass = kCTFontSansSerifClass;
-            fontDescriptor.fontFamily = @"Helvetica";
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"serif"].length)
-        {
-            // kCTFontTransitionalSerifsClass = Baskerville
-            // kCTFontClarendonSerifsClass = American Typewriter
-            // kCTFontSlabSerifsClass = Courier New
-            // 
-            // strangely none of the classes yields Times
-            fontDescriptor.fontFamily = @"Times New Roman";
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"fantasy"].length)
-        {
-            fontDescriptor.fontFamily = @"Papyrus"; // only available on iPad
-        }
-        else if ([lowercaseFontFamily rangeOfString:@"monospace"].length) 
-        {
-            fontDescriptor.monospaceTrait = YES;
-            fontDescriptor.fontFamily = @"Courier";
-        }
-        else
-        {
-            // probably custom font registered in info.plist
-            fontDescriptor.fontFamily = fontFamily;
-        }
-    }
-    
-    NSString *fontStyle = [[styles objectForKey:@"font-style"] lowercaseString];
-    if (fontStyle)
-    {
-        if ([fontStyle isEqualToString:@"normal"])
-        {
-            fontDescriptor.italicTrait = NO;
-        }
-        else if ([fontStyle isEqualToString:@"italic"] || [fontStyle isEqualToString:@"oblique"])
-        {
-            fontDescriptor.italicTrait = YES;
-        }
-        else if ([fontStyle isEqualToString:@"inherit"])
-        {
-            // nothing to do
-        }
-    }
-    
-    NSString *fontWeight = [[styles objectForKey:@"font-weight"] lowercaseString];
-    if (fontWeight)
-    {
-        if ([fontWeight isEqualToString:@"normal"])
-        {
-            fontDescriptor.boldTrait = NO;
-        }
-        else if ([fontWeight isEqualToString:@"bold"])
-        {
-            fontDescriptor.boldTrait = YES;
-        }
-        else if ([fontWeight isEqualToString:@"bolder"])
-        {
-            fontDescriptor.boldTrait = YES;
-        }
-        else if ([fontWeight isEqualToString:@"lighter"])
-        {
-            fontDescriptor.boldTrait = NO;
-        }
-        else 
-        {
-            // can be 100 - 900
-            
-            NSInteger value = [fontWeight intValue];
-            
-            if (value<=600)
-            {
-                fontDescriptor.boldTrait = NO;
-            }
-            else 
-            {
-                fontDescriptor.boldTrait = YES;
-            }
-        }
-    }
-    
-    
-    NSString *decoration = [[styles objectForKey:@"text-decoration"] lowercaseString];
-    if (decoration)
-    {
-        if ([decoration isEqualToString:@"underline"])
-        {
-            self.underlineStyle = kCTUnderlineStyleSingle;
-        }
-        else if ([decoration isEqualToString:@"line-through"])
-        {
-            self.strikeOut = YES;
-        }
-        else if ([decoration isEqualToString:@"none"])
-        {
-            // remove all
-            self.underlineStyle = kCTUnderlineStyleNone;
-            self.strikeOut = NO;
-        }
-        else if ([decoration isEqualToString:@"overline"])
-        {
-            //TODO: add support for overline decoration
-        }
-        else if ([decoration isEqualToString:@"blink"])
-        {
-            //TODO: add support for blink decoration
-        }
-        else if ([decoration isEqualToString:@"inherit"])
-        {
-            // nothing to do
-        }
-    }
-    
-    NSString *alignment = [[styles objectForKey:@"text-align"] lowercaseString];
-    if (alignment)
-    {
-        if ([alignment isEqualToString:@"left"])
-        {
-            self.paragraphStyle.textAlignment = kCTLeftTextAlignment;
-        }
-        else if ([alignment isEqualToString:@"right"])
-        {
-            self.paragraphStyle.textAlignment = kCTRightTextAlignment;
-        }
-        else if ([alignment isEqualToString:@"center"])
-        {
-            self.paragraphStyle.textAlignment = kCTCenterTextAlignment;
-        }
-        else if ([alignment isEqualToString:@"justify"])
-        {
-            self.paragraphStyle.textAlignment = kCTJustifiedTextAlignment;
-        }
-        else if ([alignment isEqualToString:@"inherit"])
-        {
-            // nothing to do
-        }
-    }
-    
-    NSString *shadow = [styles objectForKey:@"text-shadow"];
-    if (shadow)
-    {
-        self.shadows = [shadow arrayOfCSSShadowsWithCurrentTextSize:fontDescriptor.pointSize currentColor:_textColor];
-    }
-    
-    NSString *lineHeight = [[styles objectForKey:@"line-height"] lowercaseString];
-    if (lineHeight)
-    {
-        if ([lineHeight isEqualToString:@"normal"])
-        {
-            self.paragraphStyle.lineHeightMultiple = 0.0; // default
-        }
-        else if ([lineHeight isEqualToString:@"inherit"])
-        {
-            // no op, we already inherited it
-        }
-        else if ([lineHeight isNumeric])
-        {
-            self.paragraphStyle.lineHeightMultiple = [lineHeight floatValue];
-            //            self.paragraphStyle.minimumLineHeight = fontDescriptor.pointSize * (CGFloat)[lineHeight intValue];
-            //            self.paragraphStyle.maximumLineHeight = self.paragraphStyle.minimumLineHeight;
-        }
-        else // interpret as length
-        {
-            self.paragraphStyle.minimumLineHeight = [lineHeight pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize];
-            self.paragraphStyle.maximumLineHeight = self.paragraphStyle.minimumLineHeight;
-        }
-    }
+	NSString *fontFamily = [[styles objectForKey:@"font-family"] stringByTrimmingCharactersInSet:[NSCharacterSet quoteCharacterSet]];
+	
+	if (fontFamily)
+	{
+		NSString *lowercaseFontFamily = [fontFamily lowercaseString];
+		
+		if ([lowercaseFontFamily rangeOfString:@"helvetica"].length || [lowercaseFontFamily rangeOfString:@"arial"].length || [lowercaseFontFamily rangeOfString:@"geneva"].length)
+		{
+			fontDescriptor.fontFamily = @"Helvetica";
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"courier"].length)
+		{
+			fontDescriptor.fontFamily = @"Courier";
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"cursive"].length)
+		{
+			fontDescriptor.stylisticClass = kCTFontScriptsClass;
+			fontDescriptor.fontFamily = nil;
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"sans-serif"].length)
+		{
+			// too many matches (24)
+			// fontDescriptor.stylisticClass = kCTFontSansSerifClass;
+			fontDescriptor.fontFamily = @"Helvetica";
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"serif"].length)
+		{
+			// kCTFontTransitionalSerifsClass = Baskerville
+			// kCTFontClarendonSerifsClass = American Typewriter
+			// kCTFontSlabSerifsClass = Courier New
+			// 
+			// strangely none of the classes yields Times
+			fontDescriptor.fontFamily = @"Times New Roman";
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"fantasy"].length)
+		{
+			fontDescriptor.fontFamily = @"Papyrus"; // only available on iPad
+		}
+		else if ([lowercaseFontFamily rangeOfString:@"monospace"].length) 
+		{
+			fontDescriptor.monospaceTrait = YES;
+			fontDescriptor.fontFamily = @"Courier";
+		}
+		else
+		{
+			// probably custom font registered in info.plist
+			fontDescriptor.fontFamily = fontFamily;
+		}
+	}
+	
+	NSString *fontStyle = [[styles objectForKey:@"font-style"] lowercaseString];
+	if (fontStyle)
+	{
+		if ([fontStyle isEqualToString:@"normal"])
+		{
+			fontDescriptor.italicTrait = NO;
+		}
+		else if ([fontStyle isEqualToString:@"italic"] || [fontStyle isEqualToString:@"oblique"])
+		{
+			fontDescriptor.italicTrait = YES;
+		}
+		else if ([fontStyle isEqualToString:@"inherit"])
+		{
+			// nothing to do
+		}
+	}
+	
+	NSString *fontWeight = [[styles objectForKey:@"font-weight"] lowercaseString];
+	if (fontWeight)
+	{
+		if ([fontWeight isEqualToString:@"normal"])
+		{
+			fontDescriptor.boldTrait = NO;
+		}
+		else if ([fontWeight isEqualToString:@"bold"])
+		{
+			fontDescriptor.boldTrait = YES;
+		}
+		else if ([fontWeight isEqualToString:@"bolder"])
+		{
+			fontDescriptor.boldTrait = YES;
+		}
+		else if ([fontWeight isEqualToString:@"lighter"])
+		{
+			fontDescriptor.boldTrait = NO;
+		}
+		else 
+		{
+			// can be 100 - 900
+			
+			NSInteger value = [fontWeight intValue];
+			
+			if (value<=600)
+			{
+				fontDescriptor.boldTrait = NO;
+			}
+			else 
+			{
+				fontDescriptor.boldTrait = YES;
+			}
+		}
+	}
+	
+	
+	NSString *decoration = [[styles objectForKey:@"text-decoration"] lowercaseString];
+	if (decoration)
+	{
+		if ([decoration isEqualToString:@"underline"])
+		{
+			self.underlineStyle = kCTUnderlineStyleSingle;
+		}
+		else if ([decoration isEqualToString:@"line-through"])
+		{
+			self.strikeOut = YES;
+		}
+		else if ([decoration isEqualToString:@"none"])
+		{
+			// remove all
+			self.underlineStyle = kCTUnderlineStyleNone;
+			self.strikeOut = NO;
+		}
+		else if ([decoration isEqualToString:@"overline"])
+		{
+			//TODO: add support for overline decoration
+		}
+		else if ([decoration isEqualToString:@"blink"])
+		{
+			//TODO: add support for blink decoration
+		}
+		else if ([decoration isEqualToString:@"inherit"])
+		{
+			// nothing to do
+		}
+	}
+	
+	NSString *alignment = [[styles objectForKey:@"text-align"] lowercaseString];
+	if (alignment)
+	{
+		if ([alignment isEqualToString:@"left"])
+		{
+			self.paragraphStyle.textAlignment = kCTLeftTextAlignment;
+		}
+		else if ([alignment isEqualToString:@"right"])
+		{
+			self.paragraphStyle.textAlignment = kCTRightTextAlignment;
+		}
+		else if ([alignment isEqualToString:@"center"])
+		{
+			self.paragraphStyle.textAlignment = kCTCenterTextAlignment;
+		}
+		else if ([alignment isEqualToString:@"justify"])
+		{
+			self.paragraphStyle.textAlignment = kCTJustifiedTextAlignment;
+		}
+		else if ([alignment isEqualToString:@"inherit"])
+		{
+			// nothing to do
+		}
+	}
+	
+	NSString *shadow = [styles objectForKey:@"text-shadow"];
+	if (shadow)
+	{
+		self.shadows = [shadow arrayOfCSSShadowsWithCurrentTextSize:fontDescriptor.pointSize currentColor:_textColor];
+	}
+	
+	NSString *lineHeight = [[styles objectForKey:@"line-height"] lowercaseString];
+	if (lineHeight)
+	{
+		if ([lineHeight isEqualToString:@"normal"])
+		{
+			self.paragraphStyle.lineHeightMultiple = 0.0; // default
+		}
+		else if ([lineHeight isEqualToString:@"inherit"])
+		{
+			// no op, we already inherited it
+		}
+		else if ([lineHeight isNumeric])
+		{
+			self.paragraphStyle.lineHeightMultiple = [lineHeight floatValue];
+			//            self.paragraphStyle.minimumLineHeight = fontDescriptor.pointSize * (CGFloat)[lineHeight intValue];
+			//            self.paragraphStyle.maximumLineHeight = self.paragraphStyle.minimumLineHeight;
+		}
+		else // interpret as length
+		{
+			self.paragraphStyle.minimumLineHeight = [lineHeight pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize];
+			self.paragraphStyle.maximumLineHeight = self.paragraphStyle.minimumLineHeight;
+		}
+	}
 	
 	NSString *fontVariantStr = [[styles objectForKey:@"font-variant"] lowercaseString];
 	if (fontVariantStr)
@@ -585,8 +585,8 @@
 			fontVariant = DTHTMLElementFontVariantNormal;
 		}
 	}
-    
-    NSString *listStyleStr = [[styles objectForKey:@"list-style"] lowercaseString];
+	
+	NSString *listStyleStr = [[styles objectForKey:@"list-style"] lowercaseString];
 	if (listStyleStr)
 	{
 		if ([listStyleStr isEqualToString:@"inherit"])
@@ -629,23 +629,23 @@
 		{
 			listStyle = DTHTMLElementListStyleUnderscore;
 		}  
-        else
-        {
-            listStyle = DTHTMLElementListStyleInherit;
-        }
+		else
+		{
+			listStyle = DTHTMLElementListStyleInherit;
+		}
 	}
-    
-    NSString *widthString = [styles objectForKey:@"width"];
-    if (widthString)
-    {
-        size.width = [widthString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:self.fontDescriptor.pointSize];
-    }
-    
-    NSString *heightString = [styles objectForKey:@"height"];
-    if (heightString)
-    {
-        size.height = [heightString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:self.fontDescriptor.pointSize];
-    }
+	
+	NSString *widthString = [styles objectForKey:@"width"];
+	if (widthString)
+	{
+		size.width = [widthString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:self.fontDescriptor.pointSize];
+	}
+	
+	NSString *heightString = [styles objectForKey:@"height"];
+	if (heightString)
+	{
+		size.height = [heightString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:self.fontDescriptor.pointSize];
+	}
 }
 
 - (void)addAdditionalAttribute:(id)attribute forKey:(id)key
@@ -660,8 +660,8 @@
 
 - (void)addChild:(DTHTMLElement *)child
 {
-    child.parent = self;
-    [children addObject:child];
+	child.parent = self;
+	[children addObject:child];
 }
 
 - (void)removeChild:(DTHTMLElement *)child
@@ -683,62 +683,62 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    DTHTMLElement *newObject = [[DTHTMLElement allocWithZone:zone] init];
-    
-    newObject.fontDescriptor = self.fontDescriptor; // copy
-    newObject.paragraphStyle = self.paragraphStyle; // copy
-    
-    newObject.fontVariant = self.fontVariant;
-    
-    newObject.underlineStyle = self.underlineStyle;
-    newObject.tagContentInvisible = self.tagContentInvisible;
-    newObject.textColor = self.textColor;
+	DTHTMLElement *newObject = [[DTHTMLElement allocWithZone:zone] init];
+	
+	newObject.fontDescriptor = self.fontDescriptor; // copy
+	newObject.paragraphStyle = self.paragraphStyle; // copy
+	
+	newObject.fontVariant = self.fontVariant;
+	
+	newObject.underlineStyle = self.underlineStyle;
+	newObject.tagContentInvisible = self.tagContentInvisible;
+	newObject.textColor = self.textColor;
 	newObject.isColorInherited = YES;
 	newObject.backgroundColor = self.backgroundColor;
-    newObject.strikeOut = self.strikeOut;
-    newObject.superscriptStyle = self.superscriptStyle;
+	newObject.strikeOut = self.strikeOut;
+	newObject.superscriptStyle = self.superscriptStyle;
 	newObject.shadows = self.shadows;
-    
-    newObject.link = self.link; // copy
+	
+	newObject.link = self.link; // copy
 	
 	newObject.preserveNewlines = self.preserveNewlines;
-    
-    newObject.fontCache = self.fontCache; // reference
+	
+	newObject.fontCache = self.fontCache; // reference
 	newObject.listCounter = self.listCounter;
-    
-    return newObject;
+	
+	return newObject;
 }
 
 #pragma mark Properties
 
 - (NSMutableDictionary *)fontCache
 {
-    if (!_fontCache)
-    {
-        _fontCache = [[NSMutableDictionary alloc] init];
-    }
-    
-    return _fontCache;
+	if (!_fontCache)
+	{
+		_fontCache = [[NSMutableDictionary alloc] init];
+	}
+	
+	return _fontCache;
 }
 
 - (BOOL)isInline
 {
-    if (_isInline<0)
-    {
-        _isInline = [tagName isInlineTag];
-    }
-    
-    return _isInline;
+	if (_isInline<0)
+	{
+		_isInline = [tagName isInlineTag];
+	}
+	
+	return _isInline;
 }
 
 - (BOOL)isMeta
 {
-    if (_isMeta<0)
-    {
-        _isMeta = [tagName isMetaTag];
-    }
-    
-    return _isMeta;
+	if (_isMeta<0)
+	{
+		_isMeta = [tagName isMetaTag];
+	}
+	
+	return _isMeta;
 }
 - (void)setTextColor:(UIColor *)textColor
 {
@@ -770,22 +770,22 @@
 {
 	if (listStyle == DTHTMLElementListStyleInherit)
 	{
-        // defaults
-        if ([tagName isEqualToString:@"ul"])
-        {
-            return DTHTMLElementListStyleDisc;
-        }
-        else if ([tagName isEqualToString:@"ol"])
-        {
-            return DTHTMLElementListStyleDecimal;
-        }
-        
+		// defaults
+		if ([tagName isEqualToString:@"ul"])
+		{
+			return DTHTMLElementListStyleDisc;
+		}
+		else if ([tagName isEqualToString:@"ol"])
+		{
+			return DTHTMLElementListStyleDecimal;
+		}
+		
 		if (parent)
 		{
 			return parent.listStyle;
 		}
 		
-        
+		
 		return DTHTMLElementListStyleNone;
 	}
 	
@@ -794,88 +794,88 @@
 
 - (NSString *)path
 {
-    if (parent)
-    {
-        return [[parent path] stringByAppendingFormat:@"/%@", self.tagName];
-    }
-
-    if (tagName)
-    {
-        return tagName;
-    }
-    
-    return @"root";
+	if (parent)
+	{
+		return [[parent path] stringByAppendingFormat:@"/%@", self.tagName];
+	}
+	
+	if (tagName)
+	{
+		return tagName;
+	}
+	
+	return @"root";
 }
 
 - (NSInteger)listDepth
 {
-    if (_listDepth < 0)
-    {
-        // See if this is a list related element.
-        if ([tagName isEqualToString:@"ol"] || [tagName isEqualToString:@"ul"] || [tagName isEqualToString:@"li"])
-        {
-            // Walk up the tree to the root. Increment the count every time we hit an OL or UL tag
-            // so we have our nesting count correct.
-            DTHTMLElement *elem = self;
-            _listDepth = 0;
-            while (elem.parent) {
-                NSString *tag = elem.parent.tagName;
-                if ([tag isEqualToString:@"ol"] || [tag isEqualToString:@"ul"])
-                {
-                    _listDepth++;
-                }
-                elem = elem.parent;
-            }
-        }
-        else {
-            // We're not a list element, so set the depth to zero.
-            _listDepth = 0;
-        }
-    }
-    return _listDepth;
+	if (_listDepth < 0)
+	{
+		// See if this is a list related element.
+		if ([tagName isEqualToString:@"ol"] || [tagName isEqualToString:@"ul"] || [tagName isEqualToString:@"li"])
+		{
+			// Walk up the tree to the root. Increment the count every time we hit an OL or UL tag
+			// so we have our nesting count correct.
+			DTHTMLElement *elem = self;
+			_listDepth = 0;
+			while (elem.parent) {
+				NSString *tag = elem.parent.tagName;
+				if ([tag isEqualToString:@"ol"] || [tag isEqualToString:@"ul"])
+				{
+					_listDepth++;
+				}
+				elem = elem.parent;
+			}
+		}
+		else {
+			// We're not a list element, so set the depth to zero.
+			_listDepth = 0;
+		}
+	}
+	return _listDepth;
 }
 
 - (NSInteger)listCounter
 {
-    // If the counter is set to NSIntegerMin, it hasn't been calculated or manually set.
-    // Calculate it on demand.
-    if (_listCounter == NSIntegerMin)
-    {
-        // See if this is an LI. No other elements get a counter.
-        if ([tagName isEqualToString:@"li"])
-        {
-            // Count the number of LI elements in the parent until we reach self. That's our counter.
-            NSInteger counter = 1;
-            NSUInteger numChildren = [parent.children count];
-            for (NSInteger i = 0; i < numChildren; i++)
-            {
-                // We walk through the children and check for LI elements just in case someone
-                // slipped us some bad HTML.
-                DTHTMLElement *child = [parent.children objectAtIndex:i];
-                if (child != self && [child.tagName isEqualToString:@"li"])
-                {
-                    // Add one to the last LI's value just in case its listCounter property got overridden and
-                    // set to something other than its natural order in the elements list.
-                    counter = child.listCounter + 1;
-                }
-                else
-                {
-                    break;
-                }
-            }
-            _listCounter = counter;
-        }
-        else
-        {
-            _listCounter = 0;
-        }
-    }
-    return _listCounter;
+	// If the counter is set to NSIntegerMin, it hasn't been calculated or manually set.
+	// Calculate it on demand.
+	if (_listCounter == NSIntegerMin)
+	{
+		// See if this is an LI. No other elements get a counter.
+		if ([tagName isEqualToString:@"li"])
+		{
+			// Count the number of LI elements in the parent until we reach self. That's our counter.
+			NSInteger counter = 1;
+			NSUInteger numChildren = [parent.children count];
+			for (NSInteger i = 0; i < numChildren; i++)
+			{
+				// We walk through the children and check for LI elements just in case someone
+				// slipped us some bad HTML.
+				DTHTMLElement *child = [parent.children objectAtIndex:i];
+				if (child != self && [child.tagName isEqualToString:@"li"])
+				{
+					// Add one to the last LI's value just in case its listCounter property got overridden and
+					// set to something other than its natural order in the elements list.
+					counter = child.listCounter + 1;
+				}
+				else
+				{
+					break;
+				}
+			}
+			_listCounter = counter;
+		}
+		else
+		{
+			_listCounter = 0;
+		}
+	}
+	return _listCounter;
 }
 
 - (void)setListCounter:(NSInteger)count
 {
-    _listCounter = count;
+	_listCounter = count;
 }
 
 @synthesize parent;

--- a/Classes/DTLazyImageView.m
+++ b/Classes/DTLazyImageView.m
@@ -21,8 +21,8 @@ static NSCache *_imageCache = nil;
 	[_receivedData release];
 	[_connection cancel];
 	[_connection release];
-    
-    if (_imageSource)
+	
+	if (_imageSource)
 		CFRelease(_imageSource), _imageSource = NULL;
 	
 	[super dealloc];
@@ -37,7 +37,7 @@ static NSCache *_imageCache = nil;
 	}
 	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 	NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestReturnCacheDataElseLoad timeoutInterval:10.0];
-    
+	
 	_connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
 	[_connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
 	[_connection start];
@@ -53,14 +53,14 @@ static NSCache *_imageCache = nil;
 {
 	if (!self.image && _url && !_connection && self.superview)
 	{
-        UIImage *image = [_imageCache objectForKey:_url];
-        
-        if (image)
-        {
-            self.image = image;
-            return;
-        }
-        
+		UIImage *image = [_imageCache objectForKey:_url];
+		
+		if (image)
+		{
+			self.image = image;
+			return;
+		}
+		
 		[self loadImageAtURL:_url];
 	}	
 }
@@ -93,12 +93,12 @@ static NSCache *_imageCache = nil;
 
 - (void)createAndShowProgressiveImage
 {
-    if (!_imageSource)
-    {
-        return;
-    }
-    
-    /* For progressive download */
+	if (!_imageSource)
+	{
+		return;
+	}
+	
+	/* For progressive download */
 	const NSUInteger totalSize = [_receivedData length];
 	CGImageSourceUpdateData(_imageSource, (CFDataRef)_receivedData, (totalSize == _expectedSize) ? true : false);
 	
@@ -110,10 +110,10 @@ static NSCache *_imageCache = nil;
 			CGImageRef imgTmp = [self newTransitoryImage:image]; // iOS fix to correctly handle JPG see : http://www.cocoabyss.com/mac-os-x/progressive-image-download-imageio/
 			if (imgTmp)
 			{
-                UIImage *image = [[UIImage alloc] initWithCGImage:imgTmp];
+				UIImage *image = [[UIImage alloc] initWithCGImage:imgTmp];
 				[self performSelectorOnMainThread:@selector(setImage:) withObject:image waitUntilDone:YES];
-                [image release];
-                
+				[image release];
+				
 				CGImageRelease(imgTmp);
 			}
 			CGImageRelease(image);
@@ -150,11 +150,11 @@ static NSCache *_imageCache = nil;
 		if (![[httpResponse MIMEType] hasPrefix:@"image"])
 		{
 			[self cancelLoading];
-            return;
+			return;
 		}
 	}
-    
-    /* For progressive download */
+	
+	/* For progressive download */
 	_fullWidth = _fullHeight = -1.0f;
 	_expectedSize = [response expectedContentLength];
 	
@@ -165,11 +165,11 @@ static NSCache *_imageCache = nil;
 {
 	[_receivedData appendData:data];
 	
-    if (!CGImageSourceCreateIncremental || !shouldShowProgressiveDownload)
-    {
-        // don't show progressive
-        return;
-    }
+	if (!CGImageSourceCreateIncremental || !shouldShowProgressiveDownload)
+	{
+		// don't show progressive
+		return;
+	}
 	
 	if (!_imageSource)
 	{
@@ -186,17 +186,17 @@ static NSCache *_imageCache = nil;
 		UIImage *image = [[UIImage alloc] initWithData:_receivedData];
 		
 		self.image = image;
-        
-        if (!_imageCache)
-        {
-            _imageCache = [[NSCache alloc] init];
-        }
-        
-        if (_url)
-        {
-            // cache image
-            [_imageCache setObject:image forKey:_url];
-        }
+		
+		if (!_imageCache)
+		{
+			_imageCache = [[NSCache alloc] init];
+		}
+		
+		if (_url)
+		{
+			// cache image
+			[_imageCache setObject:image forKey:_url];
+		}
 		
 		[image release];
 		
@@ -204,7 +204,7 @@ static NSCache *_imageCache = nil;
 	}
 	
 	[_connection release], _connection = nil;
-
+	
 	/* For progressive download */
 	if (_imageSource)
 		CFRelease(_imageSource), _imageSource = NULL;

--- a/Classes/DTLinkButton.m
+++ b/Classes/DTLinkButton.m
@@ -22,14 +22,14 @@
 
 - (id)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
+	self = [super initWithFrame:frame];
 	if (self)
 	{
 		self.userInteractionEnabled = YES;
 		self.enabled = YES;
 		self.opaque = NO;
 		
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(highlightNotification:) name:@"DTLinkButtonDidHighlight" object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(highlightNotification:) name:@"DTLinkButtonDidHighlight" object:nil];
 	}
 	
 	
@@ -38,10 +38,10 @@
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	
 	[_url release];
-    [_guid release];
+	[_guid release];
 	
 	[super dealloc];
 }
@@ -96,22 +96,22 @@
 #pragma mark Notifications
 - (void)highlightNotification:(NSNotification *)notification
 {
-    if ([notification object] == self)
-    {
-        // that was me
-        return;
-    }
-    
-    NSDictionary *userInfo = [notification userInfo];
-    
-    NSString *guid = [userInfo objectForKey:@"GUID"];
-    
-    if ([guid isEqualToString:_guid])
-    {
-        BOOL highlighted = [[userInfo objectForKey:@"Highlighted"] boolValue];
+	if ([notification object] == self)
+	{
+		// that was me
+		return;
+	}
+	
+	NSDictionary *userInfo = [notification userInfo];
+	
+	NSString *guid = [userInfo objectForKey:@"GUID"];
+	
+	if ([guid isEqualToString:_guid])
+	{
+		BOOL highlighted = [[userInfo objectForKey:@"Highlighted"] boolValue];
 		[super setHighlighted:highlighted];
 		[self setNeedsDisplay];
-    }
+	}
 }
 
 
@@ -120,17 +120,17 @@
 
 - (void)setHighlighted:(BOOL)highlighted
 {
-    [super setHighlighted:highlighted];
+	[super setHighlighted:highlighted];
 	[self setNeedsDisplay];
-    
-    
-    // notify other parts of the same link
-    if (_guid)
-    {
-        NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:highlighted], @"Highlighted", _guid, @"GUID", nil];
-        
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"DTLinkButtonDidHighlight" object:self userInfo:userInfo];
-    }
+	
+	
+	// notify other parts of the same link
+	if (_guid)
+	{
+		NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:highlighted], @"Highlighted", _guid, @"GUID", nil];
+		
+		[[NSNotificationCenter defaultCenter] postNotificationName:@"DTLinkButtonDidHighlight" object:self userInfo:userInfo];
+	}
 }
 
 - (void)setFrame:(CGRect)frame

--- a/Classes/DTTextAttachment.m
+++ b/Classes/DTTextAttachment.m
@@ -16,7 +16,7 @@
 	[contents release];
 	[_contentURL release];
 	[_hyperLinkURL release];
-    [_attributes release];
+	[_attributes release];
 	
 	[super dealloc];
 }

--- a/Classes/DemoAppDelegate.m
+++ b/Classes/DemoAppDelegate.m
@@ -25,17 +25,17 @@
 	
 	// Display the window
 	[_window addSubview:_navigationController.view];
-    [_window makeKeyAndVisible];
-
-    return YES;
+	[_window makeKeyAndVisible];
+	
+	return YES;
 }
 
 
 - (void)dealloc 
 {
-    [_window release];
+	[_window release];
 	[_navigationController release];
-    [super dealloc];
+	[super dealloc];
 }
 
 @end

--- a/Classes/DemoSnippetsViewController.m
+++ b/Classes/DemoSnippetsViewController.m
@@ -34,8 +34,8 @@
 #pragma mark UIViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-
+	[super viewDidLoad];
+	
 	// Load snippets from plist
 	NSString *plistPath = [[NSBundle mainBundle] pathForResource:@"Snippets" ofType:@"plist"];
 	_snippets = [[NSArray alloc] initWithContentsOfFile:plistPath];
@@ -45,12 +45,12 @@
 #pragma mark UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 1;
+	return 1;
 }
 
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return [_snippets count];
+	return [_snippets count];
 }
 
 
@@ -69,18 +69,18 @@
 		
 		NSString *title = [snippet objectForKey:@"Title"];
 		NSString *description = [snippet objectForKey:@"Description"];
-
+		
 		NSString *html = [NSString stringWithFormat:@"<h3>%@</h3><p><font color=\"gray\">%@</font></p>", title, description];
 		NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
 		NSAttributedString *string = [[[NSAttributedString alloc] initWithHTML:data documentAttributes:NULL] autorelease];
 		
 		// set width, height is calculated later from text
 		CGFloat width = self.view.frame.size.width;
-        [DTAttributedTextContentView setLayerClass:nil];
+		[DTAttributedTextContentView setLayerClass:nil];
 		contentView = [[[DTAttributedTextContentView alloc] initWithAttributedString:string width:width - 20.0] autorelease];
 		
 		contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        contentView.edgeInsets = UIEdgeInsetsMake(5, 5, 5, 5);
+		contentView.edgeInsets = UIEdgeInsetsMake(5, 5, 5, 5);
 		[contentViewCache setObject:contentView forKey:indexPath];
 	}
 	
@@ -95,14 +95,14 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    
-    static NSString *cellIdentifier = @"cellIdentifier";
-    
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
-    if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier] autorelease];
+	
+	static NSString *cellIdentifier = @"cellIdentifier";
+	
+	UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
+	if (cell == nil) {
+		cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier] autorelease];
 		cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    }
+	}
 	
 	[cell.contentView.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
 	
@@ -110,8 +110,8 @@
 	
 	contentView.frame = cell.contentView.bounds;
 	[cell.contentView addSubview:contentView];
-    
-    return cell;
+	
+	return cell;
 }
 
 

--- a/Classes/DemoTextViewController.m
+++ b/Classes/DemoTextViewController.m
@@ -68,7 +68,7 @@
 	
 	[lastActionLink release];
 	[mediaPlayers release];
-    
+	
 	[super dealloc];
 }
 
@@ -104,7 +104,7 @@
 	[self.view addSubview:_rangeView];
 	
 	// Create text view
-    [DTAttributedTextContentView setLayerClass:[CATiledLayer class]];
+	[DTAttributedTextContentView setLayerClass:[CATiledLayer class]];
 	_textView = [[DTAttributedTextView alloc] initWithFrame:frame];
 	_textView.textDelegate = self;
 	_textView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -113,7 +113,7 @@
 
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
+	[super viewDidLoad];
 	
 	// Load HTML data
 	NSString *readmePath = [[NSBundle mainBundle] pathForResource:_fileName ofType:nil];
@@ -121,19 +121,19 @@
 	NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
 	
 	// Create attributed string from HTML
-    NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:1.0], NSTextSizeMultiplierDocumentOption, 
-                             @"Times New Roman", DTDefaultFontFamily,  @"purple", DTDefaultLinkColor, nil]; // @"green",DTDefaultTextColor,
-    
+	NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:1.0], NSTextSizeMultiplierDocumentOption, 
+													 @"Times New Roman", DTDefaultFontFamily,  @"purple", DTDefaultLinkColor, nil]; // @"green",DTDefaultTextColor,
+	
 	NSAttributedString *string = [[NSAttributedString alloc] initWithHTML:data options:options documentAttributes:NULL];
 	
 	// Display string
-    _textView.contentView.edgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+	_textView.contentView.edgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
 	_textView.attributedString = string;
-    
+	
 	// Data view
 	_dataView.text = [data description];
-    
-    [string release];
+	
+	[string release];
 }
 
 
@@ -153,33 +153,33 @@
 - (void)viewDidAppear:(BOOL)animated
 {
 	[super viewDidAppear:animated];
-    
+	
 	// now the bar is up so we can autoresize again
 	_textView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    
-    // fill other tabs
-    // Create range view
+	
+	// fill other tabs
+	// Create range view
 	NSMutableString *dumpOutput = [[NSMutableString alloc] init];
 	NSDictionary *attributes = nil;
 	NSRange effectiveRange = NSMakeRange(0, 0);
-    
-    if ([_textView.attributedString length])
-    {
-        
-        while ((attributes = [_textView.attributedString attributesAtIndex:effectiveRange.location effectiveRange:&effectiveRange]))
-        {
-            [dumpOutput appendFormat:@"Range: (%d, %d), %@\n\n", effectiveRange.location, effectiveRange.length, attributes];
-            effectiveRange.location += effectiveRange.length;
-            
-            if (effectiveRange.location >= [_textView.attributedString length])
-            {
-                break;
-            }
-        }
-    }
+	
+	if ([_textView.attributedString length])
+	{
+		
+		while ((attributes = [_textView.attributedString attributesAtIndex:effectiveRange.location effectiveRange:&effectiveRange]))
+		{
+			[dumpOutput appendFormat:@"Range: (%d, %d), %@\n\n", effectiveRange.location, effectiveRange.length, attributes];
+			effectiveRange.location += effectiveRange.length;
+			
+			if (effectiveRange.location >= [_textView.attributedString length])
+			{
+				break;
+			}
+		}
+	}
 	_rangeView.text = dumpOutput;
 	
-    
+	
 	// Create characters view
 	[dumpOutput setString:@""];
 	NSData *dump = [[_textView.attributedString string] dataUsingEncoding:NSUTF8StringEncoding];
@@ -259,48 +259,48 @@
 		grayView.backgroundColor = [UIColor blackColor];
 		
 		MPMoviePlayerController *player =[[[MPMoviePlayerController alloc] initWithContentURL:url] autorelease];
-
+		
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_4_2
-        NSString *airplayAttr = [attachment.attributes objectForKey:@"x-webkit-airplay"];
-        if ([airplayAttr isEqualToString:@"allow"])
-        {
-            if ([player respondsToSelector:@selector(setAllowsAirPlay:)])
-            {
-                player.allowsAirPlay = YES;
-            }
-        }
+		NSString *airplayAttr = [attachment.attributes objectForKey:@"x-webkit-airplay"];
+		if ([airplayAttr isEqualToString:@"allow"])
+		{
+			if ([player respondsToSelector:@selector(setAllowsAirPlay:)])
+			{
+				player.allowsAirPlay = YES;
+			}
+		}
 #endif
-
-        NSString *controlsAttr = [attachment.attributes objectForKey:@"controls"];
-        if (controlsAttr)
-        {
-            player.controlStyle = MPMovieControlStyleEmbedded;
-        }
-        else
-        {
-            player.controlStyle = MPMovieControlStyleNone;
-        }
-
-        NSString *loopAttr = [attachment.attributes objectForKey:@"loop"];
-        if (loopAttr)
-        {
-            player.repeatMode = MPMovieRepeatModeOne;
-        }
-        else
-        {
-            player.repeatMode = MPMovieRepeatModeNone;
-        }
-        
-        NSString *autoplayAttr = [attachment.attributes objectForKey:@"autoplay"];
-        if (autoplayAttr)
-        {
-            player.shouldAutoplay = YES;
-        }
-        else
-        {
-            player.shouldAutoplay = NO;
-        }
-        
+		
+		NSString *controlsAttr = [attachment.attributes objectForKey:@"controls"];
+		if (controlsAttr)
+		{
+			player.controlStyle = MPMovieControlStyleEmbedded;
+		}
+		else
+		{
+			player.controlStyle = MPMovieControlStyleNone;
+		}
+		
+		NSString *loopAttr = [attachment.attributes objectForKey:@"loop"];
+		if (loopAttr)
+		{
+			player.repeatMode = MPMovieRepeatModeOne;
+		}
+		else
+		{
+			player.repeatMode = MPMovieRepeatModeNone;
+		}
+		
+		NSString *autoplayAttr = [attachment.attributes objectForKey:@"autoplay"];
+		if (autoplayAttr)
+		{
+			player.shouldAutoplay = YES;
+		}
+		else
+		{
+			player.shouldAutoplay = NO;
+		}
+		
 		[player prepareToPlay];
 		[self.mediaPlayers addObject:player];
 		
@@ -318,7 +318,7 @@
 		{
 			imageView.image = attachment.contents;
 		}
-
+		
 		// url for deferred loading
 		imageView.url = attachment.contentURL;
 		
@@ -363,8 +363,8 @@
 - (void)debugButton:(UIBarButtonItem *)sender
 {
 	_textView.contentView.drawDebugFrames = !_textView.contentView.drawDebugFrames;
-    [DTCoreTextLayoutFrame setShouldDrawDebugFrames:_textView.contentView.drawDebugFrames];
-    [self.view setNeedsDisplay];
+	[DTCoreTextLayoutFrame setShouldDrawDebugFrames:_textView.contentView.drawDebugFrames];
+	[self.view setNeedsDisplay];
 }
 
 #pragma mark Properties

--- a/Classes/NSAttributedString+HTML.m
+++ b/Classes/NSAttributedString+HTML.m
@@ -70,16 +70,16 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 		CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)textEncodingName);
 		encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
 	}
-    
-    // custom option to limit image size
-    NSValue *maxImageSizeValue = [options objectForKey:DTMaxImageSize];
-    
-    // custom option to scale text
-    CGFloat textScale = [[options objectForKey:NSTextSizeMultiplierDocumentOption] floatValue];
-    if (!textScale)
-    {
-        textScale = 1.0f;
-    }
+	
+	// custom option to limit image size
+	NSValue *maxImageSizeValue = [options objectForKey:DTMaxImageSize];
+	
+	// custom option to scale text
+	CGFloat textScale = [[options objectForKey:NSTextSizeMultiplierDocumentOption] floatValue];
+	if (!textScale)
+	{
+		textScale = 1.0f;
+	}
 	
 	// use baseURL from options if present
 	NSURL *baseURL = [options objectForKey:NSBaseURLDocumentOption];
@@ -96,7 +96,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 		return nil;
 	}
 	
-    // for performance we will return this mutable string
+	// for performance we will return this mutable string
 	NSMutableAttributedString *tmpString = [[NSMutableAttributedString alloc] init];
 	
 #if ALLOW_IPHONE_SPECIAL_CASES
@@ -109,35 +109,35 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 	NSScanner *scanner = [NSScanner scannerWithString:htmlString];
 	scanner.charactersToBeSkipped = nil;
 	[htmlString release];
-    
+	
 	// base tag with font defaults
 	DTCoreTextFontDescriptor *defaultFontDescriptor = [[[DTCoreTextFontDescriptor alloc] initWithFontAttributes:nil] autorelease];
-    defaultFontDescriptor.pointSize = 12.0 * textScale;
-    
-    NSString *defaultFontFamily = [options objectForKey:DTDefaultFontFamily];
-    if (defaultFontFamily)
-    {
-        defaultFontDescriptor.fontFamily = defaultFontFamily;
-    }
-    else
-    {
-        defaultFontDescriptor.fontFamily = @"Times New Roman";
-    }
-    
-    id defaultLinkColor = [options objectForKey:DTDefaultLinkColor];
-    
-    if (defaultLinkColor)
-    {
-        if ([defaultLinkColor isKindOfClass:[NSString class]])
-        {
-            // convert from string to color
-            defaultLinkColor = [UIColor colorWithHTMLName:defaultLinkColor];
-        }
-    }
-    else
-    {
-        defaultLinkColor = [UIColor colorWithHTMLName:@"#0000EE"];
-    }
+	defaultFontDescriptor.pointSize = 12.0 * textScale;
+	
+	NSString *defaultFontFamily = [options objectForKey:DTDefaultFontFamily];
+	if (defaultFontFamily)
+	{
+		defaultFontDescriptor.fontFamily = defaultFontFamily;
+	}
+	else
+	{
+		defaultFontDescriptor.fontFamily = @"Times New Roman";
+	}
+	
+	id defaultLinkColor = [options objectForKey:DTDefaultLinkColor];
+	
+	if (defaultLinkColor)
+	{
+		if ([defaultLinkColor isKindOfClass:[NSString class]])
+		{
+			// convert from string to color
+			defaultLinkColor = [UIColor colorWithHTMLName:defaultLinkColor];
+		}
+	}
+	else
+	{
+		defaultLinkColor = [UIColor colorWithHTMLName:@"#0000EE"];
+	}
 	
 	// default is to have A underlined
 	BOOL defaultLinkDecoration = YES;
@@ -150,7 +150,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 	}
 	
 	// default paragraph style
-    DTCoreTextParagraphStyle *defaultParagraphStyle = [DTCoreTextParagraphStyle defaultParagraphStyle];
+	DTCoreTextParagraphStyle *defaultParagraphStyle = [DTCoreTextParagraphStyle defaultParagraphStyle];
 	
 	NSNumber *defaultLineHeightMultiplierNum = [options objectForKey:DTDefaultLineHeightMultiplier];
 	
@@ -166,45 +166,45 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 	{
 		defaultParagraphStyle.textAlignment = [defaultTextAlignmentNum integerValue];
 	}
-    
-    DTHTMLElement *defaultTag = [[[DTHTMLElement alloc] init] autorelease];
-    defaultTag.fontDescriptor = defaultFontDescriptor;
-    defaultTag.paragraphStyle = defaultParagraphStyle;
-    defaultTag.textScale = textScale;
-    
-    id defaultColor = [options objectForKey:DTDefaultTextColor];
-    if (defaultColor)
-    {
-        if ([defaultColor isKindOfClass:[UIColor class]])
-        {
-            // already a UIColor
-            defaultTag.textColor = defaultColor;
-        }
-        else
-        {
-            // need to convert first
-            defaultTag.textColor = [UIColor colorWithHTMLName:defaultColor];
-        }
-    }
-    
+	
+	DTHTMLElement *defaultTag = [[[DTHTMLElement alloc] init] autorelease];
+	defaultTag.fontDescriptor = defaultFontDescriptor;
+	defaultTag.paragraphStyle = defaultParagraphStyle;
+	defaultTag.textScale = textScale;
+	
+	id defaultColor = [options objectForKey:DTDefaultTextColor];
+	if (defaultColor)
+	{
+		if ([defaultColor isKindOfClass:[UIColor class]])
+		{
+			// already a UIColor
+			defaultTag.textColor = defaultColor;
+		}
+		else
+		{
+			// need to convert first
+			defaultTag.textColor = [UIColor colorWithHTMLName:defaultColor];
+		}
+	}
+	
 	DTHTMLElement *currentTag = defaultTag; // our defaults are the root
 	
 	// skip initial whitespace
 	[scanner scanCharactersFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet] intoString:NULL];
  	
-    // skip doctype tag
-    [scanner scanDOCTYPE:NULL];
-    
-    // skip initial whitespace
+	// skip doctype tag
+	[scanner scanDOCTYPE:NULL];
+	
+	// skip initial whitespace
 	[scanner scanCharactersFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet] intoString:NULL];
-    
+	
 	while (![scanner isAtEnd]) 
 	{
 		NSString *tagName = nil;
 		NSDictionary *tagAttributesDict = nil;
 		BOOL tagOpen = YES;
 		BOOL immediatelyClosed = NO;
-        
+		
 		if ([scanner scanHTMLTag:&tagName attributes:&tagAttributesDict isOpen:&tagOpen isClosed:&immediatelyClosed] && tagName)
 		{
 			
@@ -215,12 +215,12 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			
 			if (tagOpen)
 			{
-                // make new tag as copy of previous tag
+				// make new tag as copy of previous tag
 				DTHTMLElement *parent = currentTag;
-                currentTag = [[currentTag copy] autorelease];
-                currentTag.tagName = tagName;
-                currentTag.textScale = textScale;
-                [parent addChild:currentTag];
+				currentTag = [[currentTag copy] autorelease];
+				currentTag.tagName = tagName;
+				currentTag.textScale = textScale;
+				[parent addChild:currentTag];
 				
 				// convert CSS Styles into our own style
 				NSString *styleString = [tagAttributesDict objectForKey:@"style"];
@@ -229,33 +229,33 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 				{
 					[currentTag parseStyleString:styleString];
 				}
-                
-                if (![currentTag isInline] && !tagOpen && ![currentTag isMeta])
-                {
-                    // next text needs a NL
-                    needsNewLineBefore = YES;
-                }
-                
-                
-                // direction
-                NSString *direction = [tagAttributesDict objectForKey:@"dir"];
-                
-                if (direction)
-                {
-                    NSString *lowerDirection = [direction lowercaseString];
-                    
-                    
-                    if ([lowerDirection isEqualToString:@"ltr"])
-                    {
-                        currentTag.paragraphStyle.writingDirection = kCTWritingDirectionLeftToRight;
-                    }
-                    else if ([lowerDirection isEqualToString:@"rtl"])
-                    {
-                        currentTag.paragraphStyle.writingDirection = kCTWritingDirectionRightToLeft;
-                    }
-                }
+				
+				if (![currentTag isInline] && !tagOpen && ![currentTag isMeta])
+				{
+					// next text needs a NL
+					needsNewLineBefore = YES;
+				}
+				
+				
+				// direction
+				NSString *direction = [tagAttributesDict objectForKey:@"dir"];
+				
+				if (direction)
+				{
+					NSString *lowerDirection = [direction lowercaseString];
+					
+					
+					if ([lowerDirection isEqualToString:@"ltr"])
+					{
+						currentTag.paragraphStyle.writingDirection = kCTWritingDirectionLeftToRight;
+					}
+					else if ([lowerDirection isEqualToString:@"rtl"])
+					{
+						currentTag.paragraphStyle.writingDirection = kCTWritingDirectionRightToLeft;
+					}
+				}
 			}
-            
+			
 			// ---------- Processing
 			
 			if ([tagName isEqualToString:@"#COMMENT#"])
@@ -276,18 +276,18 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 				NSURL *imageURL = nil;
 				UIImage *decodedImage = nil;
 				
-                // get size of width/height if it's not in style
+				// get size of width/height if it's not in style
 				CGSize imageSize = currentTag.size;
 				
-                if (!imageSize.width)
-                {
-                    imageSize.width = [[tagAttributesDict objectForKey:@"width"] floatValue];
-                }
+				if (!imageSize.width)
+				{
+					imageSize.width = [[tagAttributesDict objectForKey:@"width"] floatValue];
+				}
 				
-                if (!imageSize.height)
-                {
-                    imageSize.height = [[tagAttributesDict objectForKey:@"height"] floatValue];
-                }
+				if (!imageSize.height)
+				{
+					imageSize.height = [[tagAttributesDict objectForKey:@"height"] floatValue];
+				}
 				
 				// decode data URL
 				if ([src hasPrefix:@"data:"])
@@ -355,25 +355,25 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						}
 					}
 				}
-                
+				
 				CGSize adjustedSize = imageSize;
 				
-                // option DTMaxImageSize
-                if (maxImageSizeValue)
-                {
-                    CGSize maxImageSize = [maxImageSizeValue CGSizeValue];
-                    
-                    if (maxImageSize.width < imageSize.width || maxImageSize.height < imageSize.height)
-                    {
-                        adjustedSize = sizeThatFitsKeepingAspectRatio(imageSize,maxImageSize);
-                    }
-                }
+				// option DTMaxImageSize
+				if (maxImageSizeValue)
+				{
+					CGSize maxImageSize = [maxImageSizeValue CGSizeValue];
+					
+					if (maxImageSize.width < imageSize.width || maxImageSize.height < imageSize.height)
+					{
+						adjustedSize = sizeThatFitsKeepingAspectRatio(imageSize,maxImageSize);
+					}
+				}
 				
 				DTTextAttachment *attachment = [[DTTextAttachment alloc] init];
 				attachment.contentURL = imageURL;
 				attachment.originalSize = imageSize;
 				attachment.displaySize = adjustedSize;
-                attachment.attributes = tagAttributesDict;
+				attachment.attributes = tagAttributesDict;
 				attachment.contents = decodedImage;
 				
 				// we copy the link because we might need for it making the custom view
@@ -381,22 +381,22 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 				{
 					attachment.hyperLinkURL = currentTag.link;
 				}
-                
-                currentTag.textAttachment = attachment;
+				
+				currentTag.textAttachment = attachment;
 				
 				if (needsNewLineBefore)
 				{
 					if ([tmpString length] && ![[tmpString string] hasSuffix:@"\n"])
 					{
-                        [tmpString appendNakedString:@"\n"];
+						[tmpString appendNakedString:@"\n"];
 					}
 					
 					needsNewLineBefore = NO;
 				}
-                
-                [tmpString appendAttributedString:[currentTag attributedString]];
+				
+				[tmpString appendAttributedString:[currentTag attributedString]];
 				[attachment release];
-                
+				
 #if ALLOW_IPHONE_SPECIAL_CASES
 				// workaround, make float images blocks because we have no float
 				if (currentTag.floatStyle || attachment.displaySize.height > 5.0 * currentTag.fontDescriptor.pointSize)
@@ -405,56 +405,56 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 				}
 #endif
 			}
-            else if ([tagName isEqualToString:@"blockquote"] && tagOpen)
-            {
-                currentTag.paragraphStyle.headIndent += 25.0 * textScale;
-                currentTag.paragraphStyle.firstLineIndent = currentTag.paragraphStyle.headIndent;
-                currentTag.paragraphStyle.paragraphSpacing = defaultFontDescriptor.pointSize;
-            }
-            else if ([tagName isEqualToString:@"video"] && tagOpen)
+			else if ([tagName isEqualToString:@"blockquote"] && tagOpen)
+			{
+				currentTag.paragraphStyle.headIndent += 25.0 * textScale;
+				currentTag.paragraphStyle.firstLineIndent = currentTag.paragraphStyle.headIndent;
+				currentTag.paragraphStyle.paragraphSpacing = defaultFontDescriptor.pointSize;
+			}
+			else if ([tagName isEqualToString:@"video"] && tagOpen)
 			{
 				// hide contents of recognized tag
-                currentTag.tagContentInvisible = YES;
-                
-                // get size of width/height if it's not in style
-				CGSize imageSize = currentTag.size;
-                
-                if (!imageSize.width)
-                {
-                    imageSize.width = [[tagAttributesDict objectForKey:@"width"] floatValue];
-                }
-                
-                if (!imageSize.height)
-                {
-                    imageSize.height = [[tagAttributesDict objectForKey:@"height"] floatValue];
-                }
+				currentTag.tagContentInvisible = YES;
 				
-                // if we still have no size then we use standard size
-                if (!imageSize.width || !imageSize.height)
-                {
-                    imageSize = CGSizeMake(300, 225);
-                }
-                
-                // option DTMaxImageSize
-                if (maxImageSizeValue)
-                {
-                    CGSize maxImageSize = [maxImageSizeValue CGSizeValue];
-                    
-                    if (maxImageSize.width < imageSize.width || maxImageSize.height < imageSize.height)
-                    {
-                        imageSize = sizeThatFitsKeepingAspectRatio(imageSize,maxImageSize);
-                    }
-                }
-                
+				// get size of width/height if it's not in style
+				CGSize imageSize = currentTag.size;
+				
+				if (!imageSize.width)
+				{
+					imageSize.width = [[tagAttributesDict objectForKey:@"width"] floatValue];
+				}
+				
+				if (!imageSize.height)
+				{
+					imageSize.height = [[tagAttributesDict objectForKey:@"height"] floatValue];
+				}
+				
+				// if we still have no size then we use standard size
+				if (!imageSize.width || !imageSize.height)
+				{
+					imageSize = CGSizeMake(300, 225);
+				}
+				
+				// option DTMaxImageSize
+				if (maxImageSizeValue)
+				{
+					CGSize maxImageSize = [maxImageSizeValue CGSizeValue];
+					
+					if (maxImageSize.width < imageSize.width || maxImageSize.height < imageSize.height)
+					{
+						imageSize = sizeThatFitsKeepingAspectRatio(imageSize,maxImageSize);
+					}
+				}
+				
 				DTTextAttachment *attachment = [[[DTTextAttachment alloc] init] autorelease];
 				attachment.contentURL = [NSURL URLWithString:[tagAttributesDict objectForKey:@"src"]];
-                attachment.contentType = DTTextAttachmentTypeVideoURL;
+				attachment.contentType = DTTextAttachmentTypeVideoURL;
 				attachment.originalSize = imageSize;
-                attachment.attributes = tagAttributesDict;
-                
-                currentTag.textAttachment = attachment;
-                
-                [tmpString appendAttributedString:[currentTag attributedString]];
+				attachment.attributes = tagAttributesDict;
+				
+				currentTag.textAttachment = attachment;
+				
+				[tmpString appendAttributedString:[currentTag attributedString]];
 			}
 			else if ([tagName isEqualToString:@"a"])
 			{
@@ -464,7 +464,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 					{
 						currentTag.underlineStyle = kCTUnderlineStyleSingle;
 					}
-                    
+					
  					if (currentTag.isColorInherited || !currentTag.textColor)
 					{
 						currentTag.textColor = defaultLinkColor;
@@ -490,7 +490,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						}
 					}
 					
-                    currentTag.link = link;
+					currentTag.link = link;
 				}
 			}
 			else if ([tagName isEqualToString:@"b"] || [tagName isEqualToString:@"strong"])
@@ -516,27 +516,27 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						counterElement.listCounter = value;
 						currentTag.listCounter = value;
 					}
-
+					
 					counterElement.listCounter++;
 					
 					needsListItemStart = YES;
-                    currentTag.paragraphStyle.paragraphSpacing = 0;
+					currentTag.paragraphStyle.paragraphSpacing = 0;
 					
 #if ALLOW_IPHONE_SPECIAL_CASES                    
-                    CGFloat indentSize = 27.0 * textScale;
+					CGFloat indentSize = 27.0 * textScale;
 #else
-                    CGFloat indentSize = 36.0 * textScale;
+					CGFloat indentSize = 36.0 * textScale;
 #endif
-                    
-                    CGFloat indentHang = indentSize;
 					
-                    currentTag.paragraphStyle.headIndent += indentSize;
-                    currentTag.paragraphStyle.firstLineIndent = currentTag.paragraphStyle.headIndent - indentHang;
+					CGFloat indentHang = indentSize;
 					
-                    [currentTag.paragraphStyle addTabStopAtPosition:currentTag.paragraphStyle.headIndent - 5.0*textScale alignment:kCTRightTextAlignment];
+					currentTag.paragraphStyle.headIndent += indentSize;
+					currentTag.paragraphStyle.firstLineIndent = currentTag.paragraphStyle.headIndent - indentHang;
 					
-                    [currentTag.paragraphStyle addTabStopAtPosition:currentTag.paragraphStyle.headIndent alignment:	kCTLeftTextAlignment];			
-                }
+					[currentTag.paragraphStyle addTabStopAtPosition:currentTag.paragraphStyle.headIndent - 5.0*textScale alignment:kCTRightTextAlignment];
+					
+					[currentTag.paragraphStyle addTabStopAtPosition:currentTag.paragraphStyle.headIndent alignment:	kCTLeftTextAlignment];			
+				}
 				else 
 				{
 					needsListItemStart = NO;
@@ -547,7 +547,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    currentTag.paragraphStyle.textAlignment = kCTLeftTextAlignment;
+					currentTag.paragraphStyle.textAlignment = kCTLeftTextAlignment;
 				}
 #if ALLOW_IPHONE_SPECIAL_CASES
 				else 
@@ -558,14 +558,14 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			}
 			else if ([tagName isEqualToString:@"center"] && tagOpen)
 			{
-                currentTag.paragraphStyle.textAlignment = kCTCenterTextAlignment;
+				currentTag.paragraphStyle.textAlignment = kCTCenterTextAlignment;
 #if ALLOW_IPHONE_SPECIAL_CASES						
 				nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
 #endif
 			}
 			else if ([tagName isEqualToString:@"right"] && tagOpen)
 			{
-                currentTag.paragraphStyle.textAlignment = kCTRightTextAlignment;
+				currentTag.paragraphStyle.textAlignment = kCTRightTextAlignment;
 #if ALLOW_IPHONE_SPECIAL_CASES						
 				nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
 #endif
@@ -574,7 +574,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    currentTag.strikeOut = YES;
+					currentTag.strikeOut = YES;
 				}
 			}
 			else if ([tagName isEqualToString:@"ol"]) 
@@ -592,13 +592,13 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						currentTag.listCounter = 1;
 					}
 					
-                    needsNewLineBefore = YES;
+					needsNewLineBefore = YES;
 				} 
 				else 
 				{
 #if ALLOW_IPHONE_SPECIAL_CASES
-                    if (currentTag.listDepth < 1)
-                        nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
+					if (currentTag.listDepth < 1)
+						nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
 #endif
 				}
 			}
@@ -606,31 +606,31 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    needsNewLineBefore = YES;
+					needsNewLineBefore = YES;
 					
 					currentTag.listCounter = 0;
 				}
 				else 
 				{
 #if ALLOW_IPHONE_SPECIAL_CASES
-                    if (currentTag.listDepth < 1)
-                        nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
+					if (currentTag.listDepth < 1)
+						nextParagraphAdditionalSpaceBefore = defaultFontDescriptor.pointSize;
 #endif
 				}
 			}
-            
+			
 			else if ([tagName isEqualToString:@"u"])
 			{
 				if (tagOpen)
 				{
-                    currentTag.underlineStyle = kCTUnderlineStyleSingle;
+					currentTag.underlineStyle = kCTUnderlineStyleSingle;
 				}
 			}
 			else if ([tagName isEqualToString:@"sup"])
 			{
 				if (tagOpen)
 				{
-                    currentTag.superscriptStyle = 1;
+					currentTag.superscriptStyle = 1;
 					currentTag.fontDescriptor.pointSize *= 0.83;
 				}
 			}
@@ -638,7 +638,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    currentTag.fontDescriptor.fontFamily = @"Courier";
+					currentTag.fontDescriptor.fontFamily = @"Courier";
 					currentTag.preserveNewlines = YES;
 				}
 			}
@@ -646,7 +646,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    currentTag.superscriptStyle = -1;
+					currentTag.superscriptStyle = -1;
 					currentTag.fontDescriptor.pointSize *= 0.83;
 				}
 			}
@@ -654,9 +654,9 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    // TODO: store style info in a dictionary and apply it to tags
+					// TODO: store style info in a dictionary and apply it to tags
 					currentTag.tagContentInvisible = YES;
-                    needsNewLineBefore = NO;
+					needsNewLineBefore = NO;
 				}
 			}
 			else if ([tagName isEqualToString:@"hr"])
@@ -693,56 +693,56 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 			{
 				if (tagOpen)
 				{
-                    NSString *levelString = [tagName substringFromIndex:1];
-                    
-                    NSInteger headerLevel = [levelString integerValue];
-                    
+					NSString *levelString = [tagName substringFromIndex:1];
+					
+					NSInteger headerLevel = [levelString integerValue];
+					
 					if (headerLevel)
 					{
-                        currentTag.headerLevel = headerLevel;
+						currentTag.headerLevel = headerLevel;
 						currentTag.fontDescriptor.boldTrait = YES;
 						
 						switch (headerLevel) 
 						{
 							case 1:
 							{
-                                // H1: 2 em, spacing before 0.67 em, after 0.67 em
-                                currentTag.fontDescriptor.pointSize *= 2.0;
-                                currentTag.paragraphStyle.paragraphSpacing = 0.67 * currentTag.fontDescriptor.pointSize;
+								// H1: 2 em, spacing before 0.67 em, after 0.67 em
+								currentTag.fontDescriptor.pointSize *= 2.0;
+								currentTag.paragraphStyle.paragraphSpacing = 0.67 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							case 2:
 							{
-                                // H2: 1.5 em, spacing before 0.83 em, after 0.83 em
-                                currentTag.fontDescriptor.pointSize *= 1.5;
-                                currentTag.paragraphStyle.paragraphSpacing = 0.83 * currentTag.fontDescriptor.pointSize;
+								// H2: 1.5 em, spacing before 0.83 em, after 0.83 em
+								currentTag.fontDescriptor.pointSize *= 1.5;
+								currentTag.paragraphStyle.paragraphSpacing = 0.83 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							case 3:
 							{
-                                // H3: 1.17 em, spacing before 1 em, after 1 em
-                                currentTag.fontDescriptor.pointSize *= 1.17;
-                                currentTag.paragraphStyle.paragraphSpacing = 1.0 * currentTag.fontDescriptor.pointSize;
+								// H3: 1.17 em, spacing before 1 em, after 1 em
+								currentTag.fontDescriptor.pointSize *= 1.17;
+								currentTag.paragraphStyle.paragraphSpacing = 1.0 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							case 4:
 							{
-                                // H4: 1 em, spacing before 1.33 em, after 1.33 em
-                                currentTag.paragraphStyle.paragraphSpacing = 1.33 * currentTag.fontDescriptor.pointSize;
+								// H4: 1 em, spacing before 1.33 em, after 1.33 em
+								currentTag.paragraphStyle.paragraphSpacing = 1.33 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							case 5:
 							{
-                                // H5: 0.83 em, spacing before 1.67 em, after 1.167 em
-                                currentTag.fontDescriptor.pointSize *= 0.83;
-                                currentTag.paragraphStyle.paragraphSpacing = 1.67 * currentTag.fontDescriptor.pointSize;
+								// H5: 0.83 em, spacing before 1.67 em, after 1.167 em
+								currentTag.fontDescriptor.pointSize *= 0.83;
+								currentTag.paragraphStyle.paragraphSpacing = 1.67 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							case 6:
 							{
-                                // H6: 0.67 em, spacing before 2.33 em, after 2.33 em
-                                currentTag.fontDescriptor.pointSize *= 0.67;
-                                currentTag.paragraphStyle.paragraphSpacing = 2.33 * currentTag.fontDescriptor.pointSize;
+								// H6: 0.67 em, spacing before 2.33 em, after 2.33 em
+								currentTag.fontDescriptor.pointSize *= 0.67;
+								currentTag.paragraphStyle.paragraphSpacing = 2.33 * currentTag.fontDescriptor.pointSize;
 								break;
 							}
 							default:
@@ -751,20 +751,20 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 					}
 				}
 			}
-            else if ([tagName isEqualToString:@"big"])
-            {
-                if (tagOpen)
-                {
-                    currentTag.fontDescriptor.pointSize *= 1.2;
-                }
-            }
-            else if ([tagName isEqualToString:@"small"])
-            {
-                if (tagOpen)
-                {
-                    currentTag.fontDescriptor.pointSize /= 1.2;
-                }
-            }
+			else if ([tagName isEqualToString:@"big"])
+			{
+				if (tagOpen)
+				{
+					currentTag.fontDescriptor.pointSize *= 1.2;
+				}
+			}
+			else if ([tagName isEqualToString:@"small"])
+			{
+				if (tagOpen)
+				{
+					currentTag.fontDescriptor.pointSize /= 1.2;
+				}
+			}
 			else if ([tagName isEqualToString:@"font"])
 			{
 				if (tagOpen)
@@ -803,27 +803,27 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 					{
 						currentTag.fontDescriptor.fontName = face;
 					}
-                    
-                    NSString *color = [tagAttributesDict objectForKey:@"color"];
-                    
-                    if (color)
-                    {
-                        currentTag.textColor = [UIColor colorWithHTMLName:color];       
-                    }
+					
+					NSString *color = [tagAttributesDict objectForKey:@"color"];
+					
+					if (color)
+					{
+						currentTag.textColor = [UIColor colorWithHTMLName:color];       
+					}
 				}
 			}
 			else if ([tagName isEqualToString:@"p"])
 			{
 				if (tagOpen)
 				{
-                    currentTag.paragraphStyle.paragraphSpacing = defaultFontDescriptor.pointSize;
+					currentTag.paragraphStyle.paragraphSpacing = defaultFontDescriptor.pointSize;
 				}
 				
 			}
 			else if ([tagName isEqualToString:@"br"])
 			{
 				immediatelyClosed = YES; 
-                
+				
 				currentTag.text = UNICODE_LINE_FEED;
 				[tmpString appendAttributedString:[currentTag attributedString]];
 			}
@@ -840,7 +840,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 				// block items have to have a NL at the end.
 				if (![currentTag isInline] && ![currentTag isMeta] && ![[tmpString string] hasSuffix:@"\n"] && ![[tmpString string] hasSuffix:UNICODE_OBJECT_PLACEHOLDER])
 				{
-                    [tmpString appendString:@"\n"];  // extends attributed area at end
+					[tmpString appendString:@"\n"];  // extends attributed area at end
 				}
 				
 				// check if this tag is indeed closing the currently open one
@@ -865,28 +865,28 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 		{
 			//----------------------------------------- TAG CONTENTS -----------------------------------------
 			NSString *tagContents = nil;
-            
-            // if we find a < at this stage then we can assume it was a malformed tag, need to skip it to prevent endless loop
-            
-            BOOL skippedAngleBracket = NO;
-            if ([scanner scanString:@"<" intoString:NULL])
-            {
-                skippedAngleBracket = YES;
-            }
+			
+			// if we find a < at this stage then we can assume it was a malformed tag, need to skip it to prevent endless loop
+			
+			BOOL skippedAngleBracket = NO;
+			if ([scanner scanString:@"<" intoString:NULL])
+			{
+				skippedAngleBracket = YES;
+			}
 			
 			if ((skippedAngleBracket||[scanner scanUpToString:@"<" intoString:&tagContents]) && !currentTag.tagContentInvisible)
 			{
-                if (skippedAngleBracket)
-                {
-                    if (tagContents)
-                    {
-                        tagContents = [@"<" stringByAppendingString:tagContents];
-                    }
-                    else
-                    {
-                        tagContents = @"<";
-                    }
-                }
+				if (skippedAngleBracket)
+				{
+					if (tagContents)
+					{
+						tagContents = [@"<" stringByAppendingString:tagContents];
+					}
+					else
+					{
+						tagContents = @"<";
+					}
+				}
 				
 				if ([[tagContents stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]] length])
 				{
@@ -895,9 +895,9 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						tagContents = [tagContents stringByNormalizingWhitespace];
 					}
 					tagContents = [tagContents stringByReplacingHTMLEntities];
-                    
-                    tagName = currentTag.tagName;
-                    
+					
+					tagName = currentTag.tagName;
+					
 #if ALLOW_IPHONE_SPECIAL_CASES				
 					if (tagOpen && ![currentTag isInline] && ![tagName isEqualToString:@"li"])
 					{
@@ -925,7 +925,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						{
 							if (![[tmpString string] hasSuffix:@"\n"])
 							{
-                                [tmpString appendNakedString:@"\n"];
+								[tmpString appendNakedString:@"\n"];
 							}
 						}
 						needsNewLineBefore = NO;
@@ -940,37 +940,37 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 							tagContents = [tagContents substringFromIndex:1];
 						}
 					}
-                    
-                    // if we start a list, then we wait until we have actual text
+					
+					// if we start a list, then we wait until we have actual text
 					if (needsListItemStart && [tagContents length] > 0 && ![tagContents isEqualToString:@" "])
 					{
-                        NSAttributedString *prefixString = [currentTag prefixForListItemWithCounter:currentTag.listCounter];
-                        
-                        if (prefixString)
-                        {
-                            [tmpString appendAttributedString:prefixString]; 
-                        }
+						NSAttributedString *prefixString = [currentTag prefixForListItemWithCounter:currentTag.listCounter];
+						
+						if (prefixString)
+						{
+							[tmpString appendAttributedString:prefixString]; 
+						}
 						
 						needsListItemStart = NO;
 					}
 					
-                    
-                    // we don't want whitespace before first tag to turn into paragraphs
-                    if (![currentTag isMeta])
-                    {
-                        currentTag.text = tagContents;
-                        
-                        [tmpString appendAttributedString:[currentTag attributedString]];
-                    }
+					
+					// we don't want whitespace before first tag to turn into paragraphs
+					if (![currentTag isMeta])
+					{
+						currentTag.text = tagContents;
+						
+						[tmpString appendAttributedString:[currentTag attributedString]];
+					}
 				}
 			}
 		}
 	}
 	
-    // returning the temporary mutable string is faster
+	// returning the temporary mutable string is faster
 	//return [self initWithAttributedString:tmpString];
-    [self release];
-    return tmpString;
+	[self release];
+	return tmpString;
 }
 
 #pragma mark Convenience Methods

--- a/Classes/NSAttributedStringRunDelegates.m
+++ b/Classes/NSAttributedStringRunDelegates.m
@@ -19,7 +19,7 @@ CGFloat embeddedObjectGetAscentCallback(void *context)
 	{
 		return [(DTTextAttachment *)context displaySize].height;
 	}
-    
+	
 	return 0;
 }
 CGFloat embeddedObjectGetDescentCallback(void *context)
@@ -28,8 +28,8 @@ CGFloat embeddedObjectGetDescentCallback(void *context)
 	{
 		return 0;
 	}
-
-    return 0;
+	
+	return 0;
 }
 
 CGFloat embeddedObjectGetWidthCallback(void * context)

--- a/Classes/NSCharacterSet+HTML.m
+++ b/Classes/NSCharacterSet+HTML.m
@@ -17,45 +17,45 @@ static NSCharacterSet *_nonQuotedAttributeEndCharacterSet = nil;
 
 + (NSCharacterSet *)tagNameCharacterSet
 {
-    if (!_tagNameCharacterSet)
-    {
-        _tagNameCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"] retain];
-    }
-    
-    return _tagNameCharacterSet;
+	if (!_tagNameCharacterSet)
+	{
+		_tagNameCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"] retain];
+	}
+	
+	return _tagNameCharacterSet;
 }
 
 + (NSCharacterSet *)tagAttributeNameCharacterSet
 {
-    if (!_tagAttributeNameCharacterSet)
-    {
-        _tagAttributeNameCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"] retain];
-    }
-    
-    return _tagAttributeNameCharacterSet;
- }
+	if (!_tagAttributeNameCharacterSet)
+	{
+		_tagAttributeNameCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"] retain];
+	}
+	
+	return _tagAttributeNameCharacterSet;
+}
 
 + (NSCharacterSet *)quoteCharacterSet
 {
-    if (!_quoteCharacterSet)
-    {
-        _quoteCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"'\""] retain];
-    }
-    
-    return _quoteCharacterSet;
+	if (!_quoteCharacterSet)
+	{
+		_quoteCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:@"'\""] retain];
+	}
+	
+	return _quoteCharacterSet;
 }
 
 + (NSCharacterSet *)nonQuotedAttributeEndCharacterSet
 {
-    if (!_nonQuotedAttributeEndCharacterSet)
-    {
-        NSMutableCharacterSet *tmpCharacterSet = [NSMutableCharacterSet characterSetWithCharactersInString:@"/>"];
-        [tmpCharacterSet formUnionWithCharacterSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        
-        _nonQuotedAttributeEndCharacterSet = [tmpCharacterSet copy];
-    }
-    
-    return _nonQuotedAttributeEndCharacterSet;
+	if (!_nonQuotedAttributeEndCharacterSet)
+	{
+		NSMutableCharacterSet *tmpCharacterSet = [NSMutableCharacterSet characterSetWithCharactersInString:@"/>"];
+		[tmpCharacterSet formUnionWithCharacterSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+		
+		_nonQuotedAttributeEndCharacterSet = [tmpCharacterSet copy];
+	}
+	
+	return _nonQuotedAttributeEndCharacterSet;
 }
 
 

--- a/Classes/NSData+Base64.m
+++ b/Classes/NSData+Base64.m
@@ -27,7 +27,7 @@
 // Mapping from 6 bit pattern to ASCII character.
 //
 static unsigned char base64EncodeLookup[65] =
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 //
 // Definition for "masked-out" areas of the base64DecodeLookup mapping
@@ -39,22 +39,22 @@ static unsigned char base64EncodeLookup[65] =
 //
 static unsigned char base64DecodeLookup[256] =
 {
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 62, xx, xx, xx, 63, 
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, xx, xx, xx, xx, xx, xx, 
-    xx,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, xx, xx, xx, xx, xx, 
-    xx, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
-    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 62, xx, xx, xx, 63, 
+	52, 53, 54, 55, 56, 57, 58, 59, 60, 61, xx, xx, xx, xx, xx, xx, 
+	xx,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 
+	15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, xx, xx, xx, xx, xx, 
+	xx, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 
+	41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
 };
 
 //
@@ -77,9 +77,9 @@ static unsigned char base64DecodeLookup[256] =
 //	outputLength.
 //
 void *NewBase64Decode(
-	const char *inputBuffer,
-	size_t length,
-	size_t *outputLength)
+											const char *inputBuffer,
+											size_t length,
+											size_t *outputLength)
 {
 	if (length == -1)
 	{
@@ -87,7 +87,7 @@ void *NewBase64Decode(
 	}
 	
 	size_t outputBufferSize =
-		((length+BASE64_UNIT_SIZE-1) / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE;
+	((length+BASE64_UNIT_SIZE-1) / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE;
 	unsigned char *outputBuffer = (unsigned char *)malloc(outputBufferSize);
 	
 	size_t i = 0;
@@ -152,36 +152,36 @@ void *NewBase64Decode(
 //	outputLength.
 //
 char *NewBase64Encode(
-	const void *buffer,
-	size_t length,
-	bool separateLines,
-	size_t *outputLength)
+											const void *buffer,
+											size_t length,
+											bool separateLines,
+											size_t *outputLength)
 {
 	const unsigned char *inputBuffer = (const unsigned char *)buffer;
 	
-	#define MAX_NUM_PADDING_CHARS 2
-	#define OUTPUT_LINE_LENGTH 64
-	#define INPUT_LINE_LENGTH ((OUTPUT_LINE_LENGTH / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE)
-	#define CR_LF_SIZE 2
+#define MAX_NUM_PADDING_CHARS 2
+#define OUTPUT_LINE_LENGTH 64
+#define INPUT_LINE_LENGTH ((OUTPUT_LINE_LENGTH / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE)
+#define CR_LF_SIZE 2
 	
 	//
 	// Byte accurate calculation of final buffer size
 	//
 	size_t outputBufferSize =
-			((length / BINARY_UNIT_SIZE)
-				+ ((length % BINARY_UNIT_SIZE) ? 1 : 0))
-					* BASE64_UNIT_SIZE;
+	((length / BINARY_UNIT_SIZE)
+	 + ((length % BINARY_UNIT_SIZE) ? 1 : 0))
+	* BASE64_UNIT_SIZE;
 	if (separateLines)
 	{
 		outputBufferSize +=
-			(outputBufferSize / OUTPUT_LINE_LENGTH) * CR_LF_SIZE;
+		(outputBufferSize / OUTPUT_LINE_LENGTH) * CR_LF_SIZE;
 	}
 	
 	//
 	// Include space for a terminating zero
 	//
 	outputBufferSize += 1;
-
+	
 	//
 	// Allocate the output buffer
 	//
@@ -190,7 +190,7 @@ char *NewBase64Encode(
 	{
 		return NULL;
 	}
-
+	
 	size_t i = 0;
 	size_t j = 0;
 	const size_t lineLength = separateLines ? INPUT_LINE_LENGTH : length;
@@ -202,7 +202,7 @@ char *NewBase64Encode(
 		{
 			lineEnd = length;
 		}
-
+		
 		for (; i + BINARY_UNIT_SIZE - 1 < lineEnd; i += BINARY_UNIT_SIZE)
 		{
 			//
@@ -210,9 +210,9 @@ char *NewBase64Encode(
 			//
 			outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
 			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
-				| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+																						 | ((inputBuffer[i + 1] & 0xF0) >> 4)];
 			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i + 1] & 0x0F) << 2)
-				| ((inputBuffer[i + 2] & 0xC0) >> 6)];
+																						 | ((inputBuffer[i + 2] & 0xC0) >> 6)];
 			outputBuffer[j++] = base64EncodeLookup[inputBuffer[i + 2] & 0x3F];
 		}
 		
@@ -236,7 +236,7 @@ char *NewBase64Encode(
 		//
 		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
 		outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
-			| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+																					 | ((inputBuffer[i + 1] & 0xF0) >> 4)];
 		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i + 1] & 0x0F) << 2];
 		outputBuffer[j++] =	'=';
 	}
@@ -298,14 +298,14 @@ char *NewBase64Encode(
 {
 	size_t outputLength;
 	char *outputBuffer =
-		NewBase64Encode([self bytes], [self length], true, &outputLength);
+	NewBase64Encode([self bytes], [self length], true, &outputLength);
 	
 	NSString *result =
-		[[[NSString alloc]
-			initWithBytes:outputBuffer
-			length:outputLength
-			encoding:NSASCIIStringEncoding]
-		autorelease];
+	[[[NSString alloc]
+		initWithBytes:outputBuffer
+		length:outputLength
+		encoding:NSASCIIStringEncoding]
+	 autorelease];
 	free(outputBuffer);
 	return result;
 }

--- a/Classes/NSMutableAttributedString+HTML.m
+++ b/Classes/NSMutableAttributedString+HTML.m
@@ -17,27 +17,27 @@
 // apends a plain string extending the attributes at this position
 - (void)appendString:(NSString *)string
 {
-    NSInteger length = [self length];
-    
-    NSDictionary *previousAttributes = nil;
-    
-    if (length)
-    {
-        // get attributes from last character
-        previousAttributes = [self attributesAtIndex:length-1 effectiveRange:NULL];
-    }
-    
-    NSAttributedString *tmpString = [[NSAttributedString alloc] initWithString:string attributes:previousAttributes];
-    [self appendAttributedString:tmpString];
-    [tmpString release];
+	NSInteger length = [self length];
+	
+	NSDictionary *previousAttributes = nil;
+	
+	if (length)
+	{
+		// get attributes from last character
+		previousAttributes = [self attributesAtIndex:length-1 effectiveRange:NULL];
+	}
+	
+	NSAttributedString *tmpString = [[NSAttributedString alloc] initWithString:string attributes:previousAttributes];
+	[self appendAttributedString:tmpString];
+	[tmpString release];
 }
 
 // appends a string without any attributes
 - (void)appendNakedString:(NSString *)string
 {
-    NSAttributedString *nakedString = [[NSAttributedString alloc] initWithString:string attributes:nil];
-    [self appendAttributedString:nakedString];
-    [nakedString release];
+	NSAttributedString *nakedString = [[NSAttributedString alloc] initWithString:string attributes:nil];
+	[self appendAttributedString:nakedString];
+	[nakedString release];
 }
 
 @end

--- a/Classes/NSScanner+HTML.m
+++ b/Classes/NSScanner+HTML.m
@@ -60,7 +60,7 @@
 	BOOL immediatelyClosed = NO;
 	
 	NSCharacterSet *tagCharacterSet = [NSCharacterSet tagNameCharacterSet];
-    NSCharacterSet *tagAttributeNameCharacterSet = [NSCharacterSet tagAttributeNameCharacterSet];
+	NSCharacterSet *tagAttributeNameCharacterSet = [NSCharacterSet tagAttributeNameCharacterSet];
 	NSCharacterSet *quoteCharacterSet = [NSCharacterSet quoteCharacterSet];
 	NSCharacterSet *whiteCharacterSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 	NSCharacterSet *nonquoteAttributedEndCharacterSet = [NSCharacterSet nonQuotedAttributeEndCharacterSet];
@@ -75,7 +75,7 @@
 	}
 	
 	[self scanCharactersFromSet:whiteCharacterSet intoString:NULL];
-
+	
 	// Read the tag name
 	if ([self scanCharactersFromSet:tagCharacterSet intoString:&scannedTagName])
 	{
@@ -120,9 +120,9 @@
 			
 			immediatelyClosed = YES;
 		}
-
+		
 		[self scanCharactersFromSet:whiteCharacterSet intoString:NULL];
-
+		
 		if ([self scanString:@">" intoString:NULL])
 		{
 			break;
@@ -180,7 +180,7 @@
 		
 		[self scanCharactersFromSet:whiteCharacterSet intoString:NULL];
 	}
-
+	
 	// Success 
 	if (isClosed)
 	{
@@ -194,9 +194,9 @@
 	
 	if (attributes)
 	{
-        // converting to immutable costs 10.4% of method
+		// converting to immutable costs 10.4% of method
 		//*attributes = [NSDictionary dictionaryWithDictionary:tmpAttributes];
-        *attributes = tmpAttributes;
+		*attributes = tmpAttributes;
 	}
 	
 	if (tagName)
@@ -217,27 +217,27 @@
 		[self setScanLocation:initialScanLocation];
 		return NO;
 	}
-   
-    NSString *body = nil;
-    
-    if (![self scanUpToString:@">" intoString:&body])
-    {
+	
+	NSString *body = nil;
+	
+	if (![self scanUpToString:@">" intoString:&body])
+	{
 		[self setScanLocation:initialScanLocation];
-        return NO;
-    }
-    
-    if (![self scanString:@">" intoString:NULL])
-    {
+		return NO;
+	}
+	
+	if (![self scanString:@">" intoString:NULL])
+	{
 		[self setScanLocation:initialScanLocation];
-        return NO;
-    }
-    
-    if (contents)
-    {
-        *contents = body;
-    }
-    
-    return YES;
+		return NO;
+	}
+	
+	if (contents)
+	{
+		*contents = body;
+	}
+	
+	return YES;
 }
 
 
@@ -249,15 +249,15 @@
 {
 	NSString *attrName = nil;
 	NSString *attrValue = nil;
-
+	
 	NSInteger initialScanLocation = [self scanLocation];
 	
 	NSCharacterSet *whiteCharacterSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 	
-
+	
 	// alphanumeric plus -
 	NSCharacterSet *attributeNameCharacterSet = [NSCharacterSet tagAttributeNameCharacterSet];
-                                                 
+	
 	
 	
 	if (![self scanCharactersFromSet:attributeNameCharacterSet intoString:&attrName])
@@ -274,10 +274,10 @@
 		[self setScanLocation:initialScanLocation];
 		return NO;
 	}
-
+	
 	// skip whitespace
 	[self scanCharactersFromSet:whiteCharacterSet intoString:NULL];
-
+	
 	if (![self scanUpToString:@";" intoString:&attrValue])
 	{
 		[self setScanLocation:initialScanLocation];

--- a/Classes/NSString+HTML.m
+++ b/Classes/NSString+HTML.m
@@ -18,9 +18,9 @@ static NSDictionary *entityLookup = nil;
 
 - (NSUInteger)integerValueFromHex 
 {
-    NSUInteger result = 0;
-    sscanf([self UTF8String], "%x", &result);
-    return result;
+	NSUInteger result = 0;
+	sscanf([self UTF8String], "%x", &result);
+	return result;
 }
 
 - (BOOL)isInlineTag
@@ -28,7 +28,7 @@ static NSDictionary *entityLookup = nil;
 	if (!inlineTags)
 	{
 		inlineTags = [[NSSet alloc] initWithObjects:@"font", @"b", @"strong", @"em", @"i", @"sub", @"sup",
-					  @"u", @"a", @"img", @"del", @"br", @"span", nil];
+									@"u", @"a", @"img", @"del", @"br", @"span", nil];
 	}
 	
 	return [inlineTags containsObject:[self lowercaseString]];
@@ -46,75 +46,75 @@ static NSDictionary *entityLookup = nil;
 
 - (BOOL)isNumeric
 {
-    const char *s = [self UTF8String];
-    
-    for (int i=0;i<strlen(s);i++)
-    {
-        if (s[i]<'0' || s[i]>'9')
-        {
-            return NO;
-        }
-    }
-    
-    return YES;
+	const char *s = [self UTF8String];
+	
+	for (int i=0;i<strlen(s);i++)
+	{
+		if (s[i]<'0' || s[i]>'9')
+		{
+			return NO;
+		}
+	}
+	
+	return YES;
 }
 
 - (float)percentValue
 {
-    float result = 1;
-    sscanf([self UTF8String], "%f", &result);
-    
-    return result/100.0;
+	float result = 1;
+	sscanf([self UTF8String], "%f", &result);
+	
+	return result/100.0;
 }
 
 - (NSString *)stringByNormalizingWhitespace
 {
-    NSInteger stringLength = [self length];
-    
-    // reserve buffer, same size as input
-    unichar *buf = malloc((stringLength) * sizeof(unichar));
-    
-    NSInteger outputLength = 0;
-    BOOL inWhite = NO;
-   
-    for (NSInteger i = 0; i<stringLength; i++)
-    {
-        unichar oneChar = [self characterAtIndex:i];
-        
-        // of whitespace chars only output one space for first
-        if (oneChar == 32 ||    // space
-            oneChar == 10 ||    // various newlines
-            oneChar == 11 ||
-            oneChar == 12 ||
-            oneChar == 13 ||
-            oneChar == (unichar)'\t' || // tab
-            oneChar == (unichar)'\x85')
-        {
-            if (!inWhite)
-            {
-                buf[outputLength] = 32;
-                outputLength++;
-                
-                inWhite = YES;
-            }
-        }
-        else
-        {
-            // all other characters we simply copy
-            buf[outputLength] = oneChar;
-            outputLength++;
-            
-            inWhite = NO;
-        }
-    }
-    
-    // convert to objC-String
-    NSString *retString = [NSString stringWithCharacters:buf length:outputLength];
-
-    // free buffers
-    free(buf);
-    
-    return retString;
+	NSInteger stringLength = [self length];
+	
+	// reserve buffer, same size as input
+	unichar *buf = malloc((stringLength) * sizeof(unichar));
+	
+	NSInteger outputLength = 0;
+	BOOL inWhite = NO;
+	
+	for (NSInteger i = 0; i<stringLength; i++)
+	{
+		unichar oneChar = [self characterAtIndex:i];
+		
+		// of whitespace chars only output one space for first
+		if (oneChar == 32 ||    // space
+				oneChar == 10 ||    // various newlines
+				oneChar == 11 ||
+				oneChar == 12 ||
+				oneChar == 13 ||
+				oneChar == (unichar)'\t' || // tab
+				oneChar == (unichar)'\x85')
+		{
+			if (!inWhite)
+			{
+				buf[outputLength] = 32;
+				outputLength++;
+				
+				inWhite = YES;
+			}
+		}
+		else
+		{
+			// all other characters we simply copy
+			buf[outputLength] = oneChar;
+			outputLength++;
+			
+			inWhite = NO;
+		}
+	}
+	
+	// convert to objC-String
+	NSString *retString = [NSString stringWithCharacters:buf length:outputLength];
+	
+	// free buffers
+	free(buf);
+	
+	return retString;
 }
 
 - (BOOL)hasPrefixCharacterFromSet:(NSCharacterSet *)characterSet
@@ -146,240 +146,240 @@ static NSDictionary *entityLookup = nil;
 	if (!entityLookup)
 	{
 		entityLookup = [[NSDictionary alloc] initWithObjectsAndKeys:@"\x22", @"quot",
-						@"\x26", @"amp",
-						@"\x27", @"apos",
-						@"\x3c", @"lt",
-						@"\x3e", @"gt",
-						@"\u00a0", @"nbsp",
-						@"\u00a1", @"iexcl",
-						@"\u00a2", @"cent",
-						@"\u00a3", @"pound",
-						@"\u00a4", @"curren",
-						@"\u00a5", @"yen",
-						@"\u00a6", @"brvbar",
-						@"\u00a7", @"sect",
-						@"\u00a8", @"uml",
-						@"\u00a9", @"copy",
-						@"\u00aa", @"ordf",
-						@"\u00ab", @"laquo",
-						@"\u00ac", @"not",
-						@"\u00ae", @"reg",
-						@"\u00af", @"macr",
-						@"\u00b0", @"deg",
-						@"\u00b1", @"plusmn",
-						@"\u00b2", @"sup2",
-						@"\u00b3", @"sup3",
-						@"\u00b4", @"acute",
-						@"\u00b5", @"micro",
-						@"\u00b6", @"para",
-						@"\u00b7", @"middot",
-						@"\u00b8", @"cedil",
-						@"\u00b9", @"sup1",
-						@"\u00ba", @"ordm",
-						@"\u00bb", @"raquo",
-						@"\u00bc", @"frac14",
-						@"\u00bd", @"frac12",
-						@"\u00be", @"frac34",
-						@"\u00bf", @"iquest",
-						@"\u00c0", @"Agrave",
-						@"\u00c1", @"Aacute",
-						@"\u00c2", @"Acirc",
-						@"\u00c3", @"Atilde",
-						@"\u00c4", @"Auml",
-						@"\u00c5", @"Aring",
-						@"\u00c6", @"AElig",
-						@"\u00c7", @"Ccedil",
-						@"\u00c8", @"Egrave",
-						@"\u00c9", @"Eacute",
-						@"\u00ca", @"Ecirc",
-						@"\u00cb", @"Euml",
-						@"\u00cc", @"Igrave",
-						@"\u00cd", @"Iacute",
-						@"\u00ce", @"Icirc",
-						@"\u00cf", @"Iuml",
-						@"\u00d0", @"ETH",
-						@"\u00d1", @"Ntilde",
-						@"\u00d2", @"Ograve",
-						@"\u00d3", @"Oacute",
-						@"\u00d4", @"Ocirc",
-						@"\u00d5", @"Otilde",
-						@"\u00d6", @"Ouml",
-						@"\u00d7", @"times",
-						@"\u00d8", @"Oslash",
-						@"\u00d9", @"Ugrave",
-						@"\u00da", @"Uacute",
-						@"\u00db", @"Ucirc",
-						@"\u00dc", @"Uuml",
-						@"\u00dd", @"Yacute",
-						@"\u00de", @"THORN",
-						@"\u00df", @"szlig",
-						@"\u00e0", @"agrave",
-						@"\u00e1", @"aacute",
-						@"\u00e2", @"acirc",
-						@"\u00e3", @"atilde",
-						@"\u00e4", @"auml",
-						@"\u00e5", @"aring",
-						@"\u00e6", @"aelig",
-						@"\u00e7", @"ccedil",
-						@"\u00e8", @"egrave",
-						@"\u00e9", @"eacute",
-						@"\u00ea", @"ecirc",
-						@"\u00eb", @"euml",
-						@"\u00ec", @"igrave",
-						@"\u00ed", @"iacute",
-						@"\u00ee", @"icirc",
-						@"\u00ef", @"iuml",
-						@"\u00f0", @"eth",
-						@"\u00f1", @"ntilde",
-						@"\u00f2", @"ograve",
-						@"\u00f3", @"oacute",
-						@"\u00f4", @"ocirc",
-						@"\u00f5", @"otilde",
-						@"\u00f6", @"ouml",
-						@"\u00f7", @"divide",
-						@"\u00f8", @"oslash",
-						@"\u00f9", @"ugrave",
-						@"\u00fa", @"uacute",
-						@"\u00fb", @"ucirc",
-						@"\u00fc", @"uuml",
-						@"\u00fd", @"yacute",
-						@"\u00fe", @"thorn",
-						@"\u00ff", @"yuml",
-						@"\u0152", @"OElig",
-						@"\u0153", @"oelig",
-						@"\u0160", @"Scaron",
-						@"\u0161", @"scaron",
-						@"\u0178", @"Yuml",
-						@"\u0192", @"fnof",
-						@"\u02c6", @"circ",
-						@"\u02dc", @"tilde",
-						@"\u0393", @"Gamma",
-						@"\u0394", @"Delta",
-						@"\u0398", @"Theta",
-						@"\u039b", @"Lambda",
-						@"\u039e", @"Xi",
-						@"\u03a3", @"Sigma",
-						@"\u03a5", @"Upsilon",
-						@"\u03a6", @"Phi",
-						@"\u03a8", @"Psi",
-						@"\u03a9", @"Omega",
-						@"\u03b1", @"alpha",
-						@"\u03b2", @"beta",
-						@"\u03b3", @"gamma",
-						@"\u03b4", @"delta",
-						@"\u03b5", @"epsilon",
-						@"\u03b6", @"zeta",
-						@"\u03b7", @"eta",
-						@"\u03b8", @"theta",
-						@"\u03b9", @"iota",
-						@"\u03ba", @"kappa",
-						@"\u03bb", @"lambda",
-						@"\u03bc", @"mu",
-						@"\u03bd", @"nu",
-						@"\u03be", @"xi",
-						@"\u03bf", @"omicron",
-						@"\u03c0", @"pi",
-						@"\u03c1", @"rho",
-						@"\u03c2", @"sigmaf",
-						@"\u03c3", @"sigma",
-						@"\u03c4", @"tau",
-						@"\u03c5", @"upsilon",
-						@"\u03c6", @"phi",
-						@"\u03c7", @"chi",
-						@"\u03c8", @"psi",
-						@"\u03c9", @"omega",
-						@"\u03d1", @"thetasym",
-						@"\u03d2", @"upsih",
-						@"\u03d6", @"piv",
-						@"\u2002", @"ensp",
-						@"\u2003", @"emsp",
-						@"\u2009", @"thinsp",
-						@"\u2013", @"ndash",
-						@"\u2014", @"mdash",
-						@"\u2018", @"lsquo",
-						@"\u2019", @"rsquo",
-						@"\u201a", @"sbquo",
-						@"\u201c", @"ldquo",
-						@"\u201d", @"rdquo",
-						@"\u201e", @"bdquo",
-						@"\u2020", @"dagger",
-						@"\u2021", @"Dagger",
-						@"\u2022", @"bull",
-						@"\u2026", @"hellip",
-						@"\u2030", @"permil",
-						@"\u2032", @"prime",
-						@"\u2033", @"Prime",
-						@"\u2039", @"lsaquo",
-						@"\u203a", @"rsaquo",
-						@"\u203e", @"oline",
-						@"\u2044", @"frasl",
-						@"\u20ac", @"euro",
-						@"\u2111", @"image",
-						@"\u2118", @"weierp",
-						@"\u211c", @"real",
-						@"\u2122", @"trade",
-						@"\u2135", @"alefsym",
-						@"\u2190", @"larr",
-						@"\u2191", @"uarr",
-						@"\u2192", @"rarr",
-						@"\u2193", @"darr",
-						@"\u2194", @"harr",
-						@"\u21b5", @"crarr",
-						@"\u21d0", @"lArr",
-						@"\u21d1", @"uArr",
-						@"\u21d2", @"rArr",
-						@"\u21d3", @"dArr",
-						@"\u21d4", @"hArr",
-						@"\u2200", @"forall",
-						@"\u2202", @"part",
-						@"\u2203", @"exist",
-						@"\u2205", @"empty",
-						@"\u2207", @"nabla",
-						@"\u2208", @"isin",
-						@"\u2209", @"notin",
-						@"\u220b", @"ni",
-						@"\u220f", @"prod",
-						@"\u2211", @"sum",
-						@"\u2212", @"minus",
-						@"\u2217", @"lowast",
-						@"\u221a", @"radic",
-						@"\u221d", @"prop",
-						@"\u221e", @"infin",
-						@"\u2220", @"ang",
-						@"\u2227", @"and",
-						@"\u2228", @"or",
-						@"\u2229", @"cap",
-						@"\u222a", @"cup",
-						@"\u222b", @"int",
-						@"\u2234", @"there4",
-						@"\u223c", @"sim",
-						@"\u2245", @"cong",
-						@"\u2248", @"asymp",
-						@"\u2260", @"ne",
-						@"\u2261", @"equiv",
-						@"\u2264", @"le",
-						@"\u2265", @"ge",
-						@"\u2282", @"sub",
-						@"\u2283", @"sup",
-						@"\u2284", @"nsub",
-						@"\u2286", @"sube",
-						@"\u2287", @"supe",
-						@"\u2295", @"oplus",
-						@"\u2297", @"otimes",
-						@"\u22a5", @"perp",
-						@"\u22c5", @"sdot",
-						@"\u2308", @"lceil",
-						@"\u2309", @"rceil",
-						@"\u230a", @"lfloor",
-						@"\u230b", @"rfloor",
-						@"\u27e8", @"lang",
-						@"\u27e9", @"rang",
-						@"\u25ca", @"loz",
-						@"\u2660", @"spades",
-						@"\u2663", @"clubs",
-						@"\u2665", @"hearts",
-						@"\u2666", @"diams",
-						nil];
+										@"\x26", @"amp",
+										@"\x27", @"apos",
+										@"\x3c", @"lt",
+										@"\x3e", @"gt",
+										@"\u00a0", @"nbsp",
+										@"\u00a1", @"iexcl",
+										@"\u00a2", @"cent",
+										@"\u00a3", @"pound",
+										@"\u00a4", @"curren",
+										@"\u00a5", @"yen",
+										@"\u00a6", @"brvbar",
+										@"\u00a7", @"sect",
+										@"\u00a8", @"uml",
+										@"\u00a9", @"copy",
+										@"\u00aa", @"ordf",
+										@"\u00ab", @"laquo",
+										@"\u00ac", @"not",
+										@"\u00ae", @"reg",
+										@"\u00af", @"macr",
+										@"\u00b0", @"deg",
+										@"\u00b1", @"plusmn",
+										@"\u00b2", @"sup2",
+										@"\u00b3", @"sup3",
+										@"\u00b4", @"acute",
+										@"\u00b5", @"micro",
+										@"\u00b6", @"para",
+										@"\u00b7", @"middot",
+										@"\u00b8", @"cedil",
+										@"\u00b9", @"sup1",
+										@"\u00ba", @"ordm",
+										@"\u00bb", @"raquo",
+										@"\u00bc", @"frac14",
+										@"\u00bd", @"frac12",
+										@"\u00be", @"frac34",
+										@"\u00bf", @"iquest",
+										@"\u00c0", @"Agrave",
+										@"\u00c1", @"Aacute",
+										@"\u00c2", @"Acirc",
+										@"\u00c3", @"Atilde",
+										@"\u00c4", @"Auml",
+										@"\u00c5", @"Aring",
+										@"\u00c6", @"AElig",
+										@"\u00c7", @"Ccedil",
+										@"\u00c8", @"Egrave",
+										@"\u00c9", @"Eacute",
+										@"\u00ca", @"Ecirc",
+										@"\u00cb", @"Euml",
+										@"\u00cc", @"Igrave",
+										@"\u00cd", @"Iacute",
+										@"\u00ce", @"Icirc",
+										@"\u00cf", @"Iuml",
+										@"\u00d0", @"ETH",
+										@"\u00d1", @"Ntilde",
+										@"\u00d2", @"Ograve",
+										@"\u00d3", @"Oacute",
+										@"\u00d4", @"Ocirc",
+										@"\u00d5", @"Otilde",
+										@"\u00d6", @"Ouml",
+										@"\u00d7", @"times",
+										@"\u00d8", @"Oslash",
+										@"\u00d9", @"Ugrave",
+										@"\u00da", @"Uacute",
+										@"\u00db", @"Ucirc",
+										@"\u00dc", @"Uuml",
+										@"\u00dd", @"Yacute",
+										@"\u00de", @"THORN",
+										@"\u00df", @"szlig",
+										@"\u00e0", @"agrave",
+										@"\u00e1", @"aacute",
+										@"\u00e2", @"acirc",
+										@"\u00e3", @"atilde",
+										@"\u00e4", @"auml",
+										@"\u00e5", @"aring",
+										@"\u00e6", @"aelig",
+										@"\u00e7", @"ccedil",
+										@"\u00e8", @"egrave",
+										@"\u00e9", @"eacute",
+										@"\u00ea", @"ecirc",
+										@"\u00eb", @"euml",
+										@"\u00ec", @"igrave",
+										@"\u00ed", @"iacute",
+										@"\u00ee", @"icirc",
+										@"\u00ef", @"iuml",
+										@"\u00f0", @"eth",
+										@"\u00f1", @"ntilde",
+										@"\u00f2", @"ograve",
+										@"\u00f3", @"oacute",
+										@"\u00f4", @"ocirc",
+										@"\u00f5", @"otilde",
+										@"\u00f6", @"ouml",
+										@"\u00f7", @"divide",
+										@"\u00f8", @"oslash",
+										@"\u00f9", @"ugrave",
+										@"\u00fa", @"uacute",
+										@"\u00fb", @"ucirc",
+										@"\u00fc", @"uuml",
+										@"\u00fd", @"yacute",
+										@"\u00fe", @"thorn",
+										@"\u00ff", @"yuml",
+										@"\u0152", @"OElig",
+										@"\u0153", @"oelig",
+										@"\u0160", @"Scaron",
+										@"\u0161", @"scaron",
+										@"\u0178", @"Yuml",
+										@"\u0192", @"fnof",
+										@"\u02c6", @"circ",
+										@"\u02dc", @"tilde",
+										@"\u0393", @"Gamma",
+										@"\u0394", @"Delta",
+										@"\u0398", @"Theta",
+										@"\u039b", @"Lambda",
+										@"\u039e", @"Xi",
+										@"\u03a3", @"Sigma",
+										@"\u03a5", @"Upsilon",
+										@"\u03a6", @"Phi",
+										@"\u03a8", @"Psi",
+										@"\u03a9", @"Omega",
+										@"\u03b1", @"alpha",
+										@"\u03b2", @"beta",
+										@"\u03b3", @"gamma",
+										@"\u03b4", @"delta",
+										@"\u03b5", @"epsilon",
+										@"\u03b6", @"zeta",
+										@"\u03b7", @"eta",
+										@"\u03b8", @"theta",
+										@"\u03b9", @"iota",
+										@"\u03ba", @"kappa",
+										@"\u03bb", @"lambda",
+										@"\u03bc", @"mu",
+										@"\u03bd", @"nu",
+										@"\u03be", @"xi",
+										@"\u03bf", @"omicron",
+										@"\u03c0", @"pi",
+										@"\u03c1", @"rho",
+										@"\u03c2", @"sigmaf",
+										@"\u03c3", @"sigma",
+										@"\u03c4", @"tau",
+										@"\u03c5", @"upsilon",
+										@"\u03c6", @"phi",
+										@"\u03c7", @"chi",
+										@"\u03c8", @"psi",
+										@"\u03c9", @"omega",
+										@"\u03d1", @"thetasym",
+										@"\u03d2", @"upsih",
+										@"\u03d6", @"piv",
+										@"\u2002", @"ensp",
+										@"\u2003", @"emsp",
+										@"\u2009", @"thinsp",
+										@"\u2013", @"ndash",
+										@"\u2014", @"mdash",
+										@"\u2018", @"lsquo",
+										@"\u2019", @"rsquo",
+										@"\u201a", @"sbquo",
+										@"\u201c", @"ldquo",
+										@"\u201d", @"rdquo",
+										@"\u201e", @"bdquo",
+										@"\u2020", @"dagger",
+										@"\u2021", @"Dagger",
+										@"\u2022", @"bull",
+										@"\u2026", @"hellip",
+										@"\u2030", @"permil",
+										@"\u2032", @"prime",
+										@"\u2033", @"Prime",
+										@"\u2039", @"lsaquo",
+										@"\u203a", @"rsaquo",
+										@"\u203e", @"oline",
+										@"\u2044", @"frasl",
+										@"\u20ac", @"euro",
+										@"\u2111", @"image",
+										@"\u2118", @"weierp",
+										@"\u211c", @"real",
+										@"\u2122", @"trade",
+										@"\u2135", @"alefsym",
+										@"\u2190", @"larr",
+										@"\u2191", @"uarr",
+										@"\u2192", @"rarr",
+										@"\u2193", @"darr",
+										@"\u2194", @"harr",
+										@"\u21b5", @"crarr",
+										@"\u21d0", @"lArr",
+										@"\u21d1", @"uArr",
+										@"\u21d2", @"rArr",
+										@"\u21d3", @"dArr",
+										@"\u21d4", @"hArr",
+										@"\u2200", @"forall",
+										@"\u2202", @"part",
+										@"\u2203", @"exist",
+										@"\u2205", @"empty",
+										@"\u2207", @"nabla",
+										@"\u2208", @"isin",
+										@"\u2209", @"notin",
+										@"\u220b", @"ni",
+										@"\u220f", @"prod",
+										@"\u2211", @"sum",
+										@"\u2212", @"minus",
+										@"\u2217", @"lowast",
+										@"\u221a", @"radic",
+										@"\u221d", @"prop",
+										@"\u221e", @"infin",
+										@"\u2220", @"ang",
+										@"\u2227", @"and",
+										@"\u2228", @"or",
+										@"\u2229", @"cap",
+										@"\u222a", @"cup",
+										@"\u222b", @"int",
+										@"\u2234", @"there4",
+										@"\u223c", @"sim",
+										@"\u2245", @"cong",
+										@"\u2248", @"asymp",
+										@"\u2260", @"ne",
+										@"\u2261", @"equiv",
+										@"\u2264", @"le",
+										@"\u2265", @"ge",
+										@"\u2282", @"sub",
+										@"\u2283", @"sup",
+										@"\u2284", @"nsub",
+										@"\u2286", @"sube",
+										@"\u2287", @"supe",
+										@"\u2295", @"oplus",
+										@"\u2297", @"otimes",
+										@"\u22a5", @"perp",
+										@"\u22c5", @"sdot",
+										@"\u2308", @"lceil",
+										@"\u2309", @"rceil",
+										@"\u230a", @"lfloor",
+										@"\u230b", @"rfloor",
+										@"\u27e8", @"lang",
+										@"\u27e9", @"rang",
+										@"\u25ca", @"loz",
+										@"\u2660", @"spades",
+										@"\u2663", @"clubs",
+										@"\u2665", @"hearts",
+										@"\u2666", @"diams",
+										nil];
 	}
 	
 	NSScanner *scanner = [NSScanner scannerWithString:self];
@@ -455,17 +455,17 @@ static NSDictionary *entityLookup = nil;
 	{
 		[tmpDict setObject:value forKey:name];
 	}
-
-// converting to non-mutable costs 37.5% of method	
-//	return [NSDictionary dictionaryWithDictionary:tmpDict];
-    return tmpDict;
+	
+	// converting to non-mutable costs 37.5% of method	
+	//	return [NSDictionary dictionaryWithDictionary:tmpDict];
+	return tmpDict;
 }
 
 - (CGFloat)pixelSizeOfCSSMeasureRelativeToCurrentTextSize:(CGFloat)textSize
 {
-    float value = textSize;
-    sscanf([self UTF8String], "%f", &value);
-    
+	float value = textSize;
+	sscanf([self UTF8String], "%f", &value);
+	
 	if ([self hasSuffix:@"em"])
 	{
 		return value * textSize;
@@ -521,8 +521,8 @@ static NSDictionary *entityLookup = nil;
 						CGFloat blur = [blurString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:textSize];
 						
 						NSDictionary *shadowDict = [NSDictionary dictionaryWithObjectsAndKeys:[NSValue valueWithCGSize:offset], @"Offset",
-													[NSNumber numberWithFloat:blur], @"Blur",
-													shadowColor, @"Color", nil];
+																				[NSNumber numberWithFloat:blur], @"Blur",
+																				shadowColor, @"Color", nil];
 						
 						[tmpArray addObject:shadowDict];
 					}
@@ -547,7 +547,7 @@ static NSDictionary *entityLookup = nil;
 							blurString = nil;
 						}
 					}
-							
+					
 					// color is optional, or we might already have one from the blur position
 					if (!shadowColor && [scanner scanUpToCharactersFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet] intoString:&colorString])
 					{
@@ -567,8 +567,8 @@ static NSDictionary *entityLookup = nil;
 					CGFloat blur = [blurString pixelSizeOfCSSMeasureRelativeToCurrentTextSize:textSize];
 					
 					NSDictionary *shadowDict = [NSDictionary dictionaryWithObjectsAndKeys:[NSValue valueWithCGSize:offset], @"Offset",
-												[NSNumber numberWithFloat:blur], @"Blur",
-												shadowColor, @"Color", nil];
+																			[NSNumber numberWithFloat:blur], @"Blur",
+																			shadowColor, @"Color", nil];
 					
 					[tmpArray addObject:shadowDict];
 					
@@ -596,15 +596,15 @@ static NSDictionary *entityLookup = nil;
 #pragma mark Utility
 + (NSString *)guid
 {
-    CFUUIDRef uuid = CFUUIDCreate(NULL);
-    CFStringRef cfStr = CFUUIDCreateString(NULL, uuid);
-    
-    NSString *ret = [NSString stringWithString:(NSString *)cfStr];
-    
-    CFRelease(uuid);
-    CFRelease(cfStr);
-    
-    return ret;
+	CFUUIDRef uuid = CFUUIDCreate(NULL);
+	CFStringRef cfStr = CFUUIDCreateString(NULL, uuid);
+	
+	NSString *ret = [NSString stringWithString:(NSString *)cfStr];
+	
+	CFRelease(uuid);
+	CFRelease(cfStr);
+	
+	return ret;
 }
 
 @end

--- a/Classes/UIColor+HTML.m
+++ b/Classes/UIColor+HTML.m
@@ -15,19 +15,19 @@ static NSDictionary *colorLookup = nil;
 
 + (UIColor *)colorWithHexString:(NSString *)hex 
 {
-    if ([hex length]!=6 && [hex length]!=3) 
-    {
-        return nil;   
-    }
-    
-    NSUInteger digits = [hex length]/3;
-    CGFloat maxValue = (digits==1)?15.0:255.0;
-    
-    CGFloat red = [[hex substringWithRange:NSMakeRange(0, digits)] integerValueFromHex]/maxValue;
-    CGFloat green = [[hex substringWithRange:NSMakeRange(digits, digits)] integerValueFromHex]/maxValue;
-    CGFloat blue = [[hex substringWithRange:NSMakeRange(2*digits, digits)] integerValueFromHex]/maxValue;
-    
-    return [UIColor colorWithRed:red green:green blue:blue alpha:1.0];
+	if ([hex length]!=6 && [hex length]!=3) 
+	{
+		return nil;   
+	}
+	
+	NSUInteger digits = [hex length]/3;
+	CGFloat maxValue = (digits==1)?15.0:255.0;
+	
+	CGFloat red = [[hex substringWithRange:NSMakeRange(0, digits)] integerValueFromHex]/maxValue;
+	CGFloat green = [[hex substringWithRange:NSMakeRange(digits, digits)] integerValueFromHex]/maxValue;
+	CGFloat blue = [[hex substringWithRange:NSMakeRange(2*digits, digits)] integerValueFromHex]/maxValue;
+	
+	return [UIColor colorWithRed:red green:green blue:blue alpha:1.0];
 }
 
 
@@ -38,168 +38,168 @@ static NSDictionary *colorLookup = nil;
 	{
 		return [UIColor colorWithHexString:[name substringFromIndex:1]];
 	}
-    
-    if([name hasPrefix:@"rgb"])
-    {
-        NSString * rgbName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rbg() "]];
-        NSArray* rbg = [rgbName componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@","]];
-        return [UIColor colorWithRed:[[rbg objectAtIndex:0]floatValue]/255 
-                               green:[[rbg objectAtIndex:1]floatValue] /255
-                                blue:[[rbg objectAtIndex:2]floatValue] /255
-                               alpha:1.0];
-    }
+	
+	if([name hasPrefix:@"rgb"])
+	{
+		NSString * rgbName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rbg() "]];
+		NSArray* rbg = [rgbName componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@","]];
+		return [UIColor colorWithRed:[[rbg objectAtIndex:0]floatValue]/255 
+													 green:[[rbg objectAtIndex:1]floatValue] /255
+														blue:[[rbg objectAtIndex:2]floatValue] /255
+													 alpha:1.0];
+	}
 	
 	if (!colorLookup)
 	{
 		colorLookup = [[NSDictionary alloc] initWithObjectsAndKeys:
-					   @"F0F8FF", @"aliceblue",
-					   @"FAEBD7", @"antiquewhite",
-					   @"00FFFF", @"aqua",
-					   @"7FFFD4", @"aquamarine",
-					   @"F0FFFF", @"azure",
-					   @"F5F5DC", @"beige",
-					   @"FFE4C4", @"bisque",
-					   @"000000", @"black",
-					   @"FFEBCD", @"blanchedalmond",
-					   @"0000FF", @"blue",
-					   @"8A2BE2", @"blueviolet",
-					   @"A52A2A", @"brown",
-					   @"DEB887", @"burlywood",
-					   @"5F9EA0", @"cadetblue",
-					   @"7FFF00", @"chartreuse",
-					   @"D2691E", @"chocolate",
-					   @"FF7F50", @"coral",
-					   @"6495ED", @"cornflowerblue",
-					   @"FFF8DC", @"cornsilk",
-					   @"DC143C", @"crimson",
-					   @"00FFFF", @"cyan",
-					   @"00008B", @"darkblue",
-					   @"008B8B", @"darkcyan",
-					   @"B8860B", @"darkgoldenrod",
-					   @"A9A9A9", @"darkgray",
-					   @"A9A9A9", @"darkgrey",
-					   @"006400", @"darkgreen",
-					   @"BDB76B", @"darkkhaki",
-					   @"8B008B", @"darkmagenta",
-					   @"556B2F", @"darkolivegreen",
-					   @"FF8C00", @"darkorange",
-					   @"9932CC", @"darkorchid",
-					   @"8B0000", @"darkred",
-					   @"E9967A", @"darksalmon",
-					   @"8FBC8F", @"darkseagreen",
-					   @"483D8B", @"darkslateblue",
-					   @"2F4F4F", @"darkslategray",
-					   @"2F4F4F", @"darkslategrey",
-					   @"00CED1", @"darkturquoise",
-					   @"9400D3", @"darkviolet",
-					   @"FF1493", @"deeppink",
-					   @"00BFFF", @"deepskyblue",
-					   @"696969", @"dimgray",
-					   @"696969", @"dimgrey",
-					   @"1E90FF", @"dodgerblue",
-					   @"B22222", @"firebrick",
-					   @"FFFAF0", @"floralwhite",
-					   @"228B22", @"forestgreen",
-					   @"FF00FF", @"fuchsia",
-					   @"DCDCDC", @"gainsboro",
-					   @"F8F8FF", @"ghostwhite",
-					   @"FFD700", @"gold",
-					   @"DAA520", @"goldenrod",
-					   @"808080", @"gray",
-					   @"808080", @"grey",
-					   @"008000", @"green",
-					   @"ADFF2F", @"greenyellow",
-					   @"F0FFF0", @"honeydew",
-					   @"FF69B4", @"hotpink",
-					   @"CD5C5C", @"indianred",
-					   @"4B0082", @"indigo",
-					   @"FFFFF0", @"ivory",
-					   @"F0E68C", @"khaki",
-					   @"E6E6FA", @"lavender",
-					   @"FFF0F5", @"lavenderblush",
-					   @"7CFC00", @"lawngreen",
-					   @"FFFACD", @"lemonchiffon",
-					   @"ADD8E6", @"lightblue",
-					   @"F08080", @"lightcoral",
-					   @"E0FFFF", @"lightcyan",
-					   @"FAFAD2", @"lightgoldenrodyellow",
-					   @"D3D3D3", @"lightgray",
-					   @"D3D3D3", @"lightgrey",
-					   @"90EE90", @"lightgreen",
-					   @"FFB6C1", @"lightpink",
-					   @"FFA07A", @"lightsalmon",
-					   @"20B2AA", @"lightseagreen",
-					   @"87CEFA", @"lightskyblue",
-					   @"778899", @"lightslategray",
-					   @"778899", @"lightslategrey",
-					   @"B0C4DE", @"lightsteelblue",
-					   @"FFFFE0", @"lightyellow",
-					   @"00FF00", @"lime",
-					   @"32CD32", @"limegreen",
-					   @"FAF0E6", @"linen",
-					   @"FF00FF", @"magenta",
-					   @"800000", @"maroon",
-					   @"66CDAA", @"mediumaquamarine",
-					   @"0000CD", @"mediumblue",
-					   @"BA55D3", @"mediumorchid",
-					   @"9370D8", @"mediumpurple",
-					   @"3CB371", @"mediumseagreen",
-					   @"7B68EE", @"mediumslateblue",
-					   @"00FA9A", @"mediumspringgreen",
-					   @"48D1CC", @"mediumturquoise",
-					   @"C71585", @"mediumvioletred",
-					   @"191970", @"midnightblue",
-					   @"F5FFFA", @"mintcream",
-					   @"FFE4E1", @"mistyrose",
-					   @"FFE4B5", @"moccasin",
-					   @"FFDEAD", @"navajowhite",
-					   @"000080", @"navy",
-					   @"FDF5E6", @"oldlace",
-					   @"808000", @"olive",
-					   @"6B8E23", @"olivedrab",
-					   @"FFA500", @"orange",
-					   @"FF4500", @"orangered",
-					   @"DA70D6", @"orchid",
-					   @"EEE8AA", @"palegoldenrod",
-					   @"98FB98", @"palegreen",
-					   @"AFEEEE", @"paleturquoise",
-					   @"D87093", @"palevioletred",
-					   @"FFEFD5", @"papayawhip",
-					   @"FFDAB9", @"peachpuff",
-					   @"CD853F", @"peru",
-					   @"FFC0CB", @"pink",
-					   @"DDA0DD", @"plum",
-					   @"B0E0E6", @"powderblue",
-					   @"800080", @"purple",
-					   @"FF0000", @"red",
-					   @"BC8F8F", @"rosybrown",
-					   @"4169E1", @"royalblue",
-					   @"8B4513", @"saddlebrown",
-					   @"FA8072", @"salmon",
-					   @"F4A460", @"sandybrown",
-					   @"2E8B57", @"seagreen",
-					   @"FFF5EE", @"seashell",
-					   @"A0522D", @"sienna",
-					   @"C0C0C0", @"silver",
-					   @"87CEEB", @"skyblue",
-					   @"6A5ACD", @"slateblue",
-					   @"708090", @"slategray",
-					   @"708090", @"slategrey",
-					   @"FFFAFA", @"snow",
-					   @"00FF7F", @"springgreen",
-					   @"4682B4", @"steelblue",
-					   @"D2B48C", @"tan",
-					   @"008080", @"teal",
-					   @"D8BFD8", @"thistle",
-					   @"FF6347", @"tomato",
-					   @"40E0D0", @"turquoise",
-					   @"EE82EE", @"violet",
-					   @"F5DEB3", @"wheat",
-					   @"FFFFFF", @"white",
-					   @"F5F5F5", @"whitesmoke",
-					   @"FFFF00", @"yellow",
-					   @"9ACD32", @"yellowgreen",
-					   nil];
+									 @"F0F8FF", @"aliceblue",
+									 @"FAEBD7", @"antiquewhite",
+									 @"00FFFF", @"aqua",
+									 @"7FFFD4", @"aquamarine",
+									 @"F0FFFF", @"azure",
+									 @"F5F5DC", @"beige",
+									 @"FFE4C4", @"bisque",
+									 @"000000", @"black",
+									 @"FFEBCD", @"blanchedalmond",
+									 @"0000FF", @"blue",
+									 @"8A2BE2", @"blueviolet",
+									 @"A52A2A", @"brown",
+									 @"DEB887", @"burlywood",
+									 @"5F9EA0", @"cadetblue",
+									 @"7FFF00", @"chartreuse",
+									 @"D2691E", @"chocolate",
+									 @"FF7F50", @"coral",
+									 @"6495ED", @"cornflowerblue",
+									 @"FFF8DC", @"cornsilk",
+									 @"DC143C", @"crimson",
+									 @"00FFFF", @"cyan",
+									 @"00008B", @"darkblue",
+									 @"008B8B", @"darkcyan",
+									 @"B8860B", @"darkgoldenrod",
+									 @"A9A9A9", @"darkgray",
+									 @"A9A9A9", @"darkgrey",
+									 @"006400", @"darkgreen",
+									 @"BDB76B", @"darkkhaki",
+									 @"8B008B", @"darkmagenta",
+									 @"556B2F", @"darkolivegreen",
+									 @"FF8C00", @"darkorange",
+									 @"9932CC", @"darkorchid",
+									 @"8B0000", @"darkred",
+									 @"E9967A", @"darksalmon",
+									 @"8FBC8F", @"darkseagreen",
+									 @"483D8B", @"darkslateblue",
+									 @"2F4F4F", @"darkslategray",
+									 @"2F4F4F", @"darkslategrey",
+									 @"00CED1", @"darkturquoise",
+									 @"9400D3", @"darkviolet",
+									 @"FF1493", @"deeppink",
+									 @"00BFFF", @"deepskyblue",
+									 @"696969", @"dimgray",
+									 @"696969", @"dimgrey",
+									 @"1E90FF", @"dodgerblue",
+									 @"B22222", @"firebrick",
+									 @"FFFAF0", @"floralwhite",
+									 @"228B22", @"forestgreen",
+									 @"FF00FF", @"fuchsia",
+									 @"DCDCDC", @"gainsboro",
+									 @"F8F8FF", @"ghostwhite",
+									 @"FFD700", @"gold",
+									 @"DAA520", @"goldenrod",
+									 @"808080", @"gray",
+									 @"808080", @"grey",
+									 @"008000", @"green",
+									 @"ADFF2F", @"greenyellow",
+									 @"F0FFF0", @"honeydew",
+									 @"FF69B4", @"hotpink",
+									 @"CD5C5C", @"indianred",
+									 @"4B0082", @"indigo",
+									 @"FFFFF0", @"ivory",
+									 @"F0E68C", @"khaki",
+									 @"E6E6FA", @"lavender",
+									 @"FFF0F5", @"lavenderblush",
+									 @"7CFC00", @"lawngreen",
+									 @"FFFACD", @"lemonchiffon",
+									 @"ADD8E6", @"lightblue",
+									 @"F08080", @"lightcoral",
+									 @"E0FFFF", @"lightcyan",
+									 @"FAFAD2", @"lightgoldenrodyellow",
+									 @"D3D3D3", @"lightgray",
+									 @"D3D3D3", @"lightgrey",
+									 @"90EE90", @"lightgreen",
+									 @"FFB6C1", @"lightpink",
+									 @"FFA07A", @"lightsalmon",
+									 @"20B2AA", @"lightseagreen",
+									 @"87CEFA", @"lightskyblue",
+									 @"778899", @"lightslategray",
+									 @"778899", @"lightslategrey",
+									 @"B0C4DE", @"lightsteelblue",
+									 @"FFFFE0", @"lightyellow",
+									 @"00FF00", @"lime",
+									 @"32CD32", @"limegreen",
+									 @"FAF0E6", @"linen",
+									 @"FF00FF", @"magenta",
+									 @"800000", @"maroon",
+									 @"66CDAA", @"mediumaquamarine",
+									 @"0000CD", @"mediumblue",
+									 @"BA55D3", @"mediumorchid",
+									 @"9370D8", @"mediumpurple",
+									 @"3CB371", @"mediumseagreen",
+									 @"7B68EE", @"mediumslateblue",
+									 @"00FA9A", @"mediumspringgreen",
+									 @"48D1CC", @"mediumturquoise",
+									 @"C71585", @"mediumvioletred",
+									 @"191970", @"midnightblue",
+									 @"F5FFFA", @"mintcream",
+									 @"FFE4E1", @"mistyrose",
+									 @"FFE4B5", @"moccasin",
+									 @"FFDEAD", @"navajowhite",
+									 @"000080", @"navy",
+									 @"FDF5E6", @"oldlace",
+									 @"808000", @"olive",
+									 @"6B8E23", @"olivedrab",
+									 @"FFA500", @"orange",
+									 @"FF4500", @"orangered",
+									 @"DA70D6", @"orchid",
+									 @"EEE8AA", @"palegoldenrod",
+									 @"98FB98", @"palegreen",
+									 @"AFEEEE", @"paleturquoise",
+									 @"D87093", @"palevioletred",
+									 @"FFEFD5", @"papayawhip",
+									 @"FFDAB9", @"peachpuff",
+									 @"CD853F", @"peru",
+									 @"FFC0CB", @"pink",
+									 @"DDA0DD", @"plum",
+									 @"B0E0E6", @"powderblue",
+									 @"800080", @"purple",
+									 @"FF0000", @"red",
+									 @"BC8F8F", @"rosybrown",
+									 @"4169E1", @"royalblue",
+									 @"8B4513", @"saddlebrown",
+									 @"FA8072", @"salmon",
+									 @"F4A460", @"sandybrown",
+									 @"2E8B57", @"seagreen",
+									 @"FFF5EE", @"seashell",
+									 @"A0522D", @"sienna",
+									 @"C0C0C0", @"silver",
+									 @"87CEEB", @"skyblue",
+									 @"6A5ACD", @"slateblue",
+									 @"708090", @"slategray",
+									 @"708090", @"slategrey",
+									 @"FFFAFA", @"snow",
+									 @"00FF7F", @"springgreen",
+									 @"4682B4", @"steelblue",
+									 @"D2B48C", @"tan",
+									 @"008080", @"teal",
+									 @"D8BFD8", @"thistle",
+									 @"FF6347", @"tomato",
+									 @"40E0D0", @"turquoise",
+									 @"EE82EE", @"violet",
+									 @"F5DEB3", @"wheat",
+									 @"FFFFFF", @"white",
+									 @"F5F5F5", @"whitesmoke",
+									 @"FFFF00", @"yellow",
+									 @"9ACD32", @"yellowgreen",
+									 nil];
 	}
 	
 	NSString *hexString = [colorLookup objectForKey:[name lowercaseString]];
@@ -221,27 +221,27 @@ static NSDictionary *colorLookup = nil;
 	CGColorRef color = self.CGColor;
 	size_t count = CGColorGetNumberOfComponents(color);
 	const CGFloat *components = CGColorGetComponents(color);
-    
-    if (count==2)
-    {
-        // grayscale
-        CGFloat white = components[0];
-        CGFloat alpha = components[1];
-        
-        return [UIColor colorWithWhite:1.0 - white alpha:alpha];
-    }
-    else if (count==4)
-    {
-        // grayscale
-        CGFloat red = components[0];
-        CGFloat green = components[1];
-        CGFloat blue = components[2];
-        CGFloat alpha = components[3];
-        
-        return [UIColor colorWithRed:1.0 - red green:1.0 - green blue:1.0 - blue alpha:alpha];
-    } 
-    
-    return nil;
+	
+	if (count==2)
+	{
+		// grayscale
+		CGFloat white = components[0];
+		CGFloat alpha = components[1];
+		
+		return [UIColor colorWithWhite:1.0 - white alpha:alpha];
+	}
+	else if (count==4)
+	{
+		// grayscale
+		CGFloat red = components[0];
+		CGFloat green = components[1];
+		CGFloat blue = components[2];
+		CGFloat alpha = components[3];
+		
+		return [UIColor colorWithRed:1.0 - red green:1.0 - green blue:1.0 - blue alpha:alpha];
+	} 
+	
+	return nil;
 }
 
 - (NSString *)htmlHexString
@@ -249,24 +249,24 @@ static NSDictionary *colorLookup = nil;
 	CGColorRef color = self.CGColor;
 	size_t count = CGColorGetNumberOfComponents(color);
 	const CGFloat *components = CGColorGetComponents(color);
-    
-    if (count==2)
-    {
-        // grayscale
-        char white = components[0]*255;
-        
-        return [NSString stringWithFormat:@"#%02x%02x%02x", white, white, white];
-    }
-    else if (count==4)
-    {
-        // grayscale
-        NSUInteger red = components[0]*255;
-        NSUInteger green = components[1]*255;
-        NSUInteger blue = components[2]*255;
-        
-        
-        return [NSString stringWithFormat:@"#%02x%02x%02x", red, green, blue];
-    }
+	
+	if (count==2)
+	{
+		// grayscale
+		char white = components[0]*255;
+		
+		return [NSString stringWithFormat:@"#%02x%02x%02x", white, white, white];
+	}
+	else if (count==4)
+	{
+		// grayscale
+		NSUInteger red = components[0]*255;
+		NSUInteger green = components[1]*255;
+		NSUInteger blue = components[2]*255;
+		
+		
+		return [NSString stringWithFormat:@"#%02x%02x%02x", red, green, blue];
+	}
 	
 	return nil;
 }

--- a/Classes/UIColorHTMLTest.m
+++ b/Classes/UIColorHTMLTest.m
@@ -13,14 +13,14 @@
 
 - (void) testValidColorWithHexString
 {
-    UIColor *htmlColor;
+	UIColor *htmlColor;
 	UIColor *namedColor;
 	
 	namedColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:1.0];
 	htmlColor = [UIColor colorWithHexString:@"000000"];
 	STAssertNotNil(htmlColor, @"Failed to create black color");
 	STAssertEqualObjects(namedColor, htmlColor, @"Hmmm... black is not black");
-    
+	
 	namedColor = [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0];
 	htmlColor = [UIColor colorWithHexString:@"FFFFFF"];
 	STAssertNotNil(htmlColor, @"Failed to create white color");

--- a/Classes/UIDevice+DTVersion.m
+++ b/Classes/UIDevice+DTVersion.m
@@ -14,15 +14,15 @@
 {
 	NSString *versionString = [self systemVersion];
 	NSArray *parts = [versionString componentsSeparatedByString:@"."];
-    
+	
 	DTVersion retVersion;
-    
+	
 	NSUInteger partCount = [parts count];
-    
+	
 	retVersion.major = (partCount>0)?[[parts objectAtIndex:0] intValue]:0;
 	retVersion.minor = (partCount>1)?[[parts objectAtIndex:1] intValue]:0;
 	retVersion.point = (partCount>2)?[[parts objectAtIndex:2] intValue]:0;
-    
+	
 	return retVersion;
 }
 

--- a/CoreTextExtensions.xcodeproj/project.pbxproj
+++ b/CoreTextExtensions.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 			);
 			name = CustomTemplate;
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The majority of this project uses single tabs for indentation, but there are a lot of places where spaces are used. It's not really that important which you use, but it is important that a project is internally consistent (for instance, besides the philosophical annoyance, some users may have tabs set to a size other than four spaces, which makes the difference between tabs and spaces very jarring). As such, I have converted the entire project to use tabs.

For anyone curious, you can set Xcode 4's indentation style for a specific project by selecting the project in the source pane on the left, and opening the File Inspector in the right pane, and choosing Tabs under Text Settings => Indent Using.

(I won't be offended if you decline to merge this commit. I just think it's always good for a project to maintain some level of internal consistency, though it's not a gigantic deal.)
