### PR TITLE
Newline-only lines found always to not be in frame.

### DIFF
--- a/Classes/DTCoreTextLayoutFrame.m
+++ b/Classes/DTCoreTextLayoutFrame.m
@@ -176,7 +176,12 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	
 	for (DTCoreTextLayoutLine *oneLine in self.lines)
 	{
-		if (CGRectIntersectsRect(rect, oneLine.frame))
+        CGRect lineFrame = oneLine.frame;
+        // CGRectIntersectsRect returns false if the frame has 0 width, which
+        // lines that consist only of line-breaks have. Set the min-width
+        // to one to work-around.
+        lineFrame.size.width = lineFrame.size.width>1?lineFrame.size.width:1;
+		if (CGRectIntersectsRect(rect, lineFrame))
 		{
 			[tmpArray addObject:oneLine];
 			earlyBreakPossible = YES;


### PR DESCRIPTION
Fix a bug where lines consisting only of breaks are found to not be visible on the page, causing excessive pagination.
