### PR TITLE
DTAttributedTextView blocking selection when used in UITableViewCells

### DIFF
--- a/Classes/DTAttributedTextView.h
+++ b/Classes/DTAttributedTextView.h
@@ -14,6 +14,8 @@
 {
 	DTAttributedTextContentView *contentView;
 	UIView *backgroundView;
+    
+    BOOL onlyInteractWithSubview;
 }
 
 @property (nonatomic, retain) NSAttributedString *attributedString;
@@ -22,5 +24,8 @@
 @property (nonatomic, retain) IBOutlet UIView *backgroundView;
 
 @property (nonatomic, assign) IBOutlet id <DTAttributedTextContentViewDelegate> textDelegate;
+
+@property (nonatomic, assign) BOOL onlyInteractWithSubview;
+
 
 @end

--- a/Classes/DTAttributedTextView.m
+++ b/Classes/DTAttributedTextView.m
@@ -20,6 +20,7 @@
 
 
 @implementation DTAttributedTextView
+@synthesize onlyInteractWithSubview;
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -27,6 +28,7 @@
 	
 	if (self)
 	{
+        onlyInteractWithSubview = NO;
 		[self setup];
 	}
 	
@@ -51,6 +53,21 @@
 	
 	// layout custom subviews for visible area
 	[contentView layoutSubviewsInRect:self.bounds];
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    if (!onlyInteractWithSubview) {
+        return [super pointInside:point withEvent:event];
+    }
+    
+    CGPoint contentViewPoint = [self convertPoint:point toView:self.contentView];
+    for (UIView *view in self.contentView.subviews) {
+        CGPoint viewPoint = [self.contentView convertPoint:contentViewPoint toView:view];
+        if ([view pointInside:viewPoint withEvent:event]) {
+            return YES;
+        }
+    }
+    return NO;
 }
 
 - (void)awakeFromNib


### PR DESCRIPTION
I have a project, in which I'm using DTAttributedTextView inside UITableViewCells. These attributedTextView's can contain links, so user interaction must be enabled for the attributedTextView's. But since these attributedTextView's use most of the space inside the tableViewCell, the user can _barely_ click on the cell anymore.

That what this Pull Request is for. I added a new property on DTAttributedTextView:

```
@property (nonatomic, assign) BOOL onlyInteractWithSubview;
```

Default is `NO`. If `onlyInteractWithSubview` is `YES`, DTAttributedTextView will only respond to touches, that are inside the subviews of it's content view.
