### PR TITLE
Crash fix and small <code> implementation

### DIFF
--- a/Classes/NSAttributedString+HTML.m
+++ b/Classes/NSAttributedString+HTML.m
@@ -328,7 +328,10 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 						{
 							// file in app bundle
 							NSString *path = [[NSBundle mainBundle] pathForResource:src ofType:nil];
-							imageURL = [NSURL fileURLWithPath:path];
+                            if (path) {
+                                // Prevent a crash if path turns up nil.
+                                imageURL = [NSURL fileURLWithPath:path];   
+                            }
 						}
 					}
 					
@@ -641,7 +644,7 @@ NSString *DTDefaultLineHeightMultiplier = @"DTDefaultLineHeightMultiplier";
 					currentTag.fontDescriptor.pointSize *= 0.83;
 				}
 			}
-			else if ([tagName isEqualToString:@"pre"])
+			else if ([tagName isEqualToString:@"pre"] || [tagName isEqualToString:@"code"])
 			{
 				if (tagOpen)
 				{


### PR DESCRIPTION
When the img tag doesn't have a correct URL for an image and the imageURL seems to be from the file system but its not, pathForResource: returns nil and then crashes the app because fileURLWithPath can't have a nil value passed on so that was just a quick fix...

As for the code implementation while using it I needed it to use both code and pre equally, i'm not sure if this is how you want it though so it's up to you on that one
