### PR TITLE
invoke setContentOffset after set frame

### DIFF
--- a/Classes/DTAttributedTextView.m
+++ b/Classes/DTAttributedTextView.m
@@ -194,14 +194,12 @@
 {
 	if (!CGRectEqualToRect(self.frame, frame))
 	{
-		[self setContentOffset:CGPointZero animated:YES];
-		
 		if (self.frame.size.width != frame.size.width)
 		{
 			contentView.frame = CGRectMake(0,0,frame.size.width, frame.size.height);
 		}
-		
 		[super setFrame:frame];
+		[self setContentOffset:CGPointZero animated:YES];
 	}
 }
 


### PR DESCRIPTION
invoke setContentOffset before the frame been set will cause the scroll view scroll to an incorrect position.
