### PR TITLE
do NOT invoke setContentOffset in setFrame: method

### DIFF
--- a/Classes/DTAttributedTextView.m
+++ b/Classes/DTAttributedTextView.m
@@ -199,7 +199,6 @@
 			contentView.frame = CGRectMake(0,0,frame.size.width, frame.size.height);
 		}
 		[super setFrame:frame];
-		[self setContentOffset:CGPointZero animated:YES];
 	}
 }
 


### PR DESCRIPTION
There is a little strange that the UIScrollView always set its content offset to the top when the frame is changed. Maybe we should let the scroll view to set it automatically.

If we need the UIScrollView to scroll to the top, I think it's better to invoke setContentOffset in an UIViewController by ourselves.
