### PR TITLE
DTLazyImageViewDidFinishLoading Notification bad for UITableViewCell's

### DIFF
--- a/Classes/DTLazyImageView.h
+++ b/Classes/DTLazyImageView.h
@@ -9,6 +9,12 @@
 #import <Foundation/Foundation.h>
 #import <ImageIO/ImageIO.h>
 
+@class DTLazyImageView;
+
+@protocol DTLazyImageViewDelegate <NSObject>
+@optional
+- (void)lazyImageView:(DTLazyImageView *)lazyImageView didChangeImageSize:(CGSize)size;
+@end
 
 @interface DTLazyImageView : UIImageView 
 {
@@ -24,10 +30,14 @@
 	NSUInteger _expectedSize;
     
     BOOL shouldShowProgressiveDownload;
+	
+	id<DTLazyImageViewDelegate> _delegate;
 }
 
 @property (nonatomic, retain) NSURL *url;
 @property (nonatomic, assign) BOOL shouldShowProgressiveDownload;
+
+@property (nonatomic, assign) id<DTLazyImageViewDelegate> delegate;
 
 - (void)cancelLoading;
 

--- a/Classes/DTLazyImageView.m
+++ b/Classes/DTLazyImageView.m
@@ -19,6 +19,7 @@ static DTCache *_imageCache = nil;
 
 
 @implementation DTLazyImageView
+@synthesize delegate=_delegate;
 
 - (void)dealloc
 {
@@ -153,9 +154,12 @@ static DTCache *_imageCache = nil;
 
 - (void)notify
 {
-	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[NSValue valueWithCGSize:CGSizeMake(_fullWidth, _fullHeight)], @"ImageSize", _url, @"ImageURL", nil];
+//	NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:[NSValue valueWithCGSize:CGSizeMake(_fullWidth, _fullHeight)], @"ImageSize", _url, @"ImageURL", nil];
 	
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"DTLazyImageViewDidFinishLoading" object:nil userInfo:userInfo];
+	if ([self.delegate respondsToSelector:@selector(lazyImageView:didChangeImageSize:)]) {
+		[self.delegate lazyImageView:self didChangeImageSize:CGSizeMake(_fullWidth, _fullHeight)];
+	}
+//	[[NSNotificationCenter defaultCenter] postNotificationName:@"DTLazyImageViewDidFinishLoading" object:nil userInfo:userInfo];
 }
 
 - (void)completeDownloadWithData:(NSData *)data

--- a/Classes/DemoTextViewController.h
+++ b/Classes/DemoTextViewController.h
@@ -7,9 +7,9 @@
 //
 
 #import "DTAttributedTextView.h"
+#import "DTLazyImageView.h"
 
-
-@interface DemoTextViewController : UIViewController <UIActionSheetDelegate, DTAttributedTextContentViewDelegate>
+@interface DemoTextViewController : UIViewController <UIActionSheetDelegate, DTAttributedTextContentViewDelegate, DTLazyImageViewDelegate>
 {
 
 	NSString *_fileName;

--- a/Classes/DemoTextViewController.m
+++ b/Classes/DemoTextViewController.m
@@ -52,10 +52,6 @@
 		UIBarButtonItem *debug = [[[UIBarButtonItem alloc] initWithTitle:@"Debug Frames" style:UIBarButtonItemStyleBordered target:self action:@selector(debugButton:)] autorelease];
 		NSArray *toolbarItems = [NSArray arrayWithObjects:spacer, debug, nil];
 		[self setToolbarItems:toolbarItems];
-		
-		
-		// register notifications
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(lazyImageDidFinishLoading:) name:@"DTLazyImageViewDidFinishLoading" object:nil];
 	}
 	return self;
 }
@@ -335,6 +331,7 @@
 	{
 		// if the attachment has a hyperlinkURL then this is currently ignored
 		DTLazyImageView *imageView = [[[DTLazyImageView alloc] initWithFrame:frame] autorelease];
+		imageView.delegate = self;
 		if (attachment.contents)
 		{
 			imageView.image = attachment.contents;
@@ -395,12 +392,11 @@
 	[self.view setNeedsDisplay];
 }
 
-#pragma mark Notifications
-- (void)lazyImageDidFinishLoading:(NSNotification *)notification
-{
-	NSDictionary *userInfo = [notification userInfo];
-	NSURL *url = [userInfo objectForKey:@"ImageURL"];
-	CGSize imageSize = [[userInfo objectForKey:@"ImageSize"] CGSizeValue];
+#pragma mark DTLazyImageViewDelegate
+
+- (void)lazyImageView:(DTLazyImageView *)lazyImageView didChangeImageSize:(CGSize)size {
+	NSURL *url = lazyImageView.url;
+	CGSize imageSize = size;
 	
 	NSPredicate *pred = [NSPredicate predicateWithFormat:@"contentURL == %@", url];
 	


### PR DESCRIPTION
Hi,

when you try to use DTLazyImageView in UITableViewCell's, you would not want to use notifications to inform about image size changes, because each cell would get notifications from every different imageView (even from them the cell does not own). That why I have replaced the notification with a delegate.
