### PR TITLE
Support for Style Tags

### DIFF
--- a/Classes/NSString+HTML.m
+++ b/Classes/NSString+HTML.m
@@ -35,13 +35,13 @@ static NSDictionary *entityLookup = nil;
 	static dispatch_once_t predicate;
 	dispatch_once(&predicate, ^{
 		inlineTags = [[NSSet alloc] initWithObjects:@"font", @"b", @"strong", @"em", @"i", @"sub", @"sup",
-									@"u", @"a", @"img", @"del", @"br", @"span", nil];
+									@"u", @"a", @"img", @"del", @"br", @"style", @"span", nil];
 	});
 #else
 	if (!inlineTags)
 	{
 		inlineTags = [[NSSet alloc] initWithObjects:@"font", @"b", @"strong", @"em", @"i", @"sub", @"sup",
-									@"u", @"a", @"img", @"del", @"br", @"span", nil];
+									@"u", @"a", @"img", @"del", @"br", @"style", @"span", nil];
 	}
 #endif
 	
@@ -53,12 +53,12 @@ static NSDictionary *entityLookup = nil;
 #ifdef DT_USE_THREAD_SAFE_INITIALIZATION
 	static dispatch_once_t predicate;
 	dispatch_once(&predicate, ^{
-		metaTags = [[NSSet alloc] initWithObjects:@"html", @"head", @"meta", @"style", @"#COMMENT#", @"title", nil];
+		metaTags = [[NSSet alloc] initWithObjects:@"html", @"head", @"meta", @"#COMMENT#", @"title", nil];
 	});
 #else
 	if (!metaTags)
 	{
-		metaTags = [[NSSet alloc] initWithObjects:@"html", @"head", @"meta", @"style", @"#COMMENT#", @"title", nil];
+		metaTags = [[NSSet alloc] initWithObjects:@"html", @"head", @"meta", @"#COMMENT#", @"title", nil];
 	}
 #endif
 	


### PR DESCRIPTION
I added support for the following CSS rules, all single hierarchy (you can't cascade rules):
- Class based (.red { }, class="red")
- ID based (#blue, id="blue")
- Tag based (span {}, <span />)
- Multiple classes (.red, .large { }, class="large red")

I did this by applying the following changes, which can be seen in my commits:
- Making style tags NOT meta (this was resulting in them skipping the main tag processing loop, and their content being dumped on to the screen)
- When we're ready to append a tag's contents to our attributed string in NSAttributedString+HTML.m line 852, first check if we have a block of CSS from a style tag; if we do, don't append! Parse it instead.
- When we are parsing CSS, break it down in to individual simple rules (like .red has this css, #large has some other css) that we can store in a dictionary.
- Instead of just pulling each element's style string from just its attribute, I created a method that will consider the style attribute, ID, classes, and element type (from highest to lowest precedence).

This approach doesn't really consider the DOM, but it is a heck of a lot lighter. I don't think I my additional methods in the best spots, but it's a start, right?

Hope this helps!
