### PR TITLE
Crash when attempting to relayout text from different thread when view is no longer on the superview

### DIFF
--- a/Classes/DTAttributedTextContentView.m
+++ b/Classes/DTAttributedTextContentView.m
@@ -425,27 +425,30 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)relayoutText
 {
-	// need new layouter
-	self.layouter = nil;
-	self.layoutFrame = nil;
-	
-	// remove all links because they might have merged or split
-	[self removeAllCustomViewsForLinks];
-	
-	if (_attributedString)
-	{
-		// triggers new layout
-		CGSize neededSize = [self sizeThatFits:self.bounds.size];
-		
-		// set frame to fit text preserving origin
-		// call super to avoid endless loop
-		[self willChangeValueForKey:@"frame"];
-		super.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, neededSize.width, neededSize.height);
-		[self didChangeValueForKey:@"frame"];
-	}
-	
-	[self setNeedsDisplay];
-	[self setNeedsLayout];
+    // Make sure we actually have a superview before attempting to relayout the text.
+    if (self.superview) {
+        // need new layouter
+        self.layouter = nil;
+        self.layoutFrame = nil;
+        
+        // remove all links because they might have merged or split
+        [self removeAllCustomViewsForLinks];
+        
+        if (_attributedString)
+        {
+            // triggers new layout
+            CGSize neededSize = [self sizeThatFits:self.bounds.size];
+            
+            // set frame to fit text preserving origin
+            // call super to avoid endless loop
+            [self willChangeValueForKey:@"frame"];
+            super.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, neededSize.width, neededSize.height);
+            [self didChangeValueForKey:@"frame"];
+        }
+        
+        [self setNeedsDisplay];
+        [self setNeedsLayout];
+    }
 }
 
 - (void)removeAllCustomViewsForLinks


### PR DESCRIPTION
I discovered this while trying to swap views sorta like Mail.app in iOS does with the segmented control in its navigation bar, except with animation and so when the view is moved its removed from the superview, though I changed my attributed text in a different thread and so by the time it attempted to relayout the text it was removed from the screen therefore causing a crash.  Just a simple check to make sure there's a superview before re-layouting, but I don't know if you want to do some thread checking instead.
