### PR TITLE
Safer way to get a color's alpha.

### DIFF
--- a/Classes/UIColor+HTML.m
+++ b/Classes/UIColor+HTML.m
@@ -370,11 +370,7 @@ static NSDictionary *colorLookup = nil;
 
 - (CGFloat)alpha
 {
-	CGColorRef color = self.CGColor;
-	size_t count = CGColorGetNumberOfComponents(color);
-	const CGFloat *components = CGColorGetComponents(color);
-	
-	return components[count-1];
+	return CGColorGetAlpha(self.CGColor);
 }
 
 - (UIColor *)invertedColor


### PR DESCRIPTION
Use the built-in CG function instead of inspecting color components.
