### PR TITLE
Disregard incorrect syntax for rgba() and rgb()

### DIFF
--- a/Classes/UIColor+HTML.m
+++ b/Classes/UIColor+HTML.m
@@ -45,23 +45,33 @@ static NSDictionary *colorLookup = nil;
 		return [UIColor colorWithHexString:[name substringFromIndex:1]];
 	}
 	
-  if ([name hasPrefix:@"rgba"]) {
-    NSString *rgbaName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rgba() "]];
-    NSArray *rgba = [rgbaName componentsSeparatedByString:@","];
-    return [UIColor colorWithRed:[[rgba objectAtIndex:0] floatValue] / 255
-                           green:[[rgba objectAtIndex:1] floatValue] / 255
-                            blue:[[rgba objectAtIndex:2] floatValue] / 255
-                           alpha:[[rgba objectAtIndex:3] floatValue]];
-  }
-  
+	if ([name hasPrefix:@"rgba"]) {
+		NSString *rgbaName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rgba() "]];
+		NSArray *rgba = [rgbaName componentsSeparatedByString:@","];
+		
+		if ([rgba count] != 4) {
+			// Incorrect syntax
+			return nil;
+		}
+		
+		return [UIColor colorWithRed:[[rgba objectAtIndex:0] floatValue] / 255
+							   green:[[rgba objectAtIndex:1] floatValue] / 255
+								blue:[[rgba objectAtIndex:2] floatValue] / 255
+							   alpha:[[rgba objectAtIndex:3] floatValue]];
+	}
+	
 	if([name hasPrefix:@"rgb"])
 	{
 		NSString * rgbName = [name stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"rbg() "]];
 		NSArray* rbg = [rgbName componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@","]];
+		if ([rbg count] != 3) {
+			// Incorrect syntax
+			return nil;
+		}
 		return [UIColor colorWithRed:[[rbg objectAtIndex:0]floatValue]/255 
-													 green:[[rbg objectAtIndex:1]floatValue] /255
-														blue:[[rbg objectAtIndex:2]floatValue] /255
-													 alpha:1.0];
+                               green:[[rbg objectAtIndex:1]floatValue] /255
+                                blue:[[rbg objectAtIndex:2]floatValue] /255
+                               alpha:1.0];
 	}
 	
 #ifdef DT_USE_THREAD_SAFE_INITIALIZATION


### PR DESCRIPTION
When rgba() and rgb() are given incorrect syntax (not enough parameters/to many) the app using this will crash since it may access an index that isn't there.  Just a quick fix, I returned nil based on the method name instead of blackColor, but thats up to you.
