### PR TITLE
Fix compile error in NSAttributedString+HTML.m

### DIFF
--- a/Classes/NSAttributedString+HTML.m
+++ b/Classes/NSAttributedString+HTML.m
@@ -870,6 +870,7 @@ NSString *DTDefaultListIndent = @"DTDefaultListIndent";
 						
 						if (prefixString)
 						{
+#if ALLOW_IPHONE_SPECIAL_CASES							
 							// need to add paragraph space after previous paragraph
 							if (nextParagraphAdditionalSpaceBefore>0)
 							{
@@ -888,7 +889,7 @@ NSString *DTDefaultListIndent = @"DTDefaultListIndent";
 
 								nextParagraphAdditionalSpaceBefore = 0;
 							}
-							
+#endif							
 							[tmpString appendAttributedString:prefixString]; 
 						}
 						


### PR DESCRIPTION
`nextParagraphAdditionalSpaceBefore` is only defined if `ALLOW_IPHONE_SPECIAL_CASES` is turned on.
