### PR TITLE
fix to correctLineOrigins for image handling

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -781,12 +781,10 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		if (previousLine)
 		{
 			float paragraphSpacing = [previousLine paragraphSpacing];
-			float lineHeight = 0;
+			float lineHeight = [currentLine lineHeight];
 			if (paragraphSpacing > 0) {
-				lineHeight = MIN([previousLine lineHeight], [currentLine lineHeight]);
-			} else {
-				lineHeight = [previousLine lineHeight];
-			}
+				paragraphSpacing = MIN(paragraphSpacing, [currentLine paragraphSpacing:NO]);
+			} 
 			currentOrigin.y = previousLineOrigin.y + lineHeight + paragraphSpacing;
 			
 			currentOrigin.x = currentLine.baselineOrigin.x;

--- a/Core/Source/DTCoreTextLayoutLine.h
+++ b/Core/Source/DTCoreTextLayoutLine.h
@@ -24,7 +24,7 @@
 - (NSArray *)stringIndices;
 - (CGFloat)offsetForStringIndex:(NSInteger)index;
 - (NSInteger)stringIndexForPosition:(CGPoint)position;
-
+- (CGFloat)paragraphSpacing:(BOOL)zeroNonLast;
 - (CGFloat)paragraphSpacing;
 - (CGFloat)lineHeight;
 - (CGFloat)calculatedLeading;

--- a/Core/Source/DTCoreTextLayoutLine.m
+++ b/Core/Source/DTCoreTextLayoutLine.m
@@ -280,10 +280,10 @@
 }
 
 // returns the maximum paragraph spacing for this line
-- (CGFloat)paragraphSpacing
+- (CGFloat)paragraphSpacing:(BOOL)zeroNonLast
 {
 	// a paragraph spacing only is effective for last line in paragraph
-	if (![[_attributedString string] hasSuffix:@"\n"])
+	if (![[_attributedString string] hasSuffix:@"\n"] && zeroNonLast)
 	{
 		return 0;
 	}
@@ -305,6 +305,9 @@
 	return retSpacing;
 }
 
+- (CGFloat)paragraphSpacing {
+	return [self paragraphSpacing:YES];
+}
 
 // returns the calculated line height
 // http://stackoverflow.com/questions/5511830/how-does-line-spacing-work-in-core-text-and-why-is-it-different-from-nslayoutm


### PR DESCRIPTION
this was apparently caused by incorrect accounting of paragraph spacing. Should be fixed now. As far as I could determine I see no difference in how images are laid out now and before pull #109. The behavior appears the same, except the fix for line-height in correctLineOrigins is active.
