### PR TITLE
Extraneous newline at the end of attribute spans in [ NSAttributedString htmlString ]

### DIFF
--- a/Core/Source/NSAttributedString+DTCoreText.m
+++ b/Core/Source/NSAttributedString+DTCoreText.m
@@ -343,7 +343,7 @@
 			{
 				if ([fontStyle length])
 				{
-					[retString appendFormat:@"<span style=\"%@\">%@</span>\n", fontStyle, subString];
+					[retString appendFormat:@"<span style=\"%@\">%@</span>", fontStyle, subString];
 				}
 				else
 				{

--- a/Core/Test/Source/NSAttributedStringHTMLTest.m
+++ b/Core/Test/Source/NSAttributedStringHTMLTest.m
@@ -8,6 +8,9 @@
 
 #import "NSAttributedStringHTMLTest.h"
 #import "NSAttributedString+HTML.h"
+
+#import "NSAttributedString+DTCoreText.h"
+
 #import "DTHTMLAttributedStringBuilder.h"
 
 @implementation NSAttributedStringHTMLTest
@@ -114,6 +117,20 @@
 	
 	STAssertEqualObjects(resultOnIOS, resultOnMac, @"Output on Invalid Tag Test differs");
 	
+}
+
+
+- (void)testAttributedStringColorToHTML {
+	NSMutableAttributedString *string = [[NSMutableAttributedString alloc]initWithString: @"test"];
+	
+	UIColor *color = [ UIColor colorWithRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0 ];
+
+	[ string setAttributes: [ NSDictionary dictionaryWithObject: (id)color.CGColor forKey: (id)kCTForegroundColorAttributeName ] range: NSMakeRange(0, 2) ];	
+	
+	NSString *expected = @"<span><span style=\"color:#ff0000;\">te</span>st</span>\n";
+
+	STAssertEqualObjects([ string htmlString ], expected, @"Output on HTML string color test differs");
+
 }
 
 @end


### PR DESCRIPTION
When using [ NSAttributedString htmlString ] from NSAttributedString+DTCoreText.h, there's an extraneous "\n" inserted at the end of each attribute span.  This introduces an unexpected word break when rendered, and this becomes an issue if an attribute span doesn't end on a clean word break.  The test case I added illustrates this issue.
