### PR TITLE
text-shadow not handling negative offsets

### DIFF
--- a/Core/Source/NSString+CSS.m
+++ b/Core/Source/NSString+CSS.m
@@ -43,6 +43,7 @@
 	CGFloat value = 0;
 	
 	BOOL commaSeen = NO;
+	BOOL negative = NO;
 	NSUInteger digitsPastComma = 0;
 	
 	NSUInteger i=0;
@@ -65,6 +66,10 @@
 		else if (ch=='.')
 		{
 			commaSeen = YES;
+		}
+		else if (ch=='-') 
+		{
+			negative = YES;
 		}
 		else
 		{
@@ -104,6 +109,11 @@
 				}
 			}
 		}
+	}
+	
+	if (negative)
+	{
+		value *= -1;
 	}
 	
 	free(_characters);


### PR DESCRIPTION
There was a bug where "text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black" would only draw two shadows.  The negative numbers were turned into zero by the parsing routine.
