### PR TITLE
UIDevice+DTVersion fix

### DIFF
--- a/Core/Source/UIDevice+DTVersion.m
+++ b/Core/Source/UIDevice+DTVersion.m
@@ -19,8 +19,6 @@
 		NSString* versionString = [self systemVersion];
 		NSArray *parts = [versionString componentsSeparatedByString:@"."];
 		
-		DTVersion retVersion;
-		
 		NSUInteger partCount = [parts count];
 		
 		retVersion.major = (partCount>0)?[[parts objectAtIndex:0] intValue]:0;


### PR DESCRIPTION
Was always returning a zero filled struct. Now returns the correct version information. And eliminates a warning from the compiler.
