### PR TITLE
Made it so -webkit-margin-before and margin-top are heeded.

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -274,8 +274,8 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 			
 			if (isAtBeginOfParagraph)
 			{
-				lineOrigin.y += previousParaMetrics.paragraphSpacing;
-				lineOrigin.y += currentParaMetrics.paragraphSpacingBefore;
+				// Margins should overlap.
+				lineOrigin.y += MAX(currentParaMetrics.paragraphSpacingBefore, previousParaMetrics.paragraphSpacing);
 			}
 			
 			if (usesSyntheticLeading)

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -568,6 +568,20 @@
 			self.paragraphStyle.paragraphSpacing = [webkitMarginAfter pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize];
 		}
 	}
+	NSString *marginTop = [styles objectForKey:@"margin-top"];
+	if (marginTop) 
+	{
+		self.paragraphStyle.paragraphSpacingBefore = [marginTop pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize];
+	}
+	else
+	{
+		NSString *webkitMarginBefore = [styles objectForKey:@"-webkit-margin-before"];
+		if (webkitMarginBefore) 
+		{
+			self.paragraphStyle.paragraphSpacingBefore = [webkitMarginBefore pixelSizeOfCSSMeasureRelativeToCurrentTextSize:fontDescriptor.pointSize];
+		}
+	}
+	
 	NSString *fontVariantStr = [[styles objectForKey:@"font-variant"] lowercaseString];
 	if (fontVariantStr)
 	{

--- a/Demo/Source/DemoSnippetsViewController.m
+++ b/Demo/Source/DemoSnippetsViewController.m
@@ -53,7 +53,7 @@
 	NSString *title = [snippet objectForKey:@"Title"];
 	NSString *description = [snippet objectForKey:@"Description"];
 	
-	NSString *html = [NSString stringWithFormat:@"<h3>%@</h3><p><font color=\"gray\">%@</font></p>", title, description];
+	NSString *html = [NSString stringWithFormat:@"<h3 style='margin-top: 0;'>%@</h3><p style='color: gray;'>%@</p>", title, description];
 	
 	[cell setHTMLString:html];
 	


### PR DESCRIPTION
I made it so margin-top and margin-bottom overlap, as they're supposed to. And made it so margin-top/-webkit-margin-before are read like their bottom counterparts are.

I noticed one difference in the demo Snippets screen which I'm not sure how to fix. Now there are margins on the bottom of the description paragraphs, which seems odd, since I was only touching the top ones... But otherwise it seems good.
