### PR TITLE
Introduces DTCompatibility.h

### DIFF
--- a/Core/Source/DTCompatibility.h
+++ b/Core/Source/DTCompatibility.h
@@ -1,0 +1,30 @@
+//
+//  DTCompatibility.h
+//  DTCoreText
+//
+//  Created by Oliver Letterer on 09.04.12.
+//  Copyright (c) 2012 Drobnik.com. All rights reserved.
+//
+
+// DTColor is UIColor on iOS, NSColor on Mac
+#if TARGET_OS_IPHONE
+@compatibility_alias DTColor UIColor;
+#else
+@compatibility_alias DTColor NSColor;
+#endif
+
+// DTImage is UIImage on iOS, NSImage on Mac
+#if TARGET_OS_IPHONE
+@compatibility_alias DTImage UIImage;
+#else
+@compatibility_alias DTImage NSImage;
+#endif
+
+// DTEdgeInsets is UIEdgeInsets on iOS, NSEdgeInsets on Mac
+#if TARGET_OS_IPHONE
+#define DTEdgeInsets UIEdgeInsets
+#define DTEdgeInsetsMake(a, b, c, d) UIEdgeInsetsMake(a, b, c, d)
+#else
+#define DTEdgeInsets NSEdgeInsets
+#define DTEdgeInsetsMake(a, b, c, d) NSEdgeInsetsMake(a, b, c, d)
+#endif

--- a/Core/Source/DTCoreText.h
+++ b/Core/Source/DTCoreText.h
@@ -4,33 +4,10 @@
 
 // global constants
 #import "DTCoreTextConstants.h"
-
-// DTColor is UIColor on iOS, NSColor on Mac
-#if TARGET_OS_IPHONE
-@compatibility_alias DTColor UIColor;
-#else
-@compatibility_alias DTColor NSColor;
-#endif
+#import "DTCompatibility.h"
 
 #import "DTColor+HTML.h"
-
-// DTImage is UIImage on iOS, NSImage on Mac
-#if TARGET_OS_IPHONE
-@compatibility_alias DTImage UIImage;
-#else
-@compatibility_alias DTImage NSImage;
-#endif
-
 #import "DTImage+HTML.h"
-
-// DTEdgeInsets is UIEdgeInsets on iOS, NSEdgeInsets on Mac
-#if TARGET_OS_IPHONE
-#define DTEdgeInsets UIEdgeInsets
-#define DTEdgeInsetsMake(a, b, c, d) UIEdgeInsetsMake(a, b, c, d)
-#else
-#define DTEdgeInsets NSEdgeInsets
-#define DTEdgeInsetsMake(a, b, c, d) NSEdgeInsetsMake(a, b, c, d)
-#endif
 
 // common utilities
 #import "CGUtils.h"

--- a/Core/Source/DTTextBlock.h
+++ b/Core/Source/DTTextBlock.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
-#import "DTCoreText.h"
+#import "DTCompatibility.h"
 
 /**
  Class that represents a block of text with attributes like padding or a background color.

--- a/Core/Source/DTTextBlock.m
+++ b/Core/Source/DTTextBlock.m
@@ -7,6 +7,7 @@
 //
 
 #import "DTTextBlock.h"
+#import "DTCoreText.h"
 
 @implementation DTTextBlock
 {

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -252,6 +252,8 @@
 		A7949AA314CC5BDF00A8CCDE /* DTHTMLAttributedStringBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A7949A4614CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.m */; };
 		A7949AA514CD3C5D00A8CCDE /* DTHTMLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = A7949A4914CAF5A300A8CCDE /* DTHTMLParser.m */; };
 		A7949AA614CD3C5E00A8CCDE /* DTHTMLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = A7949A4914CAF5A300A8CCDE /* DTHTMLParser.m */; };
+		A7A672BA1532F2D100920A18 /* DTCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A672B91532F2D100920A18 /* DTCompatibility.h */; };
+		A7A672BB1532F2D100920A18 /* DTCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A672B91532F2D100920A18 /* DTCompatibility.h */; };
 		A7A95D9514F3F45E002E3F7E /* LineHeight.html in Resources */ = {isa = PBXBuildFile; fileRef = A7A95D9414F3F45E002E3F7E /* LineHeight.html */; };
 		A7A95D9714F3F496002E3F7E /* LineHeight.html in Resources */ = {isa = PBXBuildFile; fileRef = A7A95D9414F3F45E002E3F7E /* LineHeight.html */; };
 		A7B0B56814D9921F0091C2C9 /* NSAttributedString+DTCoreText.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B0B56614D9921F0091C2C9 /* NSAttributedString+DTCoreText.h */; };
@@ -509,6 +511,7 @@
 		A7949A6D14CC45B400A8CCDE /* MacUnitTest-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "MacUnitTest-Info.plist"; sourceTree = "<group>"; };
 		A7949A6E14CC45B500A8CCDE /* MacUnitTest-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MacUnitTest-Prefix.pch"; sourceTree = "<group>"; };
 		A7949A9C14CC565F00A8CCDE /* DTCoreTextConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = DTCoreTextConstants.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		A7A672B91532F2D100920A18 /* DTCompatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DTCompatibility.h; path = Core/Source/DTCompatibility.h; sourceTree = "<group>"; };
 		A7A95D9414F3F45E002E3F7E /* LineHeight.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = LineHeight.html; sourceTree = "<group>"; };
 		A7B0B56614D9921F0091C2C9 /* NSAttributedString+DTCoreText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSAttributedString+DTCoreText.h"; sourceTree = "<group>"; };
 		A7B0B56714D9921F0091C2C9 /* NSAttributedString+DTCoreText.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSAttributedString+DTCoreText.m"; sourceTree = "<group>"; };
@@ -715,6 +718,7 @@
 			isa = PBXGroup;
 			children = (
 				A70B4C9E1486558200873A4A /* DTCoreText.h */,
+				A7A672B91532F2D100920A18 /* DTCompatibility.h */,
 				A788CA1514863EC600E1AFD9 /* DTCoreText-Prefix.pch */,
 				A788CA1614863EC600E1AFD9 /* DTCoreText-Info.plist */,
 				A788C90D14863E8700E1AFD9 /* Source */,
@@ -965,6 +969,7 @@
 				A7B0B56814D9921F0091C2C9 /* NSAttributedString+DTCoreText.h in Headers */,
 				A760F54114F56E9000AD1B0E /* DTImage+HTML.h in Headers */,
 				A7081EA315036460002987F1 /* DTTextBlock.h in Headers */,
+				A7A672BA1532F2D100920A18 /* DTCompatibility.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1010,6 +1015,7 @@
 				A70B4CA01486558200873A4A /* DTCoreText.h in Headers */,
 				A760F54014F56E8E00AD1B0E /* DTImage+HTML.h in Headers */,
 				A7081EA415036460002987F1 /* DTTextBlock.h in Headers */,
+				A7A672BB1532F2D100920A18 /* DTCompatibility.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
to fix import cycle `#import "DTCoreText.h"` --> `#import "DTTextBlock.h"` --> `#import "DTCoreText.h"`.
