### PR TITLE
Need __block for ios4 for block weak ref in DTAttributedTextContentView.m

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -660,7 +660,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 					
 					if (_delegateFlags.delegateSupportsNotificationBeforeTextBoxDrawing)
 					{
-						__weak DTAttributedTextContentView *weakself = self;
+						__block __weak DTAttributedTextContentView *weakself = self;
 						
 						[_layoutFrame setTextBlockHandler:^(DTTextBlock *textBlock, CGRect frame, CGContextRef context, BOOL *shouldDrawDefaultBackground) {
 							BOOL result = [weakself->_delegate attributedTextContentView:weakself shouldDrawBackgroundForTextBlock:textBlock frame:frame context:context forLayoutFrame:weakself->_layoutFrame];


### PR DESCRIPTION
Just look up some information about arc library used in non-arc, and found __block is need in ios4 since __weak is not supported in ios4.  Sorry to split the issue to two pull request
