### PR TITLE
Fix missing user header search paths

### DIFF
--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -1783,6 +1783,7 @@
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				SDKROOT = iphoneos;
+				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\"";
 			};
 			name = Debug;
 		};
@@ -1804,6 +1805,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
+				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\"";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Missing header search paths causes indexer failures not apparent in Xcode (but can be viewed in the Console) - see my SO answer here for more details - http://stackoverflow.com/a/10245076/123632

Signed-off-by: Ashley Mills (Air) ashleymills@mac.com
