### PR TITLE
Fixed memory leak if the characters exceed the boundary of the drawing frame

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -396,6 +396,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		if (lineBottom>maxY)
 		{
 			// doesn't fit any more
+			CFRelease(line);
 			break;
 		}
 		


### PR DESCRIPTION
Fixed memory leak if the characters exceed the boundary of the drawing frame
