### PR TITLE
Resolves issue #195, justification of the final line of paragraphs.

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -170,7 +170,6 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		}
 		
 		BOOL isAtBeginOfParagraph = (currentParagraphRange.location == lineRange.location);
-		BOOL isAtEndOfParagraph    = (currentParagraphRange.location+currentParagraphRange.length == lineRange.location-1);
 		
 		CGFloat offset = 0;
 		
@@ -375,7 +374,11 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 				
 			case kCTJustifiedTextAlignment:
 			{
-				// only justify if not last line and if the line widht is longer than 60% of the frame to avoid over-stretching
+				BOOL isAtEndOfParagraph    = (currentParagraphRange.location+currentParagraphRange.length <= lineRange.location+lineRange.length || 		// JTL 28/June/2012
+					[[_attributedStringFragment string] characterAtIndex:lineRange.location+lineRange.length-1]==0x2028);									// JTL 28/June/2012
+
+				// only justify if not last line, not <br>, and if the line width is longer than 60% of the frame
+				// avoids over-stretching
 				if( !isAtEndOfParagraph && (currentLineMetrics.width > 0.60 * _frame.size.width) ) 
 				{
 					// create a justified line and replace the current one with it


### PR DESCRIPTION
Justify is still justifying the last line of some paragraphs, despite
pull request #180/ issue #179.

There are two bugs. First, the calculation of isAtEndOfParagraph on
line 172 of DTCoreTextLayoutFrame.m is wrong, checking to see if the
line starts at the end of the paragraph. Second, a br doesn't end the
paragraph but should suppress justification as if it was the end of the
paragraph.

Both issues are solved with this change.
