### PR TITLE
URL encode src attributes

### DIFF
--- a/Core/Source/DTTextAttachment.m
+++ b/Core/Source/DTTextAttachment.m
@@ -103,6 +103,11 @@
 		{
 			contentURL = [NSURL URLWithString:src];
 			
+			if(!contentURL){
+				src = [src stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+				contentURL = [NSURL URLWithString:src relativeToURL:baseURL];
+			}
+			
 			if (![contentURL scheme])
 			{
 				// possibly a relative url


### PR DESCRIPTION
When making requests to load attachments, URL must be encoded.
