### PR TITLE
Truncation support so DTAttributedTextContentView subclasses can  used like UILabels

### DIFF
--- a/Core/Source/DTAttributedTextContentView.h
+++ b/Core/Source/DTAttributedTextContentView.h
@@ -103,6 +103,8 @@
 	UIEdgeInsets _edgeInsets;
 	
 	NSMutableDictionary *customViewsForAttachmentsIndex;
+
+	BOOL _flexibleHeight;
 }
 
 - (id)initWithAttributedString:(NSAttributedString *)attributedString width:(CGFloat)width;

--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -95,6 +95,8 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	// DTLinkButton set this property to NO and create a highlighted version of the attributed string
 	_shouldDrawLinks = YES;
 	
+	_flexibleHeight = YES;
+
 	// possibly already set in NIB
 	if (!self.backgroundColor)
 	{
@@ -671,8 +673,11 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 				if (theLayouter)
 				{
 					CGRect rect = UIEdgeInsetsInsetRect(self.bounds, _edgeInsets);
-					rect.size.height = CGFLOAT_OPEN_HEIGHT; // necessary height set as soon as we know it.
-					
+					if (_flexibleHeight)
+					{
+						rect.size.height = CGFLOAT_OPEN_HEIGHT; // necessary height set as soon as we know it.
+					}
+
 					_layoutFrame = [theLayouter layoutFrameWithRect:rect range:NSMakeRange(0, 0)];
 					
 					if (_delegateFlags.delegateSupportsNotificationBeforeTextBoxDrawing)

--- a/Core/Source/DTCoreTextLayoutFrame.h
+++ b/Core/Source/DTCoreTextLayoutFrame.h
@@ -282,4 +282,27 @@ typedef void (^DTCoreTextLayoutFrameTextBlockHandler)(DTTextBlock *textBlock, CG
  */
 + (void)setShouldDrawDebugFrames:(BOOL)debugFrames;
 
+
+/**
+ @name Truncation
+ */
+
+
+/**
+ Maximum number of lines to display before truncation.  Default is 0 which indicates no limit.
+ */
+@property(nonatomic, assign) NSInteger numberOfLines;
+
+
+/**
+ Line break mode used to indicate how truncation should occur
+ */
+@property(nonatomic, assign) NSLineBreakMode lineBreakMode;
+
+
+/**
+ Optional attributed string tu use as truncation indicator.  If nil, will use "…" w/ attributes taken from text being truncated
+ */
+@property(nonatomic, strong)NSAttributedString *truncationString;
+
 @end


### PR DESCRIPTION
DTCoreTextLayoutFrame - added truncation support w/ attributed truncation string

DTAttributedTextContentView - added flag to disable automatic height adjustment. This allow us to subclass, disable resizing, enable truncation, and have a DTAttributedTextContentView that behaves like a UILabel.

Change-Id: Ibb3231c3c58f2650f9358a5e8297ab45b7d792d6
