### PR TITLE
Doc fixes

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -25,7 +25,7 @@ typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
 /**
  Initializes and returns a new `NSAttributedString` object from the HTML contained in the given object and base URL.
  @param data The data in HTML format from which to create the attributed string.
- @param options Specifies how the document should be loaded. Contains values described in “Option keys for importing documents.” 
+ @param options Specifies how the document should be loaded. Contains values described in NSAttributedString(HTML).
  @param docAttributes Currently not in used.
  @returns Returns an initialized object, or `nil` if the data can’t be decoded.
  */

--- a/Core/Source/NSAttributedString+HTML.h
+++ b/Core/Source/NSAttributedString+HTML.h
@@ -57,7 +57,7 @@
  - DTWillFlushBlockCallBack: a block to be executed whenever content is flushed to the output string
 
  @param data The data in HTML format from which to create the attributed string.
- @param options Specifies how the document should be loaded. Contains values described in “Option keys for importing documents.” 
+ @param options Specifies how the document should be loaded.
  @param docAttributes Currently not in used.
  @returns Returns an initialized object, or `nil` if the data can’t be decoded.
  */


### PR DESCRIPTION
- Add doc line for DTDefaultFontSize
- Add reference to NSAttributedString(HTML) in DTHTMLAttributedStringBuilder docs.  I'm not 100% sure this is correct but it _seems_ correct...
