### PR TITLE
Changed import of NSData+Base64.h to use DTFoundation library

### DIFF
--- a/Core/Source/DTTextAttachment.m
+++ b/Core/Source/DTTextAttachment.m
@@ -10,7 +10,7 @@
 #import "DTCoreText.h"
 #import "DTUtils.h"
 
-#import "NSData+Base64.h"
+#import <DTFoundation/NSData+Base64.h>
 
 static NSCache *imageCache = nil;
 


### PR DESCRIPTION
Changed import of NSData+Base64.h to use DTFoundation library in order to prevent collision with other Base64 libs that are used in other projects.
