### PR TITLE
Don't save the current context when drawing shadows.

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -731,6 +731,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		}
 	}
 	
+	offset.width -= 10000;
 	CGContextSetShadowWithColor(context, offset, blur, color.CGColor);
 }
 
@@ -1136,7 +1137,10 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 				
 				if (shadows)
 				{
-					CGContextBeginTransparencyLayer(context, nil);
+					CGContextSaveGState(context);
+          
+          // Move the text 10000pt away from the current position so that on the shadow is visisble
+          CGContextSetTextPosition(context, textPosition.x + 10000, textPosition.y);
 					
 					for (NSDictionary *shadowDict in shadows)
 					{
@@ -1144,8 +1148,9 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 						
 						[oneRun drawInContext:context];
 					}
-					
-					CGContextEndTransparencyLayer(context);
+          
+          CGContextSetTextPosition(context, textPosition.x, textPosition.y);
+					CGContextRestoreGState(context);
 				}
 				
 				// regular text


### PR DESCRIPTION
Honestly, I don't know enough to know exactly what is going on. But it seems that because `drawInContext:context` is being called for every shadow, and then again for the actual text.

I removed the Save/Restore context, and then draw the text and shadow all at once. It fixes #344 and after trying the DemoApp, everything looks fine.
