### PR TITLE
Only force 'Times New Roman' font for bullet types not textual list types

### DIFF
--- a/Core/Source/DTHTMLElementLI.m
+++ b/Core/Source/DTHTMLElementLI.m
@@ -48,9 +48,14 @@
 	DTHTMLElementLI *tmpCopy = [[DTHTMLElementLI alloc] init];
 	[tmpCopy inheritAttributesFromElement:self];
 	
-	// force bullet font to be Times New Roman because iOS 6 has a larger level 3 bullet
-	tmpCopy.fontDescriptor = listRoot.fontDescriptor;
-	tmpCopy.fontDescriptor.fontFamily = @"Times New Roman";
+	DTCSSListStyleType type = listRoot.listStyle.type;
+    // Only force Times New Roman if bullet types
+    if (type == DTCSSListStyleTypeCircle || type == DTCSSListStyleTypeSquare || type == DTCSSListStyleTypeDisc)
+    {
+        // force bullet font to be Times New Roman because iOS 6 has a larger level 3 bullet
+        tmpCopy.fontDescriptor = listRoot.fontDescriptor;
+        tmpCopy.fontDescriptor.fontFamily = @"Times New Roman";
+    }
 	
 	// take the parents text color
 	tmpCopy.textColor = listRoot.textColor;


### PR DESCRIPTION
Ordered lists should not be forced to use 'Times New Roman' font.
