### PR TITLE
More efficient solution to line truncation in DTAttributedLabel, bug fixes in DTCoreTextLayoutFrame

### DIFF
--- a/Core/Source/DTAttributedLabel.m
+++ b/Core/Source/DTAttributedLabel.m
@@ -18,17 +18,6 @@
 	return [CALayer class];
 }
 
-- (DTCoreTextLayoutFrame *)layoutFrame
-{
-    self.layoutFrameHeightIsConstrainedByBounds = YES; // height is not flexible
-	DTCoreTextLayoutFrame * layoutFrame = [super layoutFrame];
-    layoutFrame.numberOfLines = self.numberOfLines;
-    layoutFrame.lineBreakMode = self.lineBreakMode;
-    layoutFrame.truncationString = self.truncationString;
-	layoutFrame.noLeadingOnFirstLine = YES;
-	return layoutFrame;
-}
-
 - (id)initWithFrame:(CGRect)frame
 {
 	self = [super initWithFrame:frame];
@@ -37,6 +26,9 @@
 	{
 		// we want to relayout the text if height or width change
 		self.relayoutMask = DTAttributedTextContentViewRelayoutOnHeightChanged | DTAttributedTextContentViewRelayoutOnWidthChanged;
+		
+		self.layoutFrameHeightIsConstrainedByBounds = YES; // height is not flexible
+		self.shouldAddFirstLineLeading = NO;
 	}
 	
 	return self;
@@ -57,6 +49,11 @@
 
 #pragma mark - Properties 
 
+- (NSInteger)numberOfLines
+{
+	return _numberOfLines;
+}
+
 - (void)setNumberOfLines:(NSInteger)numberOfLines
 {
     if (numberOfLines != _numberOfLines)
@@ -64,6 +61,11 @@
         _numberOfLines = numberOfLines;
         [self relayoutText];
     }
+}
+
+- (NSLineBreakMode)lineBreakMode
+{
+	return _lineBreakMode;
 }
 
 - (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode
@@ -75,17 +77,19 @@
     }
 }
 
-- (void)setTruncationString:(NSAttributedString *)trunctionString
+- (NSAttributedString*)truncationString
 {
-    if (trunctionString != _truncationString)
+	return _truncationString;
+}
+
+- (void)setTruncationString:(NSAttributedString *)truncationString
+{
+    if (![truncationString isEqualToAttributedString:_truncationString])
     {
-        _truncationString = trunctionString;
+        _truncationString = truncationString;
         [self relayoutText];
     }
 }
 
-@synthesize numberOfLines = _numberOfLines;
-@synthesize lineBreakMode = _lineBreakMode;
-@synthesize truncationString = _truncationString;
 
 @end

--- a/Core/Source/DTAttributedTextContentView.h
+++ b/Core/Source/DTAttributedTextContentView.h
@@ -129,6 +129,11 @@ typedef NSUInteger DTAttributedTextContentViewRelayoutMask;
 	NSMutableDictionary *customViewsForAttachmentsIndex;
 	
 	BOOL _flexibleHeight;
+	
+	// for layoutFrame
+	NSInteger _numberOfLines;
+	NSLineBreakMode _lineBreakMode;
+	NSAttributedString *_truncationString;
 }
 
 

--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -574,6 +574,11 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	CGRect rect = [self _frameForLayoutFrameConstraintedToWidth:width];
 	DTCoreTextLayoutFrame *tmpLayoutFrame = [self.layouter layoutFrameWithRect:rect range:NSMakeRange(0, 0)];
 	
+	// assign current layout frame properties to tmpLayoutFrame
+	tmpLayoutFrame.numberOfLines = _numberOfLines;
+	tmpLayoutFrame.lineBreakMode = _lineBreakMode;
+	tmpLayoutFrame.truncationString = _truncationString;
+	
 	//  we have a layout frame and from this we get the needed size
 	return CGSizeMake(tmpLayoutFrame.frame.size.width + _edgeInsets.left + _edgeInsets.right, CGRectGetMaxY(tmpLayoutFrame.frame) + _edgeInsets.bottom);
 }
@@ -772,6 +777,9 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 				
 				_layoutFrame = [theLayouter layoutFrameWithRect:rect range:NSMakeRange(0, 0)];
 				_layoutFrame.noLeadingOnFirstLine = !_shouldAddFirstLineLeading;
+				_layoutFrame.numberOfLines = _numberOfLines;
+				_layoutFrame.lineBreakMode = _lineBreakMode;
+				_layoutFrame.truncationString = _truncationString;
 
 				// this must have been the initial layout pass
 				CGSize neededSize = CGSizeMake(_layoutFrame.frame.size.width + _edgeInsets.left + _edgeInsets.right, CGRectGetMaxY(_layoutFrame.frame) + _edgeInsets.bottom);


### PR DESCRIPTION
Bug fixes in DTCoreTextLayoutFrame :
- paragraphRanges was not properly calculated when a string isn't ended with '\n'
- uninitialized variable baseWritingDirection in [DTCoreTextLayoutFrame_buildLinesWithTypesetter] so for a attributed strings without paragraph style (by ex. created with [NSAttributedString initWithString:] ) lines were rendered wrong
