### PR TITLE
Fix textAttachmentsWithPredicate:nil returning nil

### DIFF
--- a/Core/Source/NSAttributedString+DTCoreText.m
+++ b/Core/Source/NSAttributedString+DTCoreText.m
@@ -28,7 +28,7 @@
 		
 		if (attachment)
 		{
-			if ([predicate evaluateWithObject:attachment])
+			if (predicate == nil || [predicate evaluateWithObject:attachment])
 			{
 				[tmpArray addObject:attachment];
 			}


### PR DESCRIPTION
Documentation says passing nil returns all attachments, but was returning nil.  This fixes that issue.
