### PR TITLE
Assign another missing property to DTCoreTextLayoutFrame when calculating needed height in constrained width

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -578,6 +578,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	tmpLayoutFrame.numberOfLines = _numberOfLines;
 	tmpLayoutFrame.lineBreakMode = _lineBreakMode;
 	tmpLayoutFrame.truncationString = _truncationString;
+	tmpLayoutFrame.noLeadingOnFirstLine = !_shouldAddFirstLineLeading;
 	
 	//  we have a layout frame and from this we get the needed size
 	return CGSizeMake(tmpLayoutFrame.frame.size.width + _edgeInsets.left + _edgeInsets.right, CGRectGetMaxY(tmpLayoutFrame.frame) + _edgeInsets.bottom);


### PR DESCRIPTION
- (CGSize)suggestedFrameSizeToFitEntireStringConstraintedToWidth:(CGFloat)width
- assign another missing property to DTCoreTextLayoutFrame when calculating needed height in constrained width (noLeadingOnFirstLine)
