### PR TITLE
Added “dir=auto” to HTML output for natural writing direction

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -593,7 +593,8 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		lineOrigin.y = _frame.size.height - lineOrigin.y + _frame.origin.y;
 		lineOrigin.x += _frame.origin.x;
 		
-		DTCoreTextLayoutLine *newLine = [[DTCoreTextLayoutLine alloc] initWithLine:(__bridge CTLineRef)oneLine];		newLine.baselineOrigin = lineOrigin;
+		DTCoreTextLayoutLine *newLine = [[DTCoreTextLayoutLine alloc] initWithLine:(__bridge CTLineRef)oneLine];
+		newLine.baselineOrigin = lineOrigin;
 		
 		[tmpLines addObject:newLine];
 		

--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -384,19 +384,28 @@
 			}
 		}
 		
+		// Add dir="auto" if the writing direction is unknown
+		NSString *directionAttributeString = @"";
+		if (paraStyle)
+		{
+			DTCoreTextParagraphStyle *para = [DTCoreTextParagraphStyle paragraphStyleWithCTParagraphStyle:paraStyle];
+			if (para.baseWritingDirection == kCTWritingDirectionNatural)
+				directionAttributeString = @" dir=\"auto\"";
+		}
+		
 		if ([paraStyleString length])
 		{
 			NSString *className = [self _styleClassForElement:blockElement style:paraStyleString];
 			
 			if (fragment) {
-				[retString appendFormat:@"<%@ style=\"%@\">", blockElement, paraStyleString];
+				[retString appendFormat:@"<%@ style=\"%@\"%@>", blockElement, paraStyleString, directionAttributeString];
 			} else {
-				[retString appendFormat:@"<%@ class=\"%@\">", blockElement, className];
+				[retString appendFormat:@"<%@ class=\"%@\"%@>", blockElement, className, directionAttributeString];
 			}
 		}
 		else
 		{
-			[retString appendFormat:@"<%@>", blockElement];
+			[retString appendFormat:@"<%@%@>", blockElement, directionAttributeString];
 		}
 		
 		// add the attributed string ranges in this paragraph to the paragraph container


### PR DESCRIPTION
The additional attribute “dir=auto” is only added to HTML elements with an undefined writing direction (“natural”), e.g. for Arabic or Hebrew.
