### PR TITLE
Fixes an issue where URLs with https would be treated as an external URL

### DIFF
--- a/Core/Source/DTWebVideoView.m
+++ b/Core/Source/DTWebVideoView.m
@@ -78,13 +78,13 @@
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
 	// allow the embed request for YouTube
-	if ([[[request URL] absoluteString] hasPrefix:@"http://www.youtube.com/embed/"])
+	if (NSNotFound != [[[request URL] absoluteString] rangeOfString:@"www.youtube.com/embed/"].location)
 	{
 		return YES;
 	}
 
 	// allow the embed request for DailyMotion Cloud
-	if ([[[request URL] absoluteString] hasPrefix:@"http://api.dmcloud.net/player/embed/"])
+	if (NSNotFound != [[[request URL] absoluteString] rangeOfString:@"api.dmcloud.net/player/embed/"].location)
 	{
 		return YES;
 	}


### PR DESCRIPTION
If a video URL's protocol is https, it is treated as an external URL.  (Oh Noes!)
This patch checks the URL's absoluteString for a matching sub-string of the service's domain + path to avoid being tripped up by an unexpected protocol.
