### PR TITLE
DTAttributedLabel: fix NIB usage and edge insets

### DIFF
--- a/Core/Source/DTAttributedLabel.m
+++ b/Core/Source/DTAttributedLabel.m
@@ -18,20 +18,31 @@
 	return [CALayer class];
 }
 
+- (void) setupAttributedLabel
+{
+	// we want to relayout the text if height or width change
+	self.relayoutMask = DTAttributedTextContentViewRelayoutOnHeightChanged | DTAttributedTextContentViewRelayoutOnWidthChanged;
+	
+	self.layoutFrameHeightIsConstrainedByBounds = YES; // height is not flexible
+	self.shouldAddFirstLineLeading = NO;
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
 	self = [super initWithFrame:frame];
 	
 	if (self)
 	{
-		// we want to relayout the text if height or width change
-		self.relayoutMask = DTAttributedTextContentViewRelayoutOnHeightChanged | DTAttributedTextContentViewRelayoutOnWidthChanged;
-		
-		self.layoutFrameHeightIsConstrainedByBounds = YES; // height is not flexible
-		self.shouldAddFirstLineLeading = NO;
+		[self setupAttributedLabel];
 	}
 	
 	return self;
+}
+
+- (void) awakeFromNib
+{
+	[super awakeFromNib];
+	[self setupAttributedLabel];
 }
 
 #pragma mark - Sizing


### PR DESCRIPTION
This PR fixes two issues in DTAttributedLabel.
- The initialization code is not executed when a DTAttributedLabel is unarchived from a NIB.
- The `intrisicContentSize` doesn't account for the `edgeInsets` when returning the expected size of the label.
