### PR TITLE
Adds support for arbitrary HTML attributes to NSAttributedString+HTML

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -68,6 +68,7 @@ extern NSString * const DTShadowsAttribute;
 extern NSString * const DTHorizontalRuleStyleAttribute;
 extern NSString * const DTTextBlocksAttribute;
 extern NSString * const DTFieldAttribute;
+extern NSString * const DTHTMLAttributesAttribute;
 
 // field constants
 

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -41,6 +41,7 @@ NSString * const DTShadowsAttribute = @"DTShadows";
 NSString * const DTHorizontalRuleStyleAttribute = @"DTHorizontalRuleStyle";
 NSString * const DTTextBlocksAttribute = @"DTTextBlocks";
 NSString * const DTFieldAttribute = @"DTField";
+NSString * const DTHTMLAttributesAttribute = @"DTHTMLAttributes";
 
 // field constants
 NSString * const DTListPrefixField = @"{listprefix}";

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -368,6 +368,14 @@ NSDictionary *_classesForNames = nil;
 				}
 				
 				NSAttributedString *nodeString = [oneChild attributedString];
+
+				//Keep all HTML attributes on the attributed string when parsing so we can write them out when going to HTML
+				if (oneChild.attributes)
+				{
+					NSMutableAttributedString *mutableNodeString = [[NSMutableAttributedString alloc] initWithAttributedString:nodeString];
+					[mutableNodeString addAttribute:DTHTMLAttributesAttribute value:[oneChild.attributes mutableCopy] range:NSMakeRange(0, nodeString.length)];
+					nodeString = mutableNodeString;
+				}
 				
 				if (nodeString)
 				{
@@ -382,6 +390,7 @@ NSDictionary *_classesForNames = nil;
 							}
 						}
 					}
+					
 					
 					[tmpString appendAttributedString:nodeString];
 				}

--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -613,6 +613,24 @@
 				}
 			}
 			
+			//Generate attribute string if any HTML attributes are present on the range in question
+			NSString *attributeString = @"";
+			NSDictionary *htmlAttributes = [attributes objectForKey:DTHTMLAttributesAttribute];
+			if (htmlAttributes && htmlAttributes.count)
+			{
+				NSMutableArray *htmlAttributesArray = [NSMutableArray arrayWithCapacity:htmlAttributes.count];
+				for (NSString *attributeName in htmlAttributes.allKeys)
+				{
+					//TODO: Need a better way to "skip" attributes already handled by writing HTML
+					//Allow the "class" attribute if we're writing fragments. This is useful when writing HTML editors that use classes for special style features.
+					if (![attributeName isEqualToString:@"style"] && ![attributeName isEqualToString:@"dir"] && ![attributeName isEqualToString:@"href"] && (![attributeName isEqualToString:@"class"] || fragment))
+					{
+						[htmlAttributesArray addObject:[NSString stringWithFormat:@"%@=\"%@\"", attributeName, htmlAttributes[attributeName]]];
+					}
+				}
+				attributeString = [htmlAttributesArray componentsJoinedByString:@" "];
+			}
+			
 			NSURL *url = [attributes objectForKey:DTLinkAttribute];
 			
 			if (url)
@@ -622,14 +640,14 @@
 					NSString *className = [self _styleClassForElement:@"a" style:fontStyle];
 					
 					if (fragment) {
-						[retString appendFormat:@"<a style=\"%@\" href=\"%@\">%@</a>", fontStyle, [url relativeString], subString];
+						[retString appendFormat:@"<a style=\"%@\" href=\"%@\" %@>%@</a>", fontStyle, [url relativeString], attributeString, subString];
 					} else {
-						[retString appendFormat:@"<a class=\"%@\" href=\"%@\">%@</a>", className, [url relativeString], subString];
+						[retString appendFormat:@"<a class=\"%@\" href=\"%@\" %@>%@</a>", className, [url relativeString], attributeString, subString];
 					}
 				}
 				else
 				{
-					[retString appendFormat:@"<a href=\"%@\">%@</a>", [url relativeString], subString];
+					[retString appendFormat:@"<a href=\"%@\" %@>%@</a>", [url relativeString], attributeString, subString];
 				}
 			}
 			else
@@ -640,11 +658,11 @@
 					
 					if (fragment)
 					{
-						[retString appendFormat:@"<span style=\"%@\">%@</span>", fontStyle, subString];
+						[retString appendFormat:@"<span style=\"%@\" %@>%@</span>", fontStyle, attributeString, subString];
 					}
 					else
 					{
-						[retString appendFormat:@"<span class=\"%@\">%@</span>", className, subString];
+						[retString appendFormat:@"<span class=\"%@\" %@>%@</span>", className, attributeString, subString];
 					}
 				}
 				else

--- a/Core/Source/NSMutableAttributedString+HTML.h
+++ b/Core/Source/NSMutableAttributedString+HTML.h
@@ -25,8 +25,15 @@
 /** 
  Appends a string with a given paragraph style and font to this string. 
  @param string The string to be appended to this string.
- @param paragraphStyle Paragraph style to be attributed to the appended string. 
+ @param paragraphStyle Paragraph style to be attributed to the appended string.
  @param fontDescriptor Font descriptor to be attributed to the appended string. */
 - (void)appendString:(NSString *)string withParagraphStyle:(DTCoreTextParagraphStyle *)paragraphStyle fontDescriptor:(DTCoreTextFontDescriptor *)fontDescriptor;
+
+/**
+ Adds an HTML attribute with the given name and value to the characters in the specified range. The attribute is written DTHTMLWriter when writing HTML.
+ @param A string specifying the HTML attribute name. For example "target" or "title."
+ @param The attribute value associated with name.
+ @param The range of characters to which the specified attribute/value pair applies. */
+- (void)addHTMLAttribute:(NSString *)name value:(id)value range:(NSRange)aRange;
 
 @end

--- a/Core/Source/NSMutableAttributedString+HTML.m
+++ b/Core/Source/NSMutableAttributedString+HTML.m
@@ -12,6 +12,23 @@
 
 @implementation NSMutableAttributedString (HTML)
 
+- (void)addHTMLAttribute:(NSString *)name value:(id)value range:(NSRange)aRange {
+	if (name == nil)
+	{
+		return;
+	}
+
+	NSDictionary *allAttributes = [self attributesAtIndex:aRange.location longestEffectiveRange:NULL inRange:aRange];
+	NSMutableDictionary *htmlAttributes = [NSMutableDictionary dictionaryWithDictionary:allAttributes[DTHTMLAttributesAttribute]];
+
+	if (value == nil)
+	{
+		[htmlAttributes removeObjectForKey:name];
+	} else {
+		htmlAttributes[name] = value;
+		[self addAttribute:DTHTMLAttributesAttribute value:htmlAttributes range:aRange];
+	}
+}
 
 // appends a plain string extending the attributes at this position
 - (void)appendString:(NSString *)string

--- a/Core/Test/Source/NSAttributedStringHTMLTest.m
+++ b/Core/Test/Source/NSAttributedStringHTMLTest.m
@@ -8,10 +8,11 @@
 
 #import "NSAttributedStringHTMLTest.h"
 #import "NSAttributedString+HTML.h"
-
 #import "NSAttributedString+DTCoreText.h"
 
 #import "DTHTMLAttributedStringBuilder.h"
+
+#import "DTCoreTextConstants.h"
 
 @implementation NSAttributedStringHTMLTest
 
@@ -153,6 +154,18 @@
 	
 	STAssertEqualObjects(resultOnIOS, resultOnMac, @"Output on Invalid Tag Test differs");
 	
+}
+
+- (void)testParseHTMLAttributes {
+	NSString *html = @"<span><a href=\"http://cocoanetics.com\" title=\"Cocoanetics Website\" target=\"_blank\">Cocoanetics</a></span>";
+	NSAttributedString *string = [self attributedStringFromHTML:html];
+	NSDictionary *attributes = [string attributesAtIndex:0 longestEffectiveRange:NULL inRange:NSMakeRange(0, string.length - 1)];
+	NSDictionary *htmlAttributes = attributes[DTHTMLAttributesAttribute];
+
+	STAssertTrue(htmlAttributes.count == 3, @"Parsed the wrong number of attributes");
+	STAssertEqualObjects(htmlAttributes[@"href"], @"http://cocoanetics.com", @"href attribute was not property parsed");
+	STAssertEqualObjects(htmlAttributes[@"title"], @"Cocoanetics Website", @"target attribute was not property parsed");
+	STAssertEqualObjects(htmlAttributes[@"target"], @"_blank", @"blank attribute was not property parsed");
 }
 
 /*


### PR DESCRIPTION
New pull request with the cherry-picked commit. I couldn't figure out how to amend the other pull request.

DTHTMLElement now keeps HTML attributes in a dictionary in NSAttributedString's attributes. The idea is to segregate HTML attributes from general attributes.

This is useful when building an editor that mimics web-based editors that provide classes or special attributes to style elements. Another use is setting attributes like "target" or "title" on links based on UI.

These attributes are written out, with a few exceptions, by DTHTMLWriter. I'm not entirely happy with how I currently filter in DTHTMLWriter so please give feedback on that if you like. I'm also not sure my list is all encompassing (e.g. "src" attribute on images).

The class attribute is only written if DTHTMLWriter is asked to generate an HTML fragment so as not to stomp on the class attribute it generates in document mode.

I also added a single test to make sure parsing happened.
