### PR TITLE
added support for soft hyphens

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -240,8 +240,21 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		CTLineRef line;
 		if(!truncateLine)
 		{
-			// create a line to fit
-			line = CTTypesetterCreateLine(typesetter, CFRangeMake(lineRange.location, lineRange.length));
+            static const unichar softHypen = 0x00AD;
+            NSString *lineString = [[_attributedStringFragment attributedSubstringFromRange:lineRange] string];
+            unichar lastChar = [lineString characterAtIndex:[lineString length] - 1];
+            if (softHypen == lastChar)
+            {
+                NSMutableAttributedString *hyphenatedString = [[_attributedStringFragment attributedSubstringFromRange:lineRange] mutableCopy];
+                NSRange replaceRange = NSMakeRange(hyphenatedString.length - 1, 1);
+                [hyphenatedString replaceCharactersInRange:replaceRange withString:@"-"];
+                line = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)hyphenatedString);
+            }
+            else
+            {
+                // create a line to fit
+                line = CTTypesetterCreateLine(typesetter, CFRangeMake(lineRange.location, lineRange.length));
+            }
 		}
 		else
 		{


### PR DESCRIPTION
i read about the hyphenation problems with licensing so i know that including the complete mechanism is not an option.
but when rendering the string one could respect soft hyphens. i implemented this so it seems to work.

![screen shot 2013-06-13 at 11 29 42 pm](https://f.cloud.github.com/assets/155457/651294/65d3391e-d470-11e2-978f-222dd7655ef9.png)
