### PR TITLE
Variable Superscript / Subscript Offsets

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -70,6 +70,7 @@ extern NSString * const DTHorizontalRuleStyleAttribute;
 extern NSString * const DTTextBlocksAttribute;
 extern NSString * const DTFieldAttribute;
 extern NSString * const DTCustomAttributesAttribute;
+extern NSString * const DTAscentMultiplierAttribute;
 
 // field constants
 

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -43,6 +43,7 @@ NSString * const DTHorizontalRuleStyleAttribute = @"DTHorizontalRuleStyle";
 NSString * const DTTextBlocksAttribute = @"DTTextBlocks";
 NSString * const DTFieldAttribute = @"DTField";
 NSString * const DTCustomAttributesAttribute = @"DTCustomAttributes";
+NSString * const DTAscentMultiplierAttribute = @"DTAscentMultiplierAttribute";
 
 // field constants
 NSString * const DTListPrefixField = @"{listprefix}";

--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -1205,16 +1205,19 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 			
 			NSInteger superscriptStyle = [[oneRun.attributes objectForKey:(id)kCTSuperscriptAttributeName] integerValue];
 			
+			NSNumber *ascentMultiplier = [oneRun.attributes objectForKey:(id)DTAscentMultiplierAttribute];
+			
+
 			switch (superscriptStyle)
 			{
 				case 1:
 				{
-					textPosition.y += oneRun.ascent * 0.47f;
+					textPosition.y += oneRun.ascent * (ascentMultiplier ? [ascentMultiplier floatValue] : 0.47f);
 					break;
 				}
 				case -1:
 				{
-					textPosition.y -= oneRun.ascent * 0.25f;
+					textPosition.y -= oneRun.ascent * (ascentMultiplier ? [ascentMultiplier floatValue] : 0.25f);
 					break;
 				}
 				default:


### PR DESCRIPTION
Added DTAscentMultiplierAttribute to allow vertical placement control for superscript and subscript.

kCTSuperscriptAttributeName is still used to enable and specify super or sub-script
