### PR TITLE
Fix for spelling error in DTHTMLAttributedStringBuilder.h

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -45,7 +45,7 @@ typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
  
  @param data The data in HTML format from which to create the attributed string.
  @param options Specifies how the document should be loaded. Contains values described in NSAttributedString(HTML).
- @param docAttributes Currently not in used.
+ @param docAttributes Currently not in use.
  @returns Returns an initialized object, or `nil` if the data can’t be decoded.
  */
 - (id)initWithHTML:(NSData *)data options:(NSDictionary *)options documentAttributes:(NSDictionary **)docAttributes;


### PR DESCRIPTION
Found a spelling error in Core/Source/DTHTMLAttributedStringBuilder.h and fixed it.
