### PR TITLE
Return background-color as a string instead of an array

### DIFF
--- a/Core/Source/NSScanner+HTML.m
+++ b/Core/Source/NSScanner+HTML.m
@@ -99,18 +99,22 @@
 			
 			if ([self scanString:@"," intoString:&value])
 			{
+                BOOL isStringOnlyCSSProperty = NO;
+                
 				if (![value isEqualToString:@","])
 				{
 					[results addObject:value];
 				}
-				else if ([attrName isEqualToString:@"font"] || [attrName isEqualToString:@"color"] || [attrName isEqualToString:@"text-shadow"])
+				else if ([attrName isEqualToString:@"font"] || ([attrName rangeOfString:@"color"].location != NSNotFound) || ([attrName rangeOfString:@"shadow"].location != NSNotFound))
 				{
 					value = [NSString stringWithFormat:@"%@%@", [results lastObject], value];
 					[results removeLastObject];
 					[results addObject:value];
+                    
+                    isStringOnlyCSSProperty = YES;
 				}
 				
-				if ([value isEqualToString:@","] && ![attrName isEqualToString:@"font"] && ![attrName isEqualToString:@"color"] && ![attrName isEqualToString:@"text-shadow"])
+				if ([value isEqualToString:@","] && !isStringOnlyCSSProperty)
 				{
 					nextIterationAddsNewEntry = YES;
 				}

--- a/Core/Test/Source/NSStringCSSTest.m
+++ b/Core/Test/Source/NSStringCSSTest.m
@@ -187,4 +187,13 @@
 	STAssertTrue([color isKindOfClass:[NSString class]], @"shadow count should be a string");	
 }
 
+- (void)textBackgroundColor
+{
+	NSString *style = @"font-family:Helvetica;font-weight:bold;background-color:rgb(255, 88, 44);font-size:30px;";
+	NSDictionary *dictionary = [style dictionaryOfCSSStyles];
+	id color = dictionary[@"background-color"];
+	
+	STAssertEqualObjects(@"rgb(255, 0, 0)", color, @"Background color should be \"rgb(255, 88, 44)\"");
+}
+
 @end


### PR DESCRIPTION
Background-color was being returned as an array. It is now treated properly as a string. I applied a similar fix for shadow.

Sorry for missing this.
