### PR TITLE
check for unsigned int overflow

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -952,8 +952,15 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 			break;
 		}
 		
+        NSUInteger attributeIndex = index;
+		
+        if (attributeIndex > 0)
+        {
+            attributeIndex = attributeIndex - 1;
+        }
+		
 		NSRange effectiveRangeOfBlocksArray;
-		NSArray *textBlocks = [_attributedStringFragment attribute:DTTextBlocksAttribute atIndex:index-1 effectiveRange:&effectiveRangeOfBlocksArray];
+		NSArray *textBlocks = [_attributedStringFragment attribute:DTTextBlocksAttribute atIndex:attributeIndex effectiveRange:&effectiveRangeOfBlocksArray];
 		
 		// skip a range of empty blocks at start
 		if (!textBlocks)


### PR DESCRIPTION
Hi Oliver,

We found a crash that occurred when overflowing NSUInteger. When index is 0 and 1 is subtracted we get an overflow and subsequently an index oob when trying to view some content. I'm not sure where to put a test for this but I believe the offending HTML was simply:

```
<div dir="auto" style="margin-bottom:12px;"></div>
```

I'm not positive that HTML triggered the crash because tracking this down was pretty difficult and I don't have a lot to go on. I do know checking for the overflow fixed the issue.
