### PR TITLE
Cascade optimization issue

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -734,7 +734,7 @@ extern unsigned int default_css_len;
 	return _styles;
 }
 
-- (NSSet *)findPartialSelectorElementNamesForElement:(DTHTMLElement *)element
+- (NSSet *)findRelevantSelectorElementNamesForElement:(DTHTMLElement *)element
 {
     // NSSet has quick lookup time so it'll be our return type
     NSMutableSet *possibleElementNames = [NSMutableSet set];
@@ -761,7 +761,7 @@ extern unsigned int default_css_len;
 
 - (NSArray *)findAncestorSelectorArraysForElement:(DTHTMLElement *)element
 {
-    NSSet *possibleElementNames = [self findPartialSelectorElementNamesForElement:element];
+    NSSet *possibleElementNames = [self findRelevantSelectorElementNamesForElement:element];
 	
     // Walk up the heirarchy looking for parents with class attributes then compute cascades
 	NSMutableArray *ancestorSelectorArrays = [NSMutableArray array];


### PR DESCRIPTION
This speeds up cascade calculation tremendously if element names aren't heavily used in styles.

In my test case (a simple email campaign) with many styles but not many element name based styles) time to compute went from 1.851 seconds to 0.197 seconds.

In a much more complicated test case that used element name selectors heavily, time with this change went from 3.854 seconds to 3.92 seconds. On the average I think it's a huge improvement.

I'll look into further optimizations as I can.

The later test case is the following ridiculously long [HTML](http://s.amro.co/code/1h2h1J3Z1L3t). It was so long I couldn't embed it.

Edit: These times were recorded on an iPad Mini.
