### PR TITLE
Fix substring selectors being matched when cascading

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -785,10 +785,16 @@ extern unsigned int default_css_len;
 						}
 					} else if ([selectorPart characterAtIndex:0] == '.')
 					{
-						NSString *currentElementClassString = [currentElement.attributes objectForKey:@"class"];
-						if (currentElementClassString && ([currentElementClassString rangeOfString:[selectorPart substringFromIndex:1]].location != NSNotFound))
-						{
-							matched = YES;
+						NSString *currentElementClassesString = [currentElement.attributes objectForKey:@"class"];
+						NSArray *currentElementClasses = [currentElementClassesString componentsSeparatedByString:@" "];
+						for (NSString *currentElementClass in currentElementClasses) {
+							if ([currentElementClass isEqualToString:[selectorPart substringFromIndex:1]]) {
+								matched = YES;
+								break;
+							}
+						}
+						
+						if (matched) {
 							break;
 						}
 					} else if ([selectorPart isEqualToString:currentElement.name])

--- a/Core/Test/Source/DTHTMLAttributedStringBuilderTest.m
+++ b/Core/Test/Source/DTHTMLAttributedStringBuilderTest.m
@@ -730,4 +730,15 @@
 	STAssertEqualObjects(foreground1HTML, foreground2HTML, @"Color should be inherited via cascaded selector.");
 }
 
+- (void)testSubstringCascadedSelectorsBeingProperlyApplied
+{
+	NSString *html = @"<html><head><style> body .sample { color: red;} body .samples { color: green;}</style></head><body><div class=\"samples\">Text</div></html>";
+	NSAttributedString *output = [self _attributedStringFromHTMLString:html options:nil];
+	
+	NSDictionary *attributes = [output attributesAtIndex:1 effectiveRange:NULL];
+	DTColor *foreground = [attributes foregroundColor];
+	NSString *foregroundHTML = [foreground htmlHexString];
+	STAssertEqualObjects(foregroundHTML, @"008000", @"Color should be green and not red.");
+}
+
 @end


### PR DESCRIPTION
Fixes substring selectors being matched when cascading. Test included.
