### PR TITLE
Fixed glyphRyn has wrong stringRange for hyphenated lines

### DIFF
--- a/Core/Source/DTCoreTextGlyphRun.m
+++ b/Core/Source/DTCoreTextGlyphRun.m
@@ -351,7 +351,7 @@
 	{
 		CFRange range = CTRunGetStringRange(_run);
 
-		_stringRange = NSMakeRange(range.location, range.length);
+		_stringRange = NSMakeRange(range.location + _line.stringLocationOffset, range.length);
 	}
 	
 	return _stringRange;

--- a/Core/Source/DTCoreTextLayoutLine.h
+++ b/Core/Source/DTCoreTextLayoutLine.h
@@ -22,7 +22,6 @@
  */
 @interface DTCoreTextLayoutLine : NSObject
 {
-	NSInteger _stringLocationOffset; // offset to modify internal string location to get actual location
 }
 
 /**
@@ -188,6 +187,12 @@
  `YES` if the writing direction is Right-to-Left, otherwise `NO`
  */
 @property (nonatomic, assign) BOOL writingDirectionIsRightToLeft;
+
+/**
+ The offset to modify internal string location to get actual location
+*/
+
+@property (nonatomic, readonly) NSInteger stringLocationOffset;
 
 /**
  Method to efficiently determine if the receiver is a horizontal rule.

--- a/Core/Source/DTCoreTextLayoutLine.m
+++ b/Core/Source/DTCoreTextLayoutLine.m
@@ -534,4 +534,6 @@
 @synthesize baselineOrigin = _baselineOrigin;
 @synthesize writingDirectionIsRightToLeft = _writingDirectionIsRightToLeft;
 
+@synthesize stringLocationOffset = _stringLocationOffset;
+
 @end


### PR DESCRIPTION
If DTCoreTextLayoutLine has not zero stringLocationOffset (in case if a line was hyphenated), need to advance stringRange property of DTCoreTextGlyphRun by _line.stringLocationOffset. 
