### PR TITLE
Fix selector order on the mac

### DIFF
--- a/Core/Source/DTCSSStylesheet.h
+++ b/Core/Source/DTCSSStylesheet.h
@@ -78,4 +78,9 @@
  */
 - (NSDictionary *)styles;
 
+/**
+ Returns an ordered (by declaration) set of the selectors for all of the styles.
+ */
+- (NSOrderedSet *)orderedSelectors;
+
 @end

--- a/Core/Test/Resources/CSSCascading.html
+++ b/Core/Test/Resources/CSSCascading.html
@@ -41,7 +41,7 @@
 				color: purple;
 			}
 			
-			div div span .bling {
+			div div div .bling {
 				color: orange;
 			}
 			
@@ -49,7 +49,7 @@
 				color: #777;
 			}
 			
-			span .bling {
+			div .bling {
 				text-decoration: underline;
 			}
 			
@@ -69,7 +69,7 @@
 						<span id="blargh"> buzz <span class="zing  meow ">owzers</span></span>
 					</div>
 					<span style="color:red;">Me<span class="bing">ow</span></span>
-					<span><p class="bling">this is a test of by tag name styles targeted by class on an ancestor.</p></span>
+					<div><p class="bling">this is a test of by tag name styles targeted by class on an ancestor.</p></div>
 					<p id="moo">i'm gray text</p>
 				</div>
 			</div>


### PR DESCRIPTION
@cocoanetics,

Here's a fix for selectors on the Mac being out of order it required exposing and maintaining an ordered set of selectors (so the selectors could be added in order during style sheet merge).

An aside, there's a file called "MacUnitTest" containing a test that fails prior and after my changes. I believe it's unrelated. Does this fail normally?
