### PR TITLE
Properly order single single class selectors and add a test

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -434,8 +434,8 @@ extern unsigned int default_css_len;
 					[ruleDictionary setObject:value forKey:oneKey];
 				}
 				
-			} else if ([value isKindOfClass:[NSArray class]]) {
-				
+			} else if ([value isKindOfClass:[NSArray class]])
+			{
 				NSMutableArray *newVal;
 				
 				for (NSUInteger i = 0; i < [value count]; ++i)
@@ -449,11 +449,13 @@ extern unsigned int default_css_len;
 						s = [s stringByReplacingCharactersInRange:rangeOfImportant withString:@""];
 						s = [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 						
-						if (!newVal) {
-							
-							if ([value isKindOfClass:[NSMutableArray class]]) {
+						if (!newVal)
+						{
+							if ([value isKindOfClass:[NSMutableArray class]])
+							{
 								newVal = value;
-							} else {
+							} else
+							{
 								newVal = [value mutableCopy];
 							}
 						}
@@ -462,8 +464,8 @@ extern unsigned int default_css_len;
 					}
 				}
 				
-				if (newVal) {
-					
+				if (newVal)
+				{
 					[ruleDictionary setObject:newVal forKey:oneKey];
 				}
 			}
@@ -644,7 +646,8 @@ extern unsigned int default_css_len;
 - (void)_addStyles:(NSDictionary *)styles withSelector:(NSString *)selector {
 	[_styles setObject:styles forKey:selector];
 	
-	if (![_orderedSelectors containsObject:selector]) {
+	if (![_orderedSelectors containsObject:selector])
+	{
 		[_orderedSelectors addObject:selector];
 		_orderedSelectorWeights[selector] = @([self weightForSelector:selector]);
 	}
@@ -672,21 +675,36 @@ extern unsigned int default_css_len;
 	NSString *classString = [element.attributes objectForKey:@"class"];
 	NSArray *classes = [classString componentsSeparatedByString:@" "];
 	
+	// Cascaded selectors with more than one part are sorted by specificity
 	NSMutableArray *matchingCascadingSelectors = [self matchingComplexCascadingSelectorsForElement:element];
-	[matchingCascadingSelectors addObjectsFromArray:[self matchingSimpleCascadedSelectors:element]];
-
-	NSArray *sortedCascadingSelectors = [matchingCascadingSelectors sortedArrayUsingComparator:^NSComparisonResult(NSString *selector1, NSString *selector2) {
+	NSArray *sortedCascadingSelectors = [matchingCascadingSelectors sortedArrayUsingComparator:^NSComparisonResult(NSString *selector1, NSString *selector2)
+	{
 		NSInteger weightForSelector1 = [_orderedSelectorWeights[selector1] integerValue];
 		NSInteger weightForSelector2 = [_orderedSelectorWeights[selector2] integerValue];
 		
-		if (weightForSelector1 == weightForSelector2) {
+		if (weightForSelector1 == weightForSelector2)
+		{
 			weightForSelector1 += [_orderedSelectors indexOfObject:selector1];
 			weightForSelector2 += [_orderedSelectors indexOfObject:selector2];
 		}
 		
-		return (weightForSelector1 >= weightForSelector2);
+		if (weightForSelector1 > weightForSelector2)
+		{
+			return (NSComparisonResult)NSOrderedDescending;
+		}
+		
+		if (weightForSelector1 < weightForSelector2)
+		{
+			return (NSComparisonResult)NSOrderedAscending;
+		}
+		
+		return (NSComparisonResult)NSOrderedSame;
 	}];
 	
+	// Single part selectors are also weighted by specificity, but since they all have the same weight,
+	//we apply them in order of least specific to most specific.
+	[matchingCascadingSelectors addObjectsFromArray:[self matchingSimpleCascadedSelectors:element]];
+
 	NSMutableSet *tmpMatchedSelectors;
 	
 	if (matchedSelectors)
@@ -782,7 +800,8 @@ extern unsigned int default_css_len;
 		NSArray *selectorParts = [selector componentsSeparatedByString:@" "];
 		
 		// We only process the selector if our selector has more than 1 part to it (e.g. ".foo" would be skipped and ".foo .bar" would not)
-		if (selectorParts.count < 2) {
+		if (selectorParts.count < 2)
+		{
 			continue;
 		}
 		
@@ -812,14 +831,17 @@ extern unsigned int default_css_len;
 					{
 						NSString *currentElementClassesString = [currentElement.attributes objectForKey:@"class"];
 						NSArray *currentElementClasses = [currentElementClassesString componentsSeparatedByString:@" "];
-						for (NSString *currentElementClass in currentElementClasses) {
-							if ([currentElementClass isEqualToString:[selectorPart substringFromIndex:1]]) {
+						for (NSString *currentElementClass in currentElementClasses)
+						{
+							if ([currentElementClass isEqualToString:[selectorPart substringFromIndex:1]])
+							{
 								matched = YES;
 								break;
 							}
 						}
 						
-						if (matched) {
+						if (matched)
+						{
 							break;
 						}
 					} else if ([selectorPart isEqualToString:currentElement.name] && (selectorParts.count > 1))
@@ -868,7 +890,7 @@ extern unsigned int default_css_len;
 			
 			if (_styles[ancessorClassRule])
 			{
-				[simpleSelectors addObject:ancessorClassRule];
+				[simpleSelectors insertObject:ancessorClassRule atIndex:0];
 			}
 		}
 		
@@ -880,17 +902,21 @@ extern unsigned int default_css_len;
 
 // This computes the specificity for a given selector
 - (NSUInteger)weightForSelector:(NSString *)selector {
-	if ((selector == nil) || (selector.length == 0)) {
+	if ((selector == nil) || (selector.length == 0))
+	{
 		return 0;
 	}
 	
 	NSUInteger weight = 0;
 	
 	NSArray *selectorParts = [selector componentsSeparatedByString:@" "];
-	for (NSString *selectorPart in selectorParts) {
-		if ([selectorPart characterAtIndex:0] == '#') {
+	for (NSString *selectorPart in selectorParts)
+	{
+		if ([selectorPart characterAtIndex:0] == '#')
+		{
 			weight += 100;
-		} else if ([selectorPart characterAtIndex:0] == '.') {
+		} else if ([selectorPart characterAtIndex:0] == '.')
+		{
 			weight += 10;
 		} else {
 			weight += 1;

--- a/Core/Test/Source/DTHTMLAttributedStringBuilderTest.m
+++ b/Core/Test/Source/DTHTMLAttributedStringBuilderTest.m
@@ -763,12 +763,12 @@
 	NSString *foregroundHTML = [foreground htmlHexString];
 	STAssertEqualObjects(foregroundHTML, @"008000", @"Color should be green and not red.");
 
-	NSString *html2 = @"<html><head><style>.foo { color: red; } .foo { color: green; }</style> </head><body><div class=\"foo\"><div>Text</div></div></body></html>";
+	NSString *html2 = @"<html><head><style>.bar { color: red; } .foo { color: green; } </style> </head><body><div class=\"foo\"><div class=\"bar\"><div>Text</div></div></div></body></html>";
 	NSAttributedString *output2 = [self _attributedStringFromHTMLString:html2 options:nil];
 	NSDictionary *attributes2 = [output2 attributesAtIndex:1 effectiveRange:NULL];
 	DTColor *foreground2 = [attributes2 foregroundColor];
 	NSString *foregroundHTML2 = [foreground2 htmlHexString];
-	STAssertEqualObjects(foregroundHTML2, @"008000", @"Color should be green and not red.");
+	STAssertEqualObjects(foregroundHTML2, @"ff0000", @"Color should be red and not green.");
 }
 
 @end


### PR DESCRIPTION
Single class selectors are now weighted based on their distance from the target element since their specificity values are always the same relative to each other.
