### PR TITLE
Reformatting urls embedded in iframe from youtube. Otherwise they don't ...

### DIFF
--- a/Core/Source/DTIframeTextAttachment.m
+++ b/Core/Source/DTIframeTextAttachment.m
@@ -20,6 +20,11 @@
 		NSURL *baseURL = [options objectForKey:NSBaseURLDocumentOption];
 		NSString *src = [element.attributes objectForKey:@"src"];
 		
+		// prepend http: if URL string starts with // (seems to do with youtube iframes as standard)
+		if ([[src substringToIndex:2] isEqualToString:@"//"]) {
+			src = [@"http:" stringByAppendingString:src];
+		}
+		
 		// content URL
 		_contentURL = [NSURL URLWithString:src relativeToURL:baseURL];
 	}


### PR DESCRIPTION
...play in the application. 

The standard url that youtube creates in their iframes starts with // (//www.youtube.com/embed/4YweN6NeaJU), which doesn't play in the app.
