### PR TITLE
Too much whitespace was getting deleted

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -776,7 +776,7 @@
 									if ([_tmpString length] && ![[_tmpString string] hasSuffix:@"\n"])
 									{
 										// trim off whitespace
-										while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]])
+										while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet ignorableWhitespaceCharacterSet]])
 										{
 											[_tmpString deleteCharactersInRange:NSMakeRange([_tmpString length]-1, 1)];
 										}

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -407,7 +407,7 @@ NSDictionary *_classesForNames = nil;
 					if (oneChild.displayStyle == DTHTMLElementDisplayStyleBlock)
 					{
 						// trim off whitespace suffix
-						while ([[tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]])
+						while ([[tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet ignorableWhitespaceCharacterSet]])
 						{
 							[tmpString deleteCharactersInRange:NSMakeRange([tmpString length]-1, 1)];
 						}
@@ -424,7 +424,7 @@ NSDictionary *_classesForNames = nil;
 					if (!oneChild.containsAppleConvertedSpace)
 					{
 						// we already have a white space in the string so far
-						if ([[tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]])
+						if ([[tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet ignorableWhitespaceCharacterSet]])
 						{
 							while ([[nodeString string] hasPrefix:@" "])
 							{

--- a/Core/Source/NSCharacterSet+HTML.m
+++ b/Core/Source/NSCharacterSet+HTML.m
@@ -49,7 +49,7 @@ static NSCharacterSet *_cssLengthUnitCharacterSet = nil;
 	static dispatch_once_t predicate;
 	
 	dispatch_once(&predicate, ^{
-		NSMutableCharacterSet *tmpSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+		NSMutableCharacterSet *tmpSet = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
 		
 		// remove all special unicode space characters
 		[tmpSet removeCharactersInString:UNICODE_NON_BREAKING_SPACE];


### PR DESCRIPTION
In several places the code was using Apple's whitespaceAndNewlineCharacterSet for ignorable
whitespace, but it should have been using the internal ignorableWhitespaceCharacterSet.

ignorableWhitespaceCharacterSet was also trying to modify an immutable object, which clearly wasn't working.

These bugs were causing HTML like:

&amp;nbsp;&lt;br>

to be ignored completely in many (but not all) situations.
