### PR TITLE
Changed LazyImageView resize behavior, fixes issue #627

### DIFF
--- a/Core/Source/DTLazyImageView.m
+++ b/Core/Source/DTLazyImageView.m
@@ -195,9 +195,7 @@ NSString * const DTLazyImageViewDidFinishDownloadNotification = @"DTLazyImageVie
 	self.image = image;
 	_fullWidth = image.size.width;
 	_fullHeight = image.size.height;
-	
-	self.bounds = CGRectMake(0, 0, _fullWidth, _fullHeight);
-	
+
 	[self _notifyDelegate];
 	
 	static dispatch_once_t predicate;


### PR DESCRIPTION
This PR makes the LazyImageView ask its delegate if it wants the LazyImageView to resize itself, the ImageView will also resize when image is loaded from cache.

Please let me know if this is good to merge. If any changes are needed let me know!
