### PR TITLE
Fix textScale impacting listPadding during round trip. fixes #629

### DIFF
--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -429,7 +429,7 @@
 				}
 				
 				// only padding can be reconstructed so far
-				CGFloat listPadding = paragraphStyle.headIndent - paragraphStyle.firstLineHeadIndent;
+				CGFloat listPadding = (paragraphStyle.headIndent - paragraphStyle.firstLineHeadIndent) / _textScale;
 				
 				// beginning of a list block
 				[retString appendString:[self _tagRepresentationForListStyle:oneList closingTag:NO listPadding:listPadding inlineStyles:fragment]];

--- a/Core/Test/Source/DTHTMLWriterTest.m
+++ b/Core/Test/Source/DTHTMLWriterTest.m
@@ -126,6 +126,23 @@
 	[self _testListIndentRoundTripFromHTML:@"<ul><li>fooo</li><li>fooo</li><li>fooo</li></ul>"];
 }
 
+- (void)testSimpleListRoundTripWithTextScale
+{
+	CGFloat textSize = 32.0f;
+	CGFloat textScale = 1.5f;
+	
+	//Artificially scale up the text size
+	NSString *html = [NSString stringWithFormat:@"<ul style=\"-webkit-padding-start:%fpx;padding-left:%fpx;\"><li>fooo</li><li>fooo</li><li>fooo</li></ul>", (textSize * textScale), (textSize * textScale)];
+	NSAttributedString *string = [self attributedStringFromHTMLString:html options:nil];
+
+	DTHTMLWriter *writer = [[DTHTMLWriter alloc] initWithAttributedString:string];
+	//Give the writer the artificial scale
+	writer.textScale = textScale;
+	NSString *writtenHTML = [writer HTMLFragment];
+	
+	STAssertTrue([writtenHTML rangeOfString:@"-webkit-padding-start:32px;padding-left:32px;"].location != NSNotFound, @"Text scale should not affect list indention amount");
+}
+
 - (void)testNestedListRoundTrip
 {
 	[self _testListIndentRoundTripFromHTML:@"<ol><li>1a<ul><li>2a</li></ul></li><li>more</li><li>more</li></ol>"];


### PR DESCRIPTION
Divide the computed listPadding by the text scale so round trips don't mess with the padding when coming from a view or editor that has a non-1.0 textScale.
