### PR TITLE
add test for nested list writing with preceding element

### DIFF
--- a/Core/Test/Source/DTHTMLWriterTest.m
+++ b/Core/Test/Source/DTHTMLWriterTest.m
@@ -131,6 +131,11 @@
 	[self _testListIndentRoundTripFromHTML:@"<ol><li>1a<ul><li>2a</li></ul></li><li>more</li><li>more</li></ol>"];
 }
 
+- (void)testNestedListRoundTripWithPrecedingElement
+{
+	[self _testListIndentRoundTripFromHTML:@"<p>This breaks writing nested lists</p><ol><li>1a<ul><li>2a</li></ul></li><li>more</li><li>more</li></ol>"];
+}
+
 - (void)testNestedListWithPaddingRoundTrip
 {
 	[self _testListIndentRoundTripFromHTML:@"<ul style=\"padding-left:55px\"><li>fooo<ul style=\"padding-left:66px\"><li>bar</li></ul></li></ul>"];


### PR DESCRIPTION
Add test for nested list writing with preceding element. This case is currently broken w/ the latest in develop.
