### PR TITLE
partially fix #637 NSMakeRange in rangeOfAnchorNamed:

### DIFF
--- a/Core/Source/DTAttributedTextView.m
+++ b/Core/Source/DTAttributedTextView.m
@@ -104,7 +104,7 @@
 {
 	NSRange range = [self.attributedTextContentView.attributedString rangeOfAnchorNamed:anchorName];
 	
-	if (range.length != NSNotFound)
+	if (range.location != NSNotFound)
 	{
 		[self scrollRangeToVisible:range animated:animated];
 	}

--- a/Core/Source/NSAttributedString+DTCoreText.m
+++ b/Core/Source/NSAttributedString+DTCoreText.m
@@ -216,7 +216,7 @@
 
 - (NSRange)rangeOfAnchorNamed:(NSString *)anchorName
 {
-	__block NSRange foundRange = NSMakeRange(0, NSNotFound);
+	__block NSRange foundRange = NSMakeRange(NSNotFound, 0);
 	
 	[self enumerateAttribute:DTAnchorAttribute inRange:NSMakeRange(0, [self length]) options:0 usingBlock:^(NSString *value, NSRange range, BOOL *stop) {
 		if ([value isEqualToString:anchorName])


### PR DESCRIPTION
This request fixes wrong using NSMakeRange macros in  rangeOfAnchorNamed: method.

Unfortunatelly  similar correction of NSMakeRange in _rangeOfObject:inArrayBehindAttribute:atIndex: method will broke unit test testEmptyListItemWithSubList. So I leave NSMakeRange in _rangeOfObject:inArrayBehindAttribute:atIndex: untouched.
