### PR TITLE
issue 655. Changed the constant to detect 6.0 ios version

### DIFF
--- a/Core/Source/DTCompatibility.h
+++ b/Core/Source/DTCompatibility.h
@@ -40,7 +40,7 @@
 	#endif
 
 	// constant for checking for iOS 6
-	#define DTNSFoundationVersionNumber_iOS_6_0  993.00
+	#define DTNSFoundationVersionNumber_iOS_6_0  992.00
 
 	// constant for checking for iOS 7
 	#define DTNSFoundationVersionNumber_iOS_7_0  1047.20


### PR DESCRIPTION
iOS simulator 6.0 returns 992.00 in NSFoundationVersionNumber
