### PR TITLE
Rename arguments to avoid using C++ reserved word class

### DIFF
--- a/Core/Source/DTTextAttachment.h
+++ b/Core/Source/DTTextAttachment.h
@@ -184,7 +184,7 @@ typedef NS_ENUM(NSUInteger, DTTextAttachmentVerticalAlignment)
  @param class The class to instantiate in textAttachmentWithElement:options: when encountering a tag with this name
  @param tagName The tag name to use this class for
  */
-+ (void)registerClass:(Class)class forTagName:(NSString *)tagName;
++ (void)registerClass:(Class)theClass forTagName:(NSString *)tagName;
 
 /**
  The class to use for a tag name

--- a/Core/Source/NSAttributedString+DTCoreText.h
+++ b/Core/Source/NSAttributedString+DTCoreText.h
@@ -27,7 +27,7 @@
  @param class The class that attachments need to have, or `nil` for all attachments regardless of class
  @returns The filtered array of attachments
  */
-- (NSArray *)textAttachmentsWithPredicate:(NSPredicate *)predicate class:(Class)class;
+- (NSArray *)textAttachmentsWithPredicate:(NSPredicate *)predicate class:(Class)theClass;
 
 /**
  @name Calculating Ranges


### PR DESCRIPTION
At the moment is not possible to use DTCoreText in Objective-C++ due to the fact that ´class´ is a reserved name in C++. I've changed a couple method signatures to fix this.
