### PR TITLE
Changed DTAttributedTextContentView to discard invalid CGContexts.

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -1020,6 +1020,10 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	
+	if(!context) {
+		return nil;
+	}
+	
 	CGContextTranslateCTM(context, -bounds.origin.x, -bounds.origin.y);
 	
 	[self.layoutFrame drawInContext:context options:options];


### PR DESCRIPTION
This method would often receive an invalid context, which littered the console with ugly warnings. Aborting on a null  context seems to fix the issue. 
