### PR TITLE
fix for strikeOut

### DIFF
--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -164,16 +164,7 @@ NSDictionary *_classesForNames = nil;
 	// add strikout if applicable
 	if (_strikeOut)
 	{
-#if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
-		if (___useiOS6Attributes)
-		{
-			[tmpDict setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
-		}
-		else
-#endif
-		{
-			[tmpDict setObject:[NSNumber numberWithBool:YES] forKey:DTStrikeOutAttribute];
-		}
+		[tmpDict setObject:[NSNumber numberWithBool:YES] forKey:DTStrikeOutAttribute];
 	}
 	
 	// set underline style


### PR DESCRIPTION
it think the error was due to a copy/paste of the code for underline
