### PR TITLE
Support text attachments in HTML Writer

### DIFF
--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -634,7 +634,7 @@
 			
 			DTTextAttachment *attachment = [attributes objectForKey:NSAttachmentAttributeName];
 
-			if ([plainSubString characterAtIndex:0] == UNICODE_OBJECT_PLACEHOLDER) {
+			if ([plainSubString isEqualToString:UNICODE_OBJECT_PLACEHOLDER]) {
 				attachment = [attributes objectForKey:@"NSAttachment"];
 				subString = @"";
 			}


### PR DESCRIPTION
if the NSTextAttachment conforms to `DTTextAttachmentHTMLPersistence`

First baby step in implementing #611.
