### PR TITLE
#752 Autolayout support for DTAttributedTextContentView

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -500,6 +500,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 			
 			[self setNeedsLayout];
 			[self setNeedsDisplayInRect:self.bounds];
+            [self invalidateIntrinsicContentSize];
 		}
 	});
 }
@@ -632,6 +633,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		_edgeInsets = edgeInsets;
 		
 		[self relayoutText];
+        [self invalidateIntrinsicContentSize];
 	}
 }
 
@@ -715,6 +717,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		_shouldAddFirstLineLeading = shouldAddLeading;
 		
 		[self setNeedsDisplay];
+        [self invalidateIntrinsicContentSize];
 	}
 }
 
@@ -725,6 +728,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		_shouldDrawImages = shouldDrawImages;
 		
 		[self setNeedsDisplay];
+        [self invalidateIntrinsicContentSize];
 	}
 }
 
@@ -735,6 +739,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 		_shouldDrawLinks = shouldDrawLinks;
 		
 		[self setNeedsDisplay];
+        [self invalidateIntrinsicContentSize];
 	}
 }
 


### PR DESCRIPTION
Solve the issue #752

I added invalidateIntrinsicContentSize to setAttributedString: to give notion to Autolayout that an updates of the layout is required.

In my codebase using [view systemLayoutSizeFittingSize:UILayoutFittingCompressedSize]; i was able to get the expected size in iOS7 but not in iOS6. Now with invalidateIntrinsicContentSize it works in both.
