### PR TITLE
Corrected CTRunGetPositionsPtr usage

### DIFF
--- a/Core/Source/DTCoreTextLayoutLine.m
+++ b/Core/Source/DTCoreTextLayoutLine.m
@@ -351,11 +351,32 @@
 				{
 					CTRunRef oneRun = CFArrayGetValueAtIndex(runs, i);
 					
+					CGPoint *positions = (CGPoint*)CTRunGetPositionsPtr(oneRun);
+					
+					BOOL shouldFreePositions = NO;
+					
+					if (positions == NULL) // Ptr gave NULL, we'll need to copy positions array and later free it
+					{
+						CFIndex glyphCount = CTRunGetGlyphCount(oneRun);
+						
+						shouldFreePositions = YES;
+						
+						size_t positionsBufferSize = sizeof(CGPoint) * glyphCount;
+						CGPoint *positionsBuffer = malloc(positionsBufferSize);
+						CTRunGetPositions(oneRun, CFRangeMake(0, 0), positionsBuffer);
+						positions = positionsBuffer;
+					}
+					
 					// assumption: position of first glyph is also the correct offset of the entire run
-					CGPoint position = *CTRunGetPositionsPtr(oneRun);
+					CGPoint position = positions[0];
 					
 					DTCoreTextGlyphRun *glyphRun = [[DTCoreTextGlyphRun alloc] initWithRun:oneRun layoutLine:self offset:position.x];
 					[tmpArray addObject:glyphRun];
+					
+					if ( shouldFreePositions )
+					{
+						free(positions);
+					}
 				}
 				
 				_glyphRuns = tmpArray;


### PR DESCRIPTION
CTRunGetPositionsPtr can return a NULL result. This correction handles
that result, copying positions using CTRunGetPositions.
