### PR TITLE
Fix for missing Font in iOS 7

### DIFF
--- a/Core/Source/UIFont+DTCoreText.m
+++ b/Core/Source/UIFont+DTCoreText.m
@@ -13,8 +13,17 @@
 + (UIFont *)fontWithCTFont:(CTFontRef)ctFont
 {
 	NSString *fontName = (__bridge_transfer NSString *)CTFontCopyName(ctFont, kCTFontPostScriptNameKey);
+
 	CGFloat fontSize = CTFontGetSize(ctFont);
-	return [UIFont fontWithName:fontName size:fontSize];
+	UIFont *font = [UIFont fontWithName:fontName size:fontSize];
+
+	// fix for missing HelveticaNeue-Italic font in iOS 7.0.x
+	if (!font && [fontName isEqualToString:@"HelveticaNeue-Italic"])
+	{
+		font = [UIFont fontWithName:@"HelveticaNeue-LightItalic" size:fontSize];
+	}
+
+	return font;
 }
 
 @end


### PR DESCRIPTION
Fix for missing Helvetica Neue Light font in iOS 7.0.x
