### PR TITLE
Added override to use direct "PostScript" names for fonts

### DIFF
--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1329,6 +1329,12 @@ NSDictionary *_classesForNames = nil;
 	{
 		self.paragraphStyle.paragraphSpacing = _margins.bottom;
 	}
+    
+    NSString *coretextFontString = [styles objectForKey:@"-coretext-fontname"];
+    if (coretextFontString)
+    {
+        _fontDescriptor.fontName = [styles objectForKey:@"-coretext-fontname"];
+    }
 }
 
 - (DTCSSListStyle *)listStyle


### PR DESCRIPTION
In order to fix #804 I added a ""-coretext-fontname" style element, it can be used to specify the postscript name of a font to use it. It was only a temporary fix but I thought it might be useful to other as well. 

I didn't build any check to see if the postscript name has an actual font installed, so this might crash if you use a font that is not in your bundle. Feel free to improve on this. 
