### PR TITLE
Remove new line characters in parserDidEndDocument

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -962,7 +962,7 @@
 
 		dispatch_group_async(_stringAssemblyGroup, _stringAssemblyQueue, ^{
 			// trim off white space at end
-			while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceCharacterSet]])
+			while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]])
 			{
 				[_tmpString deleteCharactersInRange:NSMakeRange([_tmpString length]-1, 1)];
 			}


### PR DESCRIPTION
Originally, `DTHTMLAttributedStringBuilder` used to leave the trailing new line character that was added during string construction. On iOS 8, if you assign the resulting attributed string to a UILabel, the trailing new line character is given a non-zero height (as expected), and thus the resulting text is not vertically centered. This change will most likely cause unit tests to fail. I haven't had a chance to delve into those. 
