### PR TITLE
Fix NULL dereference when CTLineCreateTruncatedLine fails and returns a NULL

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -661,7 +661,10 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 			}
 		}
 		
-		if (line == NULL) continue;
+		if (!line)
+		{
+			continue;
+		}
 		
 		// wrap it
 		DTCoreTextLayoutLine *newLine = [[DTCoreTextLayoutLine alloc] initWithLine:line

--- a/Core/Source/DTCoreTextLayoutLine.m
+++ b/Core/Source/DTCoreTextLayoutLine.m
@@ -55,7 +55,10 @@
 
 - (id)initWithLine:(CTLineRef)line stringLocationOffset:(NSInteger)stringLocationOffset
 {
-	if (line == NULL) return nil;
+	if (!line)
+	{
+		return nil;
+	}
 	
 	if ((self = [super init]))
 	{


### PR DESCRIPTION
Fixes #817.
