### PR TITLE
Use defaultParagraphStyle rather than assert crash for DTUseiOS6Attribut...

### DIFF
--- a/Core/Source/DTCoreTextParagraphStyle.m
+++ b/Core/Source/DTCoreTextParagraphStyle.m
@@ -43,7 +43,9 @@
 #if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
 + (DTCoreTextParagraphStyle *)paragraphStyleWithNSParagraphStyle:(NSParagraphStyle *)paragraphStyle
 {
-	NSParameterAssert(paragraphStyle);
+	if ( ! paragraphStyle) {
+		paragraphStyle = [NSParagraphStyle defaultParagraphStyle];
+	}
 	
 	DTCoreTextParagraphStyle *retStyle = [[DTCoreTextParagraphStyle alloc] init];
 	

--- a/Test/Source/NSAttributedStringHTMLTest.m
+++ b/Test/Source/NSAttributedStringHTMLTest.m
@@ -170,4 +170,16 @@
 }
  */
 
+- (void)testCrashAtEmptyNodeBeforeDivWithiOS6Attributes
+{
+	// This string is the simplest case that caused the crash.
+	NSString *html = @"<div><i></i><div></div></div>;";
+	NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
+	NSDictionary *options = @{DTUseiOS6Attributes: @(YES)};
+	NSAttributedString *string = [[NSAttributedString alloc] initWithHTMLData:data
+																	  options:options
+														   documentAttributes:NULL];
+	XCTAssert(string != nil);
+}
+
 @end


### PR DESCRIPTION
Running the test without the change to DTCoreTextParagraphStyle shows a crash that was occurring for initWithHTMLData while using DTUseiOS6Attributes.

Using defaultParagraph style rather than assert works for my cases and existing DTCoreText tests; if it is not an appropriate solution I'm glad to revisit.