### PR TITLE
Use correct attribute name for foreground color

### DIFF
--- a/Core/Source/NSMutableAttributedString+HTML.m
+++ b/Core/Source/NSMutableAttributedString+HTML.m
@@ -171,19 +171,33 @@
 	}
 
 	// transfer foreground color
-	id foregroundColor = [attributes objectForKey:(id)kCTForegroundColorAttributeName];
-	
-	if (foregroundColor)
+#if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
+	if (___useiOS6Attributes)
 	{
-#if TARGET_OS_IPHONE
-		if ([foregroundColor isKindOfClass:[UIColor class]])
+		id foregroundColor = [attributes objectForKey:NSForegroundColorAttributeName];
+		
+		if (foregroundColor)
 		{
-			[appendAttributes setObject:(id)[foregroundColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
+			[appendAttributes setObject:foregroundColor forKey:NSForegroundColorAttributeName];
 		}
-		else
+	}
+	else
 #endif
+	{
+		id foregroundColor = [attributes objectForKey:(id)kCTForegroundColorAttributeName];
+		
+		if (foregroundColor)
 		{
-			[appendAttributes setObject:foregroundColor forKey:(id)kCTForegroundColorAttributeName];
+#if TARGET_OS_IPHONE
+			if ([foregroundColor isKindOfClass:[UIColor class]])
+			{
+				[appendAttributes setObject:(id)[foregroundColor CGColor] forKey:(id)kCTForegroundColorAttributeName];
+			}
+			else
+#endif
+			{
+				[appendAttributes setObject:foregroundColor forKey:(id)kCTForegroundColorAttributeName];
+			}
 		}
 	}
 

--- a/Test/Source/NSMutableAttributedStringHTMLTest.m
+++ b/Test/Source/NSMutableAttributedStringHTMLTest.m
@@ -187,12 +187,14 @@
 	
 	NSRange entireString = NSMakeRange(0, [attributedString length]);
 	
+	BOOL defaultValueForUseiOS6Attributes = ___useiOS6Attributes;
+	___useiOS6Attributes = NO;
+	
 	// add a foreground color using the Core Text attribute name
 	CGFloat components[4] = {1.0, 0.0, 0.0, 1.0};
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 	CGColorRef redColorRef = CGColorCreate(colorSpace, components);
 	[testingString addAttribute:(id)kCTForegroundColorAttributeName value:(id)CFBridgingRelease(redColorRef) range:entireString];
-	CGColorSpaceRelease(colorSpace);
 	
 	// append the end of a paragraph tag
 	[testingString appendEndOfParagraph];
@@ -206,6 +208,8 @@
 #endif
 	
 	XCTAssertTrue(CGColorEqualToColor(redColorRef, (CGColorRef)stringColorRef), @"Foreground color should be red");
+	
+	CGColorSpaceRelease(colorSpace);
 	
 #if TARGET_OS_IPHONE && DTCORETEXT_SUPPORT_NS_ATTRIBUTES
 	[testingString setAttributedString:attributedString];
@@ -226,9 +230,9 @@
 	} else {
 		XCTAssertTrue(CGColorEqualToColor([[UIColor redColor] CGColor], [nsAttributesStringColor CGColor]), @"Foreground color should be red");
 	}
-	
-	___useiOS6Attributes = NO;
 #endif
+	
+	___useiOS6Attributes = defaultValueForUseiOS6Attributes;
 }
 
 @end

--- a/Test/Source/NSMutableAttributedStringHTMLTest.m
+++ b/Test/Source/NSMutableAttributedStringHTMLTest.m
@@ -188,18 +188,24 @@
 	NSRange entireString = NSMakeRange(0, [attributedString length]);
 	
 	// add a foreground color using the Core Text attribute name
-	[testingString addAttribute:(id)kCTForegroundColorAttributeName value:(id)([UIColor redColor].CGColor) range:entireString];
+	CGFloat components[4] = {1.0, 0.0, 0.0, 1.0};
+	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+	CGColorRef redColorRef = CGColorCreate(colorSpace, components);
+	[testingString addAttribute:(id)kCTForegroundColorAttributeName value:(id)CFBridgingRelease(redColorRef) range:entireString];
+	CGColorSpaceRelease(colorSpace);
 	
 	// append the end of a paragraph tag
 	[testingString appendEndOfParagraph];
 	
 	// check the foreground color
-	id stringColor = [testingString attribute:(id)kCTForegroundColorAttributeName atIndex:([testingString length] - 1) effectiveRange:nil];
-	if (![stringColor isKindOfClass:[UIColor class]]) {
-		stringColor = [UIColor colorWithCGColor:(CGColorRef)stringColor];
+	id stringColorRef = [testingString attribute:(id)kCTForegroundColorAttributeName atIndex:([testingString length] - 1) effectiveRange:nil];
+#if TARGET_OS_IPHONE
+	if ([stringColorRef isKindOfClass:[UIColor class]]) {
+		stringColorRef = (id)[(UIColor *)stringColorRef CGColor];
 	}
+#endif
 	
-	XCTAssertTrue(CGColorEqualToColor([[UIColor redColor] CGColor], [stringColor CGColor]), @"Foreground color should be red");
+	XCTAssertTrue(CGColorEqualToColor(redColorRef, (CGColorRef)stringColorRef), @"Foreground color should be red");
 	
 #if TARGET_OS_IPHONE && DTCORETEXT_SUPPORT_NS_ATTRIBUTES
 	[testingString setAttributedString:attributedString];

--- a/Test/Source/NSMutableAttributedStringHTMLTest.m
+++ b/Test/Source/NSMutableAttributedStringHTMLTest.m
@@ -180,4 +180,49 @@
 	XCTAssertTrue(NSEqualRanges(queriedRange, expectedRange), @"Range is incorrect");
 }
 
+- (void)testForegroundColorAttributeNameAtEndOfParagraph
+{
+	NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:@"1234567890"];
+	NSMutableAttributedString *testingString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedString];
+	
+	NSRange entireString = NSMakeRange(0, [attributedString length]);
+	
+	// add a foreground color using the Core Text attribute name
+	[testingString addAttribute:(id)kCTForegroundColorAttributeName value:(id)([UIColor redColor].CGColor) range:entireString];
+	
+	// append the end of a paragraph tag
+	[testingString appendEndOfParagraph];
+	
+	// check the foreground color
+	id stringColor = [testingString attribute:(id)kCTForegroundColorAttributeName atIndex:([testingString length] - 1) effectiveRange:nil];
+	if (![stringColor isKindOfClass:[UIColor class]]) {
+		stringColor = [UIColor colorWithCGColor:(CGColorRef)stringColor];
+	}
+	
+	XCTAssertTrue(CGColorEqualToColor([[UIColor redColor] CGColor], [stringColor CGColor]), @"Foreground color should be red");
+	
+#if TARGET_OS_IPHONE && DTCORETEXT_SUPPORT_NS_ATTRIBUTES
+	[testingString setAttributedString:attributedString];
+	
+	___useiOS6Attributes = YES;
+	
+	// add a foreground color using the NSAttributedString attribute name
+	[testingString addAttribute:NSForegroundColorAttributeName value:[UIColor redColor] range:entireString];
+	
+	// append the end of a paragraph tag
+	[testingString appendEndOfParagraph];
+	
+	// check the foreground color
+	id nsAttributesStringColor = [testingString attribute:NSForegroundColorAttributeName atIndex:([testingString length] - 1) effectiveRange:nil];
+
+	if (![nsAttributesStringColor isKindOfClass:[UIColor class]]) {
+		XCTFail(@"Color for NSForegroundColorAttributeName should be set as a valid UIColor"	);
+	} else {
+		XCTAssertTrue(CGColorEqualToColor([[UIColor redColor] CGColor], [nsAttributesStringColor CGColor]), @"Foreground color should be red");
+	}
+	
+	___useiOS6Attributes = NO;
+#endif
+}
+
 @end


### PR DESCRIPTION
- If using the NSAttribute string attributes then use NSForegroundColorAttributeName instead of kCTForegroundColorAttributeName when adding the ending paragraph string