### PR TITLE
Added support for Cocoapods modules

### DIFF
--- a/Core/Source/DTAttributedTextCell.h
+++ b/Core/Source/DTAttributedTextCell.h
@@ -7,7 +7,6 @@
 //
 
 #import "DTAttributedTextContentView.h"
-#import "DTWeakSupport.h"
 
 /**
  This class represents a tableview cell that contains an attributed text as its content.
@@ -37,7 +36,7 @@
 /**
  A delegate implementing DTAttributedTextContentViewDelegate to provide custom subviews for images and links.
  */
-@property (nonatomic, DT_WEAK_PROPERTY) IBOutlet id <DTAttributedTextContentViewDelegate> textDelegate;
+@property (nonatomic, weak) IBOutlet id <DTAttributedTextContentViewDelegate> textDelegate;
 
 /**
  This method allows to set HTML text directly as content of the receiver. 

--- a/Core/Source/DTAttributedTextCell.m
+++ b/Core/Source/DTAttributedTextCell.m
@@ -15,12 +15,12 @@
 {
 	DTAttributedTextContentView *_attributedTextContextView;
 	
-	DT_WEAK_VARIABLE id <DTAttributedTextContentViewDelegate> _textDelegate;
+	__weak id <DTAttributedTextContentViewDelegate> _textDelegate;
 	
 	NSUInteger _htmlHash; // preserved hash to avoid relayouting for same HTML
 	
 	BOOL _hasFixedRowHeight;
-	DT_WEAK_VARIABLE UITableView *_containingTableView;
+	__weak UITableView *_containingTableView;
 }
 
 - (id)initWithReuseIdentifier:(NSString *)reuseIdentifier

--- a/Core/Source/DTAttributedTextContentView.h
+++ b/Core/Source/DTAttributedTextContentView.h
@@ -7,7 +7,6 @@
 //
 
 #import "DTCoreTextLayoutFrame.h"
-#import "DTWeakSupport.h"
 
 @class DTAttributedTextContentView;
 @class DTCoreTextLayoutFrame;
@@ -242,7 +241,7 @@ typedef NSUInteger DTAttributedTextContentViewRelayoutMask;
  The delegate that is in charge of supplying custom behavior for the receiver. It must conform to <DTAttributedTextContentViewDelegate> and provide custom subviews, link buttons, etc.
  */
 
-@property (nonatomic, DT_WEAK_PROPERTY) IBOutlet id <DTAttributedTextContentViewDelegate> delegate;
+@property (nonatomic, weak) IBOutlet id <DTAttributedTextContentViewDelegate> delegate;
 
 /**
  @name Customizing Content Display

--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -52,7 +52,7 @@ NSString * const DTAttributedTextContentViewDidFinishLayoutNotification = @"DTAt
 		unsigned int delegateSupportsNotificationBeforeTextBoxDrawing:1;
 	} _delegateFlags;
 	
-	DT_WEAK_VARIABLE id <DTAttributedTextContentViewDelegate> _delegate;
+	__weak id <DTAttributedTextContentViewDelegate> _delegate;
 }
 
 @property (nonatomic, strong) NSMutableDictionary *customViewsForLinksIndex;
@@ -884,7 +884,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 				
 				if (_delegateFlags.delegateSupportsNotificationBeforeTextBoxDrawing)
 				{
-					DT_WEAK_VARIABLE DTAttributedTextContentView *weakself = self;
+					__weak DTAttributedTextContentView *weakself = self;
 					
 					[_layoutFrame setTextBlockHandler:^(DTTextBlock *textBlock, CGRect frame, CGContextRef context, BOOL *shouldDrawDefaultBackground) {
 						

--- a/Core/Source/DTAttributedTextView.h
+++ b/Core/Source/DTAttributedTextView.h
@@ -35,7 +35,7 @@
 /**
  A delegate implementing DTAttributedTextContentViewDelegate to provide custom subviews for images and links.
  */
-@property (nonatomic, DT_WEAK_PROPERTY) IBOutlet id <DTAttributedTextContentViewDelegate> textDelegate;
+@property (nonatomic, weak) IBOutlet id <DTAttributedTextContentViewDelegate> textDelegate;
 
 
 /**

--- a/Core/Source/DTAttributedTextView.m
+++ b/Core/Source/DTAttributedTextView.m
@@ -27,7 +27,7 @@
 	UIView *_backgroundView;
 
 	// these are pass-through, i.e. store until the content view is created
-	DT_WEAK_VARIABLE id textDelegate;
+	__weak id textDelegate;
 	NSAttributedString *_attributedString;
 	
 	BOOL _shouldDrawLinks;

--- a/Core/Source/DTCoreTextGlyphRun.m
+++ b/Core/Source/DTCoreTextGlyphRun.m
@@ -13,7 +13,6 @@
 #import "DTCoreTextParagraphStyle.h"
 #import "DTCoreTextFunctions.h"
 #import "NSDictionary+DTCoreText.h"
-#import "DTWeakSupport.h"
 #import "DTLog.h"
 
 @implementation DTCoreTextGlyphRun
@@ -34,8 +33,8 @@
 	
 	const CGPoint *_glyphPositionPoints;
 	
-	DT_WEAK_VARIABLE DTCoreTextLayoutLine *_line;	// retain cycle, since these objects are retained by the _line
-	DT_WEAK_VARIABLE NSDictionary *_attributes; // weak because it is owned by _run IVAR
+	__weak DTCoreTextLayoutLine *_line;	// retain cycle, since these objects are retained by the _line
+	__weak NSDictionary *_attributes; // weak because it is owned by _run IVAR
 	NSArray *_stringIndices;
 	
 	DTTextAttachment *_attachment;

--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
-#import "DTHTMLParser.h"
+#import <Foundation/Foundation.h>
 
 @class DTHTMLElement;
 
@@ -16,7 +16,7 @@ typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
 /**
  Class for building an `NSAttributedString` from an HTML document.
  */
-@interface DTHTMLAttributedStringBuilder : NSObject <DTHTMLParserDelegate>
+@interface DTHTMLAttributedStringBuilder : NSObject
 
 /**
  @name Creating an Attributed String Builder

--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -7,6 +7,7 @@
 //
 
 #import "DTCoreText.h"
+#import "DTHTMLParser.h"
 #import "DTHTMLAttributedStringBuilder.h"
 
 #import "DTTextHTMLElement.h"
@@ -19,7 +20,7 @@
 #import "NSString+DTFormatNumbers.h"
 #endif
 
-@interface DTHTMLAttributedStringBuilder ()
+@interface DTHTMLAttributedStringBuilder () <DTHTMLParserDelegate>
 
 - (void)_registerTagStartHandlers;
 - (void)_registerTagEndHandlers;

--- a/Core/Source/DTHTMLParserNode.h
+++ b/Core/Source/DTHTMLParserNode.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <Foundation/Foundation.h>
 
 @class DTHTMLParserTextNode;
 
@@ -39,7 +39,7 @@
 /**
  A weak link to the parent node of the receiver
  */
-@property (nonatomic, DT_WEAK_PROPERTY) DTHTMLParserNode *parentNode;
+@property (nonatomic, weak) DTHTMLParserNode *parentNode;
 
 /**
  The child nodes of the receiver

--- a/Core/Source/DTHTMLParserNode.m
+++ b/Core/Source/DTHTMLParserNode.m
@@ -8,12 +8,11 @@
 
 #import "DTHTMLParserNode.h"
 #import "DTHTMLParserTextNode.h"
-#import "DTWeakSupport.h"
 
 @implementation DTHTMLParserNode
 {
 	NSString *_name;
-	DT_WEAK_VARIABLE DTHTMLParserNode *_parentNode;
+	__weak DTHTMLParserNode *_parentNode;
 	NSMutableArray *_childNodes;
 }
 

--- a/Core/Source/DTLazyImageView.h
+++ b/Core/Source/DTLazyImageView.h
@@ -6,7 +6,7 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <Foundation/Foundation.h>
 
 @class DTLazyImageView;
 
@@ -60,7 +60,7 @@ extern NSString * const DTLazyImageViewDidFinishDownloadNotification;
 /**
  The delegate, conforming to <DTLazyImageViewDelegate>, to inform when the image dimensions were determined
  */
-@property (nonatomic, DT_WEAK_PROPERTY) id<DTLazyImageViewDelegate> delegate;
+@property (nonatomic, weak) id<DTLazyImageViewDelegate> delegate;
 
 
 /**

--- a/Core/Source/DTLazyImageView.m
+++ b/Core/Source/DTLazyImageView.m
@@ -37,7 +37,7 @@ NSString * const DTLazyImageViewDidFinishDownloadNotification = @"DTLazyImageVie
 	
 	BOOL shouldShowProgressiveDownload;
 	
-	DT_WEAK_VARIABLE id<DTLazyImageViewDelegate> _delegate;
+	__weak id<DTLazyImageViewDelegate> _delegate;
 }
 
 - (void)dealloc

--- a/Core/Source/DTWebVideoView.h
+++ b/Core/Source/DTWebVideoView.h
@@ -6,7 +6,7 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <Foundation/Foundation.h>
 
 @class DTWebVideoView;
 @class DTTextAttachment;
@@ -42,7 +42,7 @@
 /**
  The delegate of the video view
  */
-@property (nonatomic, DT_WEAK_PROPERTY) id <DTWebVideoViewDelegate> delegate;
+@property (nonatomic, weak) id <DTWebVideoViewDelegate> delegate;
 
 /**
  The text attachment representing an embedded video.

--- a/Core/Source/DTWebVideoView.m
+++ b/Core/Source/DTWebVideoView.m
@@ -19,7 +19,7 @@
 {
 	DTTextAttachment *_attachment;
 	
-	DT_WEAK_VARIABLE id <DTWebVideoViewDelegate> _delegate;
+	__weak id <DTWebVideoViewDelegate> _delegate;
 	
 	UIWebView *_webView;
 }

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name         = 'DTCoreText'
   spec.version      = '1.6.15'
-  spec.platform     = :ios, '4.3'
+  spec.platform     = :ios, '5.0'
   spec.license      = 'BSD'
   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
   spec.source_files = 'Core/Source/*.{h,m,c}'

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -691,6 +691,27 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		1193B8AE1ACAF65A0016ED24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A785701C17FAA69D0080AB0A /* DTFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FAC284E619B84B5F0010C385;
+			remoteInfo = "DTActionSheet Demo";
+		};
+		1193B8B01ACAF65A0016ED24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A785701C17FAA69D0080AB0A /* DTFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A7EA07B81A2B2F6A00B61CCE;
+			remoteInfo = "DTFoundation (iOS)";
+		};
+		1193B8B21ACAF65A0016ED24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A785701C17FAA69D0080AB0A /* DTFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A7EA07391A2B215200B61CCE;
+			remoteInfo = "DTFoundation (OSX)";
+		};
 		A70E62FF16C254EB009B47BF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
@@ -711,13 +732,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = A7AC21AE196417830009E1B9;
 			remoteInfo = "DTAnimatedGIF (iOS)";
-		};
-		A781FE8E17FAABE500A1F5E8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A785701C17FAA69D0080AB0A /* DTFoundation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = A7BAD10E1483F934000E2B6A;
-			remoteInfo = "Static Framework";
 		};
 		A781FE9017FAABE500A1F5E8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1460,7 +1474,6 @@
 		A781FE7817FAABE500A1F5E8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A781FE8F17FAABE500A1F5E8 /* DTFoundation.framework */,
 				A781FE9117FAABE500A1F5E8 /* libDTFoundation.a */,
 				A781FE9517FAABE500A1F5E8 /* libDTFoundation_Mac.a */,
 				A7F0C43A1965A0D600D7FAFB /* libDTAnimatedGIF.a */,
@@ -1482,7 +1495,10 @@
 				A781FEB117FAABE500A1F5E8 /* DTReachability Demo.app */,
 				A781FEAF17FAABE500A1F5E8 /* DTSidePanels Demo.app */,
 				A781FEB317FAABE500A1F5E8 /* DTZipArchive.app */,
+				1193B8AF1ACAF65A0016ED24 /* DTActionSheet Demo.app */,
 				A781FE9317FAABE500A1F5E8 /* Unit Tests.xctest */,
+				1193B8B11ACAF65A0016ED24 /* DTFoundation.framework */,
+				1193B8B31ACAF65A0016ED24 /* DTFoundation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2280,11 +2296,25 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		A781FE8F17FAABE500A1F5E8 /* DTFoundation.framework */ = {
+		1193B8AF1ACAF65A0016ED24 /* DTActionSheet Demo.app */ = {
 			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
+			fileType = wrapper.application;
+			path = "DTActionSheet Demo.app";
+			remoteRef = 1193B8AE1ACAF65A0016ED24 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		1193B8B11ACAF65A0016ED24 /* DTFoundation.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
 			path = DTFoundation.framework;
-			remoteRef = A781FE8E17FAABE500A1F5E8 /* PBXContainerItemProxy */;
+			remoteRef = 1193B8B01ACAF65A0016ED24 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		1193B8B31ACAF65A0016ED24 /* DTFoundation.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = DTFoundation.framework;
+			remoteRef = 1193B8B21ACAF65A0016ED24 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		A781FE9117FAABE500A1F5E8 /* libDTFoundation.a */ = {
@@ -3340,7 +3370,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
 			};
@@ -3593,7 +3623,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
@@ -3613,7 +3643,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";

--- a/Documentation/Setup Guide-template.markdown
+++ b/Documentation/Setup Guide-template.markdown
@@ -14,12 +14,13 @@ GitHub offers tar balls for the individual tagged versions but you shouldn't try
 Requirements
 ------------
 
-DTCoreText needs a minimum iOS deployment target of iOS 4.2 because of:
+DTCoreText needs a minimum iOS deployment target of iOS 5.0 because of:
 
 - NSCache
 - GCD-based threading and locking
 - Blocks
 - ARC
+- Weak variables and properties
 
 Support for OS X is currently being developed.
 


### PR DESCRIPTION
This is a potential fix for Issue #850. I was not able to find any way to make the header search path work with DTFoundation given that the source is kept in a subfolder of the framework name.

In order to be compiled as a module framework, we cannot reference anything in our headers that are not included in the module, or referenced as a separate framework (ie #import <DTFoundation/DTSomething.h>). If we simply converted our #imports to frameworks imports, it breaks the sample app, and probably other apps that include the framework in a similar way.

However, if we move a single protocol reference to the .m file instead of the header, the only DTFoundation imports left is DTWeakSupport.h. This file is used to support iOS 4.3 which doesn't have weak variables. If we change the minimum version to iOS 5, we can remove our dependency on that file completely. Unfortunately, that means we break support for iOS 4.3, but it has been 4 years now.