### PR TITLE
Added DTDocumentPreserveTrailingSpaces boolean option

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -55,6 +55,7 @@ extern NSString * const DTUseiOS6Attributes;
 extern NSString * const DTWillFlushBlockCallBack;
 extern NSString * const DTProcessCustomHTMLAttributes;
 extern NSString * const DTIgnoreInlineStylesOption;
+extern NSString * const DTDocumentPreserveTrailingSpaces;
 
 
 // attributed string attribute constants

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -28,6 +28,7 @@ NSString * const DTUseiOS6Attributes = @"DTUseiOS6Attributes";
 NSString * const DTWillFlushBlockCallBack = @"DTWillFlushBlockCallBack";
 NSString * const DTProcessCustomHTMLAttributes = @"DTProcessCustomHTMLAttributes";
 NSString * const DTIgnoreInlineStylesOption = @"DTIgnoreInlineStyles";
+NSString * const DTDocumentPreserveTrailingSpaces = @"DTDocumentPreserveTrailingSpaces";
 
 // attributed string attribute constants
 

--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -68,6 +68,7 @@
 	DTHTMLElement *_currentTag;
 	BOOL _ignoreParseEvents; // ignores events from parser after first HTML tag was finished
 	BOOL _ignoreInlineStyles; // ignores style blocks attached on elements
+	BOOL _preserverDocumentTrailingSpaces; // don't remove spaces at end of document
 }
 
 - (id)initWithHTML:(NSData *)data options:(NSDictionary *)options documentAttributes:(NSDictionary * __autoreleasing*)docAttributes
@@ -321,6 +322,9 @@
 	
 	// ignore inline styles if option is passed
 	_ignoreInlineStyles = [[_options objectForKey:DTIgnoreInlineStylesOption] boolValue];
+	
+	// don't remove spaces at end of document
+	_preserverDocumentTrailingSpaces = [[_options objectForKey:DTDocumentPreserveTrailingSpaces] boolValue];
 	
 	// create a parser
 	DTHTMLParser *parser = [[DTHTMLParser alloc] initWithData:_data encoding:encoding];
@@ -956,17 +960,18 @@
 
 - (void)parserDidEndDocument:(DTHTMLParser *)parser
 {
-
 	dispatch_group_async(_treeBuildingGroup, _treeBuildingQueue, ^{
 		NSAssert(!_currentTag, @"Something went wrong, at end of document there is still an open node");
 
-		dispatch_group_async(_stringAssemblyGroup, _stringAssemblyQueue, ^{
-			// trim off white space at end
-			while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceCharacterSet]])
-			{
-				[_tmpString deleteCharactersInRange:NSMakeRange([_tmpString length]-1, 1)];
-			}
-		});
+		if (!_preserverDocumentTrailingSpaces) {
+			dispatch_group_async(_stringAssemblyGroup, _stringAssemblyQueue, ^{
+				// trim off white space at end
+				while ([[_tmpString string] hasSuffixCharacterFromSet:[NSCharacterSet whitespaceCharacterSet]])
+				{
+					[_tmpString deleteCharactersInRange:NSMakeRange([_tmpString length]-1, 1)];
+				}
+			});
+		}
 	});
 }
 


### PR DESCRIPTION
Added DTDocumentPreserveTrailingSpaces boolean option to prevent trimming of white spaces at end of document.