### PR TITLE
DTCoreLayoutFrame truncation

### DIFF
--- a/Core/Source/CTLineUtils.h
+++ b/Core/Source/CTLineUtils.h
@@ -1,0 +1,10 @@
+//
+//  CTLineUtils.h
+//  DTCoreText
+//
+//  Created by Oleksandr Deundiak on 7/15/15.
+//  Copyright 2015. All rights reserved.
+//
+
+BOOL areLinesEqual(CTLineRef line1, CTLineRef line2);
+CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc);

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -12,17 +12,17 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
 {
     CFArrayRef glyphRuns1 = CTLineGetGlyphRuns(line1);
     CFArrayRef glyphRuns2 = CTLineGetGlyphRuns(line2);
-    int runCount1 = CFArrayGetCount(glyphRuns1), runCount2 = CFArrayGetCount(glyphRuns2);
+    CFIndex runCount1 = CFArrayGetCount(glyphRuns1), runCount2 = CFArrayGetCount(glyphRuns2);
     
     if (runCount1 != runCount2)
         return NO;
     
-    for (int i = 0; i < runCount1; i++)
+    for (CFIndex i = 0; i < runCount1; i++)
     {
         CTRunRef run1 = CFArrayGetValueAtIndex(glyphRuns1, i);
         CTRunRef run2 = CFArrayGetValueAtIndex(glyphRuns2, i);
         
-        int countInRun1 = CTRunGetGlyphCount(run1), countInRun2 = CTRunGetGlyphCount(run2);
+        CFIndex countInRun1 = CTRunGetGlyphCount(run1), countInRun2 = CTRunGetGlyphCount(run2);
         if (countInRun1 != countInRun2)
             return NO;
         
@@ -45,7 +45,7 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
         }
         
         BOOL result = YES;
-        for (int j = 0; j < countInRun1; j++)
+        for (CFIndex j = 0; j < countInRun1; j++)
         {
             if (glyphs1[j] != glyphs2[j])
             {

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -26,22 +26,22 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
         if (countInRun1 != countInRun2)
             return NO;
         
-        const CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
-        BOOL shouldFreeMem1 = NO;
-        if (glyphs1 == NULL)
+        const CGGlyph* constGlyphs1 = CTRunGetGlyphsPtr(run1);
+		CGGlyph* glyphs1 = NULL;
+        if (constGlyphs1 == NULL)
         {
             glyphs1 = (CGGlyph*)malloc(countInRun1*sizeof(CGGlyph));
             CTRunGetGlyphs(run1, CFRangeMake(0, countInRun1), glyphs1);
-            shouldFreeMem1 = YES;
+			constGlyphs1 = glyphs1;
         }
         
-        const CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
-        BOOL shouldFreeMem2 = NO;
-        if (glyphs2 == NULL)
+        const CGGlyph* constGlyphs2 = CTRunGetGlyphsPtr(run2);
+		CGGlyph* glyphs2 = NULL;
+        if (constGlyphs2 == NULL)
         {
             glyphs2 = (CGGlyph*)malloc(countInRun2*sizeof(CGGlyph));
             CTRunGetGlyphs(run2, CFRangeMake(0, countInRun2), glyphs2);
-            shouldFreeMem2 = YES;
+			constGlyphs2 = glyphs2;
         }
         
         BOOL result = YES;
@@ -54,10 +54,10 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
             }
         }
         
-        if (shouldFreeMem1)
+        if (glyphs1 != NULL)
             free(glyphs1);
         
-        if (shouldFreeMem2)
+        if (glyphs2 != NULL)
             free(glyphs2);
         
         if (!result)

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -47,7 +47,7 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
         BOOL result = YES;
         for (CFIndex j = 0; j < countInRun1; j++)
         {
-            if (glyphs1[j] != glyphs2[j])
+            if (constGlyphs1[j] != constGlyphs2[j])
             {
                 result = NO;
                 break;

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -26,8 +26,8 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
         if (countInRun1 != countInRun2)
             return NO;
         
-        CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
-        CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
+        const CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
+        const CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
         
         for (int j = 0; j < countInRun1; j++) {
             if (glyphs1[j] != glyphs2[j])

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -27,12 +27,41 @@ BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
             return NO;
         
         const CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
-        const CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
-        
-        for (int j = 0; j < countInRun1; j++) {
-            if (glyphs1[j] != glyphs2[j])
-                return NO;
+        BOOL shouldFreeMem1 = NO;
+        if (glyphs1 == NULL)
+        {
+            glyphs1 = (CGGlyph*)malloc(countInRun1*sizeof(CGGlyph));
+            CTRunGetGlyphs(run1, CFRangeMake(0, countInRun1), glyphs1);
+            shouldFreeMem1 = YES;
         }
+        
+        const CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
+        BOOL shouldFreeMem2 = NO;
+        if (glyphs2 == NULL)
+        {
+            glyphs2 = (CGGlyph*)malloc(countInRun2*sizeof(CGGlyph));
+            CTRunGetGlyphs(run2, CFRangeMake(0, countInRun2), glyphs2);
+            shouldFreeMem2 = YES;
+        }
+        
+        BOOL result = YES;
+        for (int j = 0; j < countInRun1; j++)
+        {
+            if (glyphs1[j] != glyphs2[j])
+            {
+                result = NO;
+                break;
+            }
+        }
+        
+        if (shouldFreeMem1)
+            free(glyphs1);
+        
+        if (shouldFreeMem2)
+            free(glyphs2);
+        
+        if (!result)
+            return NO;
     }
     
     return YES;

--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -1,0 +1,53 @@
+//
+//  CTLineUtils.m
+//  DTCoreText
+//
+//  Created by Oleksandr Deundiak on 7/15/15.
+//  Copyright 2015. All rights reserved.
+//
+
+#import "CTLineUtils.h"
+
+BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
+{
+    CFArrayRef glyphRuns1 = CTLineGetGlyphRuns(line1);
+    CFArrayRef glyphRuns2 = CTLineGetGlyphRuns(line2);
+    int runCount1 = CFArrayGetCount(glyphRuns1), runCount2 = CFArrayGetCount(glyphRuns2);
+    
+    if (runCount1 != runCount2)
+        return NO;
+    
+    for (int i = 0; i < runCount1; i++)
+    {
+        CTRunRef run1 = CFArrayGetValueAtIndex(glyphRuns1, i);
+        CTRunRef run2 = CFArrayGetValueAtIndex(glyphRuns2, i);
+        
+        int countInRun1 = CTRunGetGlyphCount(run1), countInRun2 = CTRunGetGlyphCount(run2);
+        if (countInRun1 != countInRun2)
+            return NO;
+        
+        CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
+        CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
+        
+        for (int j = 0; j < countInRun1; j++) {
+            if (glyphs1[j] != glyphs2[j])
+                return NO;
+        }
+    }
+    
+    return YES;
+}
+
+CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc)
+{
+    CFIndex truncCount = CFArrayGetCount(CTLineGetGlyphRuns(trunc));
+    
+    CFArrayRef lineRuns = CTLineGetGlyphRuns(line);
+    CFIndex lineRunsCount = CFArrayGetCount(lineRuns);
+    
+    CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, lineRunsCount - truncCount - 1);
+    
+    CFRange lastRunRange = CTRunGetStringRange(lineLastRun);
+    
+    return lastRunRange.location = lastRunRange.length;
+}

--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -16,6 +16,7 @@
 #import "DTCoreTextFunctions.h"
 #import "DTTextAttachment.h"
 #import "NSString+Paragraphs.h"
+#import "CTLineUtils.h"
 
 #import <DTFoundation/DTLog.h>
 
@@ -411,50 +412,6 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 
 #pragma mark - Building the Lines
 
-bool areLinesEqual(CTLineRef line1, CTLineRef line2)
-{
-    CFArrayRef glyphRuns1 = CTLineGetGlyphRuns(line1);
-    CFArrayRef glyphRuns2 = CTLineGetGlyphRuns(line2);
-    int runCount1 = CFArrayGetCount(glyphRuns1), runCount2 = CFArrayGetCount(glyphRuns2);
-    
-    if (runCount1 != runCount2)
-        return false;
-    
-    for (int i = 0; i < runCount1; i++)
-    {
-        CTRunRef run1 = CFArrayGetValueAtIndex(glyphRuns1, i);
-        CTRunRef run2 = CFArrayGetValueAtIndex(glyphRuns2, i);
-        
-        int countInRun1 = CTRunGetGlyphCount(run1), countInRun2 = CTRunGetGlyphCount(run2);
-        if (countInRun1 != countInRun2)
-            return false;
-        
-        CGGlyph* glyphs1 = CTRunGetGlyphsPtr(run1);
-        CGGlyph* glyphs2 = CTRunGetGlyphsPtr(run2);
-        
-        for (int j = 0; j < countInRun1; j++) {
-            if (glyphs1[j] != glyphs2[j])
-                return false;
-        }
-    }
-    
-    return true;
-}
-
-CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc)
-{
-    CFIndex truncCount = CFArrayGetCount(CTLineGetGlyphRuns(trunc));
-    
-    CFArrayRef lineRuns = CTLineGetGlyphRuns(line);
-    CFIndex lineRunsCount = CFArrayGetCount(lineRuns);
-    
-    CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, lineRunsCount - truncCount - 1);
-    
-    CFRange lastRunRange = CTRunGetStringRange(lineLastRun);
-    
-    return lastRunRange.location = lastRunRange.length;
-}
-
 /*
  Builds the array of lines with the internal typesetter of our framesetter. No need to correct line origins in this case because they are placed correctly in the first place. This version supports text boxes.
  */
@@ -613,35 +570,42 @@ CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc)
 			// create the truncated line
 			line = CTLineCreateTruncatedLine(baseLine, availableSpace, truncationType, elipsisLineRef);
             
-            // check if truncation was occured
+            // check if truncation occured
             BOOL truncationOccured = !areLinesEqual(baseLine, line);
-            // if yes check was it before end of the current paragraph or after
+            // if yes check was it before the end of the current paragraph or after
             NSUInteger endOfParagraphIndex = NSMaxRange(currentParagraphRange);
-            if (truncationOccured)
+            // this works only for truncation at the end
+            if (truncationType == kCTLineTruncationEnd)
             {
-                CFIndex truncationIndex = getTruncationIndex(line, elipsisLineRef);
-                if (truncationIndex > endOfParagraphIndex)
+                if (truncationOccured)
                 {
-                    NSAttributedString *subStr = [_attributedStringFragment attributedSubstringFromRange:NSMakeRange(lineRange.location, endOfParagraphIndex - lineRange.location)];
-                    NSMutableAttributedString *attrMutStr = [subStr mutableCopy];
-                    [attrMutStr appendAttributedString:attribStr];
-                    CFRelease(line);
-                    line = CTLineCreateWithAttributedString((__bridge  CFAttributedStringRef)(attrMutStr));
+                    CFIndex truncationIndex = getTruncationIndex(line, elipsisLineRef);
+                    // if truncation occured after the end of the paragraph
+                    // move truncation token to the end of the paragraph
+                    if (truncationIndex > endOfParagraphIndex)
+                    {
+                        NSAttributedString *subStr = [_attributedStringFragment attributedSubstringFromRange:NSMakeRange(lineRange.location, endOfParagraphIndex - lineRange.location - 1)];
+                        NSMutableAttributedString *attrMutStr = [subStr mutableCopy];
+                        [attrMutStr appendAttributedString:attribStr];
+                        CFRelease(line);
+                        line = CTLineCreateWithAttributedString((__bridge  CFAttributedStringRef)(attrMutStr));
+                    }
+                    // otherwise, everything is OK
+                }
+                else
+                {
+                    // if no truncation happened, force addition of
+                    // the truncation token to the end of the paragraph
+                    if (maxIndex != endOfParagraphIndex)
+                    {
+                        NSAttributedString *subStr = [_attributedStringFragment attributedSubstringFromRange:NSMakeRange(lineRange.location, endOfParagraphIndex - lineRange.location - 1)];
+                        NSMutableAttributedString *attrMutStr = [subStr mutableCopy];
+                        [attrMutStr appendAttributedString:attribStr];
+                        CFRelease(line);
+                        line = CTLineCreateWithAttributedString((__bridge  CFAttributedStringRef)(attrMutStr));
+                    }
                 }
             }
-            else
-            {
-                if (maxIndex != endOfParagraphIndex)
-                {
-                    NSAttributedString *subStr = [_attributedStringFragment attributedSubstringFromRange:NSMakeRange(lineRange.location, endOfParagraphIndex - lineRange.location)];
-                    NSMutableAttributedString *attrMutStr = [subStr mutableCopy];
-                    [attrMutStr appendAttributedString:attribStr];
-                    CFRelease(line);
-                    line = CTLineCreateWithAttributedString((__bridge  CFAttributedStringRef)(attrMutStr));
-                }
-            }
-            // if before all is done
-            // if not mode truncation string just before the end of paragraph
 			
 			// clean up
 			CFRelease(baseLine);

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -30,6 +30,11 @@
 		36F8CECE1593AA3D00E9599C /* DTHTMLAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7949A4514CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		36F8CECF1593AA4200E9599C /* DTHTMLAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7949A4514CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.h */; };
 		4266937E1B56F60D00F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
+		426693AA1B56F91200F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
+		426693AB1B56F92C00F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
+		426693AC1B56F94300F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
+		426693AD1B56F97200F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
+		426693AE1B56F98500F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
 		5AF0E509CE9C6EC97E3007F5 /* AutoLayoutDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0E4DB1FBCBA1C165C0959 /* AutoLayoutDemoViewController.m */; };
 		5AF0ECFF9BD94137DE0992BA /* AutoLayoutDemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AF0E4D86A6BE8FC798F9702 /* AutoLayoutDemoViewController.xib */; };
 		944A9E6418B5A7F000E41481 /* DTCSSListStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 944A9E6318B5A7F000E41481 /* DTCSSListStyleTest.m */; };
@@ -2910,6 +2915,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A758FC9614DBC7A2007DF8B2 /* default.css in Sources */,
+				426693AB1B56F92C00F9DBFC /* CTLineUtils.m in Sources */,
 				A788C96014863E8700E1AFD9 /* DTAttributedTextCell.m in Sources */,
 				A788C96514863E8700E1AFD9 /* DTAttributedTextContentView.m in Sources */,
 				A788C96A14863E8700E1AFD9 /* DTAttributedTextView.m in Sources */,
@@ -2978,6 +2984,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A758FC9814DBCF20007DF8B2 /* default.css in Sources */,
+				426693AA1B56F91200F9DBFC /* CTLineUtils.m in Sources */,
 				A788C96114863E8700E1AFD9 /* DTAttributedTextCell.m in Sources */,
 				A788C96614863E8700E1AFD9 /* DTAttributedTextContentView.m in Sources */,
 				A788C96B14863E8700E1AFD9 /* DTAttributedTextView.m in Sources */,
@@ -3095,6 +3102,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A79BA6CD1B46A4250086C2F6 /* default.css in Sources */,
+				426693AD1B56F97200F9DBFC /* CTLineUtils.m in Sources */,
 				A79BA6B21B46A2700086C2F6 /* NSAttributedStringRunDelegates.m in Sources */,
 				A7B130501B4B25BF0014E109 /* DTLazyImageView.m in Sources */,
 				A7B130541B4B25BF0014E109 /* DTLinkButton.m in Sources */,
@@ -3162,6 +3170,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A7F7EF781573603100F5A4D0 /* default.css in Sources */,
+				426693AC1B56F94300F9DBFC /* CTLineUtils.m in Sources */,
 				A7F7EF7A1573603100F5A4D0 /* DTAttributedTextCell.m in Sources */,
 				A7F7EF7B1573603100F5A4D0 /* DTAttributedTextContentView.m in Sources */,
 				A7F7EF7C1573603100F5A4D0 /* DTAttributedTextView.m in Sources */,
@@ -3229,6 +3238,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2262E0B1638351C00BFDAD7 /* default.css in Sources */,
+				426693AE1B56F98500F9DBFC /* CTLineUtils.m in Sources */,
 				E2262DD51638336700BFDAD7 /* DTColor+Compatibility.m in Sources */,
 				E2262DD61638336700BFDAD7 /* DTImage+HTML.m in Sources */,
 				E2262DD81638337D00BFDAD7 /* DTCoreTextConstants.m in Sources */,

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		36F8CECC1593AA3C00E9599C /* DTHTMLAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7949A4514CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		36F8CECE1593AA3D00E9599C /* DTHTMLAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7949A4514CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		36F8CECF1593AA4200E9599C /* DTHTMLAttributedStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7949A4514CAF58C00A8CCDE /* DTHTMLAttributedStringBuilder.h */; };
+		4266937E1B56F60D00F9DBFC /* CTLineUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4266937D1B56F60D00F9DBFC /* CTLineUtils.m */; };
 		5AF0E509CE9C6EC97E3007F5 /* AutoLayoutDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0E4DB1FBCBA1C165C0959 /* AutoLayoutDemoViewController.m */; };
 		5AF0ECFF9BD94137DE0992BA /* AutoLayoutDemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AF0E4D86A6BE8FC798F9702 /* AutoLayoutDemoViewController.xib */; };
 		944A9E6418B5A7F000E41481 /* DTCSSListStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 944A9E6318B5A7F000E41481 /* DTCSSListStyleTest.m */; };
@@ -1087,6 +1088,8 @@
 		1D6058910D05DD3D006BFB54 /* RTDemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RTDemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		288765A40DF7441C002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		4266937C1B56F60D00F9DBFC /* CTLineUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTLineUtils.h; sourceTree = "<group>"; };
+		4266937D1B56F60D00F9DBFC /* CTLineUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTLineUtils.m; sourceTree = "<group>"; };
 		5AF0E4D86A6BE8FC798F9702 /* AutoLayoutDemoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AutoLayoutDemoViewController.xib; sourceTree = "<group>"; };
 		5AF0E4DB1FBCBA1C165C0959 /* AutoLayoutDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoLayoutDemoViewController.m; sourceTree = "<group>"; };
 		5AF0E909A170F1B0FF3CCC47 /* AutoLayoutDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoLayoutDemoViewController.h; sourceTree = "<group>"; };
@@ -1790,6 +1793,8 @@
 		A788CAA81486492200E1AFD9 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				4266937C1B56F60D00F9DBFC /* CTLineUtils.h */,
+				4266937D1B56F60D00F9DBFC /* CTLineUtils.m */,
 				A788C94A14863E8700E1AFD9 /* NSString+Paragraphs.h */,
 				A788C94B14863E8700E1AFD9 /* NSString+Paragraphs.m */,
 				A78EEA6016774B5F003B5540 /* UIFont+DTCoreText.h */,
@@ -2892,6 +2897,7 @@
 			files = (
 				A788CA5014863EF100E1AFD9 /* CoreTextDemoAppDelegate.m in Sources */,
 				A788CA5114863EF100E1AFD9 /* DemoSnippetsViewController.m in Sources */,
+				4266937E1B56F60D00F9DBFC /* CTLineUtils.m in Sources */,
 				A788CA5214863EF100E1AFD9 /* DemoTextViewController.m in Sources */,
 				A788CA5314863EF100E1AFD9 /* main.m in Sources */,
 				A740368816E51B3A00ECCDE0 /* DemoAboutViewController.m in Sources */,


### PR DESCRIPTION
Hi. Our team faced problem with DTCoreLayoutFrame truncation when using DTAttributedLabel: if numberOfLines > 0 and the last displayed line is also the last line in its paragraph (which is not the last paragraph) and it fits in label width, truncationString isn't appended at the end of this line. We consider this behavior as a bug, because the label doesn't indicate any truncation, while the text isn't fully shown.

We managed to fix this issue, in case when line breaking mode is NSLineBreakByTruncatingTail.