### PR TITLE
Remove duplicated DTDefaultLineHeightMultiplier declaration in header

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -47,7 +47,6 @@ extern NSString * const DTDefaultLinkDecoration;
 extern NSString * const DTDefaultLinkHighlightColor;
 extern NSString * const DTDefaultTextAlignment;
 extern NSString * const DTDefaultLineHeightMultiplier;
-extern NSString * const DTDefaultLineHeightMultiplier;
 extern NSString * const DTDefaultFirstLineHeadIndent;
 extern NSString * const DTDefaultHeadIndent;
 extern NSString * const DTDefaultStyleSheet;


### PR DESCRIPTION
I found a duplicated DTDefaultLineHeightMultiplier declaration in header "DDTCoreTextConstants.h"