### PR TITLE
Add iOS 7 check to NSAttachmentAttributeName declaration

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -32,7 +32,6 @@
 extern NSString * const NSBaseURLDocumentOption;
 extern NSString * const NSTextEncodingNameDocumentOption;
 extern NSString * const NSTextSizeMultiplierDocumentOption;
-extern NSString * const NSAttachmentAttributeName; 
 #endif
 
 // custom options

--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -32,6 +32,11 @@
 extern NSString * const NSBaseURLDocumentOption;
 extern NSString * const NSTextEncodingNameDocumentOption;
 extern NSString * const NSTextSizeMultiplierDocumentOption;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_7_0
+extern NSString * const NSAttachmentAttributeName; 
+#endif
+
 #endif
 
 // custom options

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -6,6 +6,11 @@
 NSString * const NSBaseURLDocumentOption = @"NSBaseURLDocumentOption";
 NSString * const NSTextEncodingNameDocumentOption = @"NSTextEncodingNameDocumentOption";
 NSString * const NSTextSizeMultiplierDocumentOption = @"NSTextSizeMultiplierDocumentOption";
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_7_0
+NSString * const NSAttachmentAttributeName = @"NSAttachmentAttributeName";
+#endif
+
 #endif
 
 // custom options

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -6,7 +6,6 @@
 NSString * const NSBaseURLDocumentOption = @"NSBaseURLDocumentOption";
 NSString * const NSTextEncodingNameDocumentOption = @"NSTextEncodingNameDocumentOption";
 NSString * const NSTextSizeMultiplierDocumentOption = @"NSTextSizeMultiplierDocumentOption";
-NSString * const NSAttachmentAttributeName = @"NSAttachmentAttributeName";
 #endif
 
 // custom options


### PR DESCRIPTION
Removed the <code>NSAttachmentAttributeName</code> constant in DTCoreTextConstants, because it overrides the same constant in UIKit and causes conflicts when mixing attributed strings created with <code>attributedStringWithAttachment:</code> and <code>initWithHTMLData:options:documentAttributes:</code>.  

Also described in issue #715.