### PR TITLE
Add ability to change paragraph tag name

### DIFF
--- a/Core/Source/DTHTMLWriter.h
+++ b/Core/Source/DTHTMLWriter.h
@@ -57,4 +57,10 @@
  */
 @property (nonatomic, readonly) NSAttributedString *attributedString;
 
+
+/**
+ The HTML element tag name to use for paragraphs. Defaults to @"p".
+ */
+@property (nonatomic, strong) NSString *paragraphTagName;
+
 @end

--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -42,6 +42,8 @@
 
 		// default is to leave px sizes as is
 		_textScale = 1.0f;
+		
+		_paragraphTagName = @"p";
 	}
 	
 	return self;
@@ -430,7 +432,7 @@
 		}
 		else
 		{
-			blockElement = @"p";
+			blockElement = _paragraphTagName;
 		}
 		
 		NSNumber *headerLevel = [paraAttributes objectForKey:DTHeaderLevelAttribute];


### PR DESCRIPTION
This allows clients who prefer to emit `div` tags to do so easily -- styles pick up the element name and are applied properly.

If you're round tripping HTML through DTCoreText, and you know the input HTML uses `div` this makes it easy to ensure the output doesn't add significant whitespace to every paragraph by switching to `p` tags.