### PR TITLE
Update Programming Guide-template.markdown

### DIFF
--- a/Documentation/Programming Guide-template.markdown
+++ b/Documentation/Programming Guide-template.markdown
@@ -193,4 +193,12 @@ NSData* descriptionData = [html dataUsingEncoding:NSUTF8StringEncoding];
 NSAttributedString* attributedDescription = [[NSAttributedString alloc] initWithHTMLData:descriptionData options:options documentAttributes:NULL];
 ```
 
+Adding Custom Font with FontFaceName
+--------------------------------
+When you want to add a custom font to the HTML being rendered using FontFaceName, you can add ```-coretext-fontname: SourceSansPro-Light;``` to the stylesheet.
+An example would be:
+```
+    let customStyleSheet = DTCSSStylesheet(styleBlock: "body { -coretext-fontname: SourceSansPro-Light; }")
+    DTCSSStylesheet.defaultStyleSheet().mergeStylesheet(customStyleSheet)
+```
 


### PR DESCRIPTION
Problem Defintion:

1. Could not find documentation to add custom font, based on the font face name. 

Solution:
1. Updated the Programming Guide to include `-coretext-fontname` as part of the documentation.