### PR TITLE
remove SYMROOT recursive search path from build settings

### DIFF
--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -3486,7 +3486,6 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"${TARGET_BUILD_DIR}/**",
-					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
@@ -3697,7 +3696,6 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"${TARGET_BUILD_DIR}/**",
-					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
@@ -3723,7 +3721,6 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"${TARGET_BUILD_DIR}/**",
-					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;


### PR DESCRIPTION
Hello,

We have an iOS project that uses DTCoreText and React Native as dependencies. We found that building via CLI logs an error with the following message: 

```
=== BUILD TARGET Static Library OF PROJECT DTCoreText WITH CONFIGURATION Release ===

Check dependencies
Argument list too long: recursive header expansion failed at /Users/jenkins/.jenkins/jobs/ios-2.2.1-release/workspace/build/../../workspace/node_modules/react-native/node_modules/babel-preset-react-native/node_modules/babel-plugin-check-es2015-constants/node_modules/babel-runtime/core-js/error.
```

This is because React Native happens to be a project with many files, folders and subfolders, but it can happen with any other project with a similar folder hierarchy. The issue is documented here: [Argument list too long: #797](https://github.com/facebook/react-native/issues/797)

DTCoreText uses a recursive Header Search Path of `$(SYMROOT)/../..`, which resolves to our project directory `ios-2.2.1-release/workspace/build/../..`, and then proceeds to recursively search all folders in our project which includes folders of other dependencies.

Podfile to include React Native and [setup steps](https://facebook.github.io/react-native/docs/embedded-app-ios.html#content)
```
pod 'React', :path => './node_modules/react-native', :subspecs => [
  'Core',
  'RCTImage',
  'RCTNetwork',
  'RCTText',
  'RCTWebSocket',
]
```