### PR TITLE
add property to better support display remote images with DTAttributedTextCell

### DIFF
--- a/Core/Source/DTLazyImageView.h
+++ b/Core/Source/DTLazyImageView.h
@@ -52,7 +52,7 @@ extern NSString * const DTLazyImageViewDidFinishDownloadNotification;
 /**
  The DTAttributedTextContentView used to display remote images with DTAttributedTextCell
  */
-@property (nonatomic, weak) DTAttributedTextContentView *contentView;
+@property (nonatomic, DT_WEAK_PROPERTY) DTAttributedTextContentView *contentView;
 
 /**
  @name Getting Information

--- a/Core/Source/DTLazyImageView.h
+++ b/Core/Source/DTLazyImageView.h
@@ -7,6 +7,7 @@
 //
 
 #import <DTFoundation/DTWeakSupport.h>
+#import "DTAttributedTextContentView.h"
 
 @class DTLazyImageView;
 
@@ -47,6 +48,11 @@ extern NSString * const DTLazyImageViewDidFinishDownloadNotification;
  The URL Request that is to be used for downloading the image. If this is left `nil` the a new URL Request will be created
  */
 @property (nonatomic, strong) NSMutableURLRequest *urlRequest;
+
+/**
+ The DTAttributedTextContentView used to display remote images with DTAttributedTextCell
+ */
+@property (nonatomic, weak) DTAttributedTextContentView *contentView;
 
 /**
  @name Getting Information

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -3489,7 +3489,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
 			};
@@ -3700,7 +3700,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
@@ -3726,7 +3726,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -3489,7 +3489,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
 			};
@@ -3700,7 +3700,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";
@@ -3726,7 +3726,7 @@
 					"$(SYMROOT)/../../**",
 					/usr/include/libxml2,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Core/Source\" \"$(SRCROOT)/Externals/DTFoundation/Core/Source\"/**";


### PR DESCRIPTION
I find it hard to access attributedTextContentView in [- (void)lazyImageView:(DTLazyImageView *)lazyImageView didChangeImageSize:(CGSize)size] when you use DTAttributedTextCell to display remote images.