### PR TITLE
Only scan list-tyle-image css value if it is a string

### DIFF
--- a/Core/Source/DTCSSListStyle.m
+++ b/Core/Source/DTCSSListStyle.m
@@ -244,14 +244,14 @@
 	[self setTypeWithString:[styles objectForKey:@"list-style-type"]];
 	[self setPositionWithString:[styles objectForKey:@"list-style-position"]];
 	
-	NSString *tmpStr =  [styles objectForKey:@"list-style-image"];
-	
-	if (tmpStr)
+	NSObject *tmpValue = [styles objectForKey:@"list-style-image"];
+
+	if ([tmpValue isKindOfClass:NSString.class])
 	{
 		// extract just the name
 		
 		NSString *urlString;
-		NSScanner *scanner = [NSScanner scannerWithString:tmpStr];
+		NSScanner *scanner = [NSScanner scannerWithString:(NSString *)tmpValue];
 		
 		if ([scanner scanCSSURL:&urlString])
 		{


### PR DESCRIPTION
In some cases--the only one I have found so far is inline svg urls--the value for a list-tyle-image is actually an array (it gets split on commas). Previously, parsing the list style would crash. Now we only parse it if it is a string. For reference, here is the line that caused the crash:

```css
list-style-image: = url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF=-8%22%3F%3E%0A%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%=20version%3D%221.1%22%20width%3D%225%22%20height%3D%2213%22%3E%0A%3Ccircle=%20cx%3D%222.5%22%20cy%3D%229.5%22%20r%3D%222.5%22%20fill%3D%22%2300528c%2=2%2F%3E%0A%3C%2Fsvg%3E%0A);
```