### PR TITLE
Fix Error: App Crashes when compare lines and one of them is nil.

### DIFF
--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -10,6 +10,10 @@
 
 BOOL areLinesEqual(CTLineRef line1, CTLineRef line2)
 {
+	if(line1 == nil || line2 == nil) {
+		return NO;
+	}
+	
     CFArrayRef glyphRuns1 = CTLineGetGlyphRuns(line1);
     CFArrayRef glyphRuns2 = CTLineGetGlyphRuns(line2);
     CFIndex runCount1 = CFArrayGetCount(glyphRuns1), runCount2 = CFArrayGetCount(glyphRuns2);


### PR DESCRIPTION
App crashes in:
CTLineUtils.m on line 16:
It cannot create a runCount2 because the line2 is nil.
This happend because Apples CTLineCreateTruncatedLine(...) in DTCoreTextLayoutFrame.m Line 571 returns nil.

I inserted this in CTLineUtils.m on Line 13 to return quickly to the calling function.

```
if(line1 == nil || line2 == nil) {
  return NO;
}
```

