### PR TITLE
Add extension subspec to podspec

### DIFF
--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -4,7 +4,6 @@ Pod::Spec.new do |spec|
   spec.platform     = :ios, '4.3'
   spec.license      = 'BSD'
   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
-  spec.source_files = 'Core/Source/*.{h,m,c}'
   spec.dependency 'DTFoundation/Core', '~>1.7.5'
   spec.dependency 'DTFoundation/UIKit', '~>1.7.5'
   spec.dependency 'DTFoundation/DTHTMLParser', '~>1.7.5'
@@ -17,15 +16,19 @@ Pod::Spec.new do |spec|
   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
-  spec.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited)' }
+  spec.default_subspec = 'Base'
   spec.prepare_command = <<-CMD
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c
   CMD
+
+  spec.subspec 'Base' do |ap|
+    ap.source_files = 'Core/Source/*.{h,m,c}'
+  end
   
   spec.subspec 'Extension' do |ap|
-    ap.source_files = 'Core/Source/*.{h,m,c}'
-#    ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
+    ap.dependency = 'DTCoreText/Base'
+    ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end
 

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -4,6 +4,7 @@ Pod::Spec.new do |spec|
   spec.platform     = :ios, '4.3'
   spec.license      = 'BSD'
   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
+  spec.source_files = 'Core/Source/*.{h,m,c}'
   spec.dependency 'DTFoundation/Core', '~>1.7.5'
   spec.dependency 'DTFoundation/UIKit', '~>1.7.5'
   spec.dependency 'DTFoundation/DTHTMLParser', '~>1.7.5'
@@ -16,19 +17,50 @@ Pod::Spec.new do |spec|
   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
+  spec.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited)' }
   spec.prepare_command = <<-CMD
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c
   CMD
-
-  #spec.default_subspec = 'Core'
-
-  # spec.subspec 'Core' do |ap|
-  #   ap.source_files = 'Core/Source/*.{h,m,c}'
-  # end
   
   spec.subspec 'Extension' do |ap|
-    ap.dependency = 'DTCoreText/Core'
+    ap.source_files = 'Core/Source/*.{h,m,c}'
     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end
+
+
+# Pod::Spec.new do |spec|
+#   spec.name         = 'DTCoreText'
+#   spec.version      = '1.6.17'
+#   spec.platform     = :ios, '4.3'
+#   spec.license      = 'BSD'
+#   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
+#   spec.dependency 'DTFoundation/Core', '~>1.7.5'
+#   spec.dependency 'DTFoundation/UIKit', '~>1.7.5'
+#   spec.dependency 'DTFoundation/DTHTMLParser', '~>1.7.5'
+#   spec.dependency 'DTFoundation/DTAnimatedGIF', '~>1.7.5'
+#   spec.frameworks   = 'MediaPlayer', 'QuartzCore', 'CoreText', 'CoreGraphics', 'ImageIO'
+#   spec.requires_arc = true
+#   spec.homepage     = 'https://github.com/Cocoanetics/DTCoreText'
+#   spec.summary      = 'Methods to allow using HTML code with CoreText.'
+#   spec.author       = { 'Oliver Drobnik' => 'oliver@cocoanetics.com' }
+#   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
+#   spec.social_media_url = 'https://twitter.com/cocoanetics'
+#   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
+#   spec.prepare_command = <<-CMD
+#     cd ./Core/Source
+#     /usr/bin/xxd -i default.css default.css.c
+#   CMD
+
+#   #spec.default_subspec = 'Core'
+
+#   # spec.subspec 'Core' do |ap|
+#   #   ap.source_files = 'Core/Source/*.{h,m,c}'
+#   # end
+  
+#   spec.subspec 'Extension' do |ap|
+#     ap.dependency = 'DTCoreText/Core'
+#     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
+#   end
+# end

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -23,9 +23,9 @@ Pod::Spec.new do |spec|
 
   #spec.default_subspec = 'Core'
 
-  spec.subspec 'Core' do |ap|
-    ap.source_files = 'Core/Source/*.{h,m,c}'
-  end
+  # spec.subspec 'Core' do |ap|
+  #   ap.source_files = 'Core/Source/*.{h,m,c}'
+  # end
   
   spec.subspec 'Extension' do |ap|
     ap.dependency = 'DTCoreText/Core'

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -21,5 +21,10 @@ Pod::Spec.new do |spec|
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c
   CMD
+  
+  spec.subspec 'Extension' do |ap|
+    ap.source_files = 'Core/Source/*.{h,m,c}'
+    ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
+  end
 end
 

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -16,11 +16,12 @@ Pod::Spec.new do |spec|
   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
-  spec.default_subspec = 'Core'
   spec.prepare_command = <<-CMD
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c
   CMD
+
+  spec.default_subspec = 'Core'
 
   spec.subspec 'Core' do |ap|
     ap.source_files = 'Core/Source/*.{h,m,c}'
@@ -31,4 +32,3 @@ Pod::Spec.new do |spec|
     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end
-

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -23,44 +23,14 @@ Pod::Spec.new do |spec|
      /usr/bin/xxd -i default.css default.css.c
   CMD
   
+  spec.default_subspec = 'Core'
+
+  spec.subspec 'Core' do |ap|
+    ap.source_files = 'Core/Source/*.{h,m,c}'
+  end
+  
   spec.subspec 'Extension' do |ap|
     ap.source_files = 'Core/Source/*.{h,m,c}'
     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end
-
-
-# Pod::Spec.new do |spec|
-#   spec.name         = 'DTCoreText'
-#   spec.version      = '1.6.17'
-#   spec.platform     = :ios, '4.3'
-#   spec.license      = 'BSD'
-#   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
-#   spec.dependency 'DTFoundation/Core', '~>1.7.5'
-#   spec.dependency 'DTFoundation/UIKit', '~>1.7.5'
-#   spec.dependency 'DTFoundation/DTHTMLParser', '~>1.7.5'
-#   spec.dependency 'DTFoundation/DTAnimatedGIF', '~>1.7.5'
-#   spec.frameworks   = 'MediaPlayer', 'QuartzCore', 'CoreText', 'CoreGraphics', 'ImageIO'
-#   spec.requires_arc = true
-#   spec.homepage     = 'https://github.com/Cocoanetics/DTCoreText'
-#   spec.summary      = 'Methods to allow using HTML code with CoreText.'
-#   spec.author       = { 'Oliver Drobnik' => 'oliver@cocoanetics.com' }
-#   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
-#   spec.social_media_url = 'https://twitter.com/cocoanetics'
-#   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
-#   spec.prepare_command = <<-CMD
-#     cd ./Core/Source
-#     /usr/bin/xxd -i default.css default.css.c
-#   CMD
-
-#   #spec.default_subspec = 'Core'
-
-#   # spec.subspec 'Core' do |ap|
-#   #   ap.source_files = 'Core/Source/*.{h,m,c}'
-#   # end
-  
-#   spec.subspec 'Extension' do |ap|
-#     ap.dependency = 'DTCoreText/Core'
-#     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
-#   end
-# end

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
   
   spec.subspec 'Extension' do |ap|
     ap.source_files = 'Core/Source/*.{h,m,c}'
-    ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
+#    ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end
 

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |spec|
   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
+  spec.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited)' }
   spec.prepare_command = <<-CMD
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -16,18 +16,18 @@ Pod::Spec.new do |spec|
   spec.documentation_url = 'http://docs.cocoanetics.com/DTCoreText'
   spec.social_media_url = 'https://twitter.com/cocoanetics'
   spec.prefix_header_contents = '#import <CoreText/CoreText.h>'
-  spec.default_subspec = 'Base'
+  spec.default_subspec = 'Core'
   spec.prepare_command = <<-CMD
      cd ./Core/Source
      /usr/bin/xxd -i default.css default.css.c
   CMD
 
-  spec.subspec 'Base' do |ap|
+  spec.subspec 'Core' do |ap|
     ap.source_files = 'Core/Source/*.{h,m,c}'
   end
   
   spec.subspec 'Extension' do |ap|
-    ap.dependency = 'DTCoreText/Base'
+    ap.dependency = 'DTCoreText/Core'
     ap.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) DT_APP_EXTENSIONS=1' }
   end
 end

--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |spec|
      /usr/bin/xxd -i default.css default.css.c
   CMD
 
-  spec.default_subspec = 'Core'
+  #spec.default_subspec = 'Core'
 
   spec.subspec 'Core' do |ap|
     ap.source_files = 'Core/Source/*.{h,m,c}'


### PR DESCRIPTION
In order to work with extensions we need DT_APP_EXTENSIONS defined, however if you're using cocoapods and DTCoreText in multiple places it's not possible (without a subspec) to add this definition.