### PR TITLE
Avoid crash on iOS 10 beta 

### DIFF
--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -74,9 +74,23 @@ CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc)
     CFArrayRef lineRuns = CTLineGetGlyphRuns(line);
     CFIndex lineRunsCount = CFArrayGetCount(lineRuns);
     
-    CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, lineRunsCount - truncCount - 1);
-    
-    CFRange lastRunRange = CTRunGetStringRange(lineLastRun);
-    
-    return lastRunRange.location = lastRunRange.length;
+		CFIndex index = lineRunsCount - truncCount - 1;
+
+		// If the index is negative, CFArrayGetValueAtIndex will crash on iOS 10 beta.
+		// We will just return 0 because on iOS 9, CFArrayGetValueAtIndex would have
+		// returned nil anyways and the return truncation index would be 0.
+		// Apple might have enabled an assert that only appears in the iOS 10 beta
+		// release, but we will just avoid passing invalid arguments just to be safe.
+		if (index < 0)
+		{
+			return 0;
+		}
+		else
+		{
+			CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, index);
+
+			CFRange lastRunRange = CTRunGetStringRange(lineLastRun);
+
+			return lastRunRange.location = lastRunRange.length;
+		}
 }


### PR DESCRIPTION
Patch to avoid passing invalid arg in getTruncationIndex() crashes on iOS 10 beta.

-1 is created when lineRunsCount and truncCount are both 1. On iOS 9 and prior, -1 is accepted as an index value and nil is returned. iOS 10 crashes with this argument.

The context for this bug appears to be when there is a line break near the end of the last which gets truncated, but I have not confirmed that for sure. In any case, this is a local protection against an invalid argument to CoreFoundation.