### PR TITLE
Fix negativ Index crashes iOS10

### DIFF
--- a/Core/Source/CTLineUtils.m
+++ b/Core/Source/CTLineUtils.m
@@ -78,8 +78,13 @@ CFIndex getTruncationIndex(CTLineRef line, CTLineRef trunc)
     CFArrayRef lineRuns = CTLineGetGlyphRuns(line);
     CFIndex lineRunsCount = CFArrayGetCount(lineRuns);
     
-    CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, lineRunsCount - truncCount - 1);
-    
+	long index = lineRunsCount - truncCount - 1;
+	if (index < 0) {
+		index = 0;
+	}
+	
+	CTRunRef lineLastRun = CFArrayGetValueAtIndex(lineRuns, index);
+	
     CFRange lastRunRange = CTRunGetStringRange(lineLastRun);
     
     return lastRunRange.location = lastRunRange.length;


### PR DESCRIPTION
We recogniced that on iOS10 an error in the calculation of lines.
The Previous line contains a value selection in an array, sometimes with a negative index what would crash an app.
So i modifie the calculation in a seperate value and check for a negative value and set it to 0.