### PR TITLE
fixing bugs (iOS7 __NSCFString containsString:]: unrecognized selector sent to instance)

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -826,7 +826,7 @@ extern unsigned int default_css_len;
 	for (NSString *selector in _orderedSelectors)
 	{
 		// We only process the selector if our selector has more than 1 part to it (e.g. ".foo" would be skipped and ".foo .bar" would not)
-	        if (![selector containsString:@" "]) {
+	        if (![selector rangeOfString:@" "].length) {
         	    continue;
 	        }
 	        


### PR DESCRIPTION
iOS7 __NSCFString containsString:]: unrecognized selector sent to
instance