### PR TITLE
Fix space to “apple coverted space span” conversion for 2 spaces

### DIFF
--- a/Core/Source/NSString+HTML.m
+++ b/Core/Source/NSString+HTML.m
@@ -764,7 +764,7 @@ static NSDictionary *entityReverseLookup = nil;
 			
 			NSUInteger numSpaces = [spaces length]-1;
 			
-			if (numSpaces > 1)
+			if (numSpaces > 0)
 			{
 				[output appendString:@"<span class=\"Apple-converted-space\">"];
 				

--- a/Test/Source/NSStringHTMLTest.m
+++ b/Test/Source/NSStringHTMLTest.m
@@ -6,6 +6,7 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import "DTCoreTextConstants.h"
 #import "NSStringHTMLTest.h"
 #import "NSString+HTML.h"
 
@@ -22,6 +23,43 @@
 	// check reverse
 	NSString *decoded = [string stringByReplacingHTMLEntities];
 	XCTAssertTrue([decoded isEqualToString:string], @"Smiley is not properly round trip decoded");
+}
+
+- (void)testStringByAddingAppleConvertedSpace
+{
+	NSMutableString *convertedStringExpected = [NSMutableString string];
+	
+	// One space
+	NSString *string = @"1 1";
+	[convertedStringExpected setString:@"1 1"];
+	NSString *convertedString = [string stringByAddingAppleConvertedSpace];
+	XCTAssertTrue([convertedString isEqualToString:convertedStringExpected], @"Spaces do not get converted properly");
+	
+	// Two spaces
+	string = @"2  2";
+	[convertedStringExpected setString:@"2 <span class=\"Apple-converted-space\">"];
+	[convertedStringExpected appendString:UNICODE_NON_BREAKING_SPACE];
+	[convertedStringExpected appendString:@"</span>2"];
+	convertedString = [string stringByAddingAppleConvertedSpace];
+	XCTAssertTrue([convertedString isEqualToString:convertedStringExpected], @"Spaces do not get converted properly");
+
+	// Three spaces
+	string = @"3   3";
+	[convertedStringExpected setString:@"3 <span class=\"Apple-converted-space\">"];
+	[convertedStringExpected appendString:UNICODE_NON_BREAKING_SPACE];
+	[convertedStringExpected appendString:@" </span>3"];
+	convertedString = [string stringByAddingAppleConvertedSpace];
+	XCTAssertTrue([convertedString isEqualToString:convertedStringExpected], @"Spaces do not get converted properly");
+
+	// Four spaces
+	string = @"4    4";
+	[convertedStringExpected setString:@"4 <span class=\"Apple-converted-space\">"];
+	[convertedStringExpected appendString:UNICODE_NON_BREAKING_SPACE];
+	[convertedStringExpected appendString:@" "];
+	[convertedStringExpected appendString:UNICODE_NON_BREAKING_SPACE];
+	[convertedStringExpected appendString:@"</span>4"];
+	convertedString = [string stringByAddingAppleConvertedSpace];
+	XCTAssertTrue([convertedString isEqualToString:convertedStringExpected], @"Spaces do not get converted properly");
 }
 
 @end


### PR DESCRIPTION
Conversion from spaces to apple converted spaces did not work with 2 spaces as they only got converted to a single space.

Added unit test and fix.