### PR TITLE
Expanded character decoding support in stringByReplacingHTMLEntities.

### DIFF
--- a/Core/Source/NSString+HTML.m
+++ b/Core/Source/NSString+HTML.m
@@ -705,12 +705,11 @@ static NSDictionary *entityReverseLookup = nil;
 			{
 				unsigned long long scannedLongLong;
 				
-				if ([scanner scanHexLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX)
+				if ([scanner scanHexLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX && [scanner scanString:@";" intoString:NULL])
 				{
 					UTF32Char inputChar = (UTF32Char)CFSwapInt32HostToLittle((UTF32Char)scannedLongLong);
 					NSString *string = [[NSString alloc] initWithBytes:&inputChar length:4 encoding:NSUTF32LittleEndianStringEncoding];
 					[output appendString:string];
-					[scanner scanString:@";" intoString:NULL];
 					matched = YES;
 				}
 			}
@@ -718,12 +717,11 @@ static NSDictionary *entityReverseLookup = nil;
 			{
 				unsigned long long scannedLongLong;
 				
-				if ([scanner scanUnsignedLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX)
+				if ([scanner scanUnsignedLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX && [scanner scanString:@";" intoString:NULL])
 				{
 					UTF32Char inputChar = (UTF32Char)CFSwapInt32HostToLittle((UTF32Char)scannedLongLong);
 					NSString *string = [[NSString alloc] initWithBytes:&inputChar length:4 encoding:NSUTF32LittleEndianStringEncoding];
 					[output appendString:string];
-					[scanner scanString:@";" intoString:NULL];
 					matched = YES;
 				}
 			}

--- a/Core/Source/NSString+HTML.m
+++ b/Core/Source/NSString+HTML.m
@@ -697,40 +697,51 @@ static NSDictionary *entityReverseLookup = nil;
 		
 		if ([scanner scanString:@"&" intoString:NULL])
 		{
+			NSUInteger originalLocation = scanner.scanLocation;
+			BOOL matched = NO;
 			NSString *afterAmpersand = nil;
-			if ([scanner scanUpToString:@";" intoString:&afterAmpersand]) 
+			
+			if ([scanner scanString:@"#x" intoString:NULL])
 			{
-				if ([scanner scanString:@";" intoString:NULL])
+				unsigned long long scannedLongLong;
+				
+				if ([scanner scanHexLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX)
 				{
-					if ([afterAmpersand hasPrefix:@"#"] && [afterAmpersand length]<=6)
-					{
-						unichar ch = (unichar)[[afterAmpersand substringFromIndex:1] integerValue];
-						[output appendFormat:@"%C", ch];
-					}
-					else 
-					{
-						NSString *converted = [entityLookup objectForKey:afterAmpersand];
-						
-						if (converted)
-						{
-							[output appendString:converted];
-						}
-						else 
-						{
-							// not a valid sequence
-							[output appendString:@"&"];
-							[output appendString:afterAmpersand];
-							[output appendString:@";"];
-						}
-					}
-					
+					UTF32Char inputChar = (UTF32Char)CFSwapInt32HostToLittle((UTF32Char)scannedLongLong);
+					NSString *string = [[NSString alloc] initWithBytes:&inputChar length:4 encoding:NSUTF32LittleEndianStringEncoding];
+					[output appendString:string];
+					[scanner scanString:@";" intoString:NULL];
+					matched = YES;
 				}
-				else 
+			}
+			else if ([scanner scanString:@"#" intoString:NULL])
+			{
+				unsigned long long scannedLongLong;
+				
+				if ([scanner scanUnsignedLongLong:&scannedLongLong] && scannedLongLong <= UINT32_MAX)
 				{
-					// no semicolon 
-					[output appendString:@"&"];
-					[output appendString:afterAmpersand];
+					UTF32Char inputChar = (UTF32Char)CFSwapInt32HostToLittle((UTF32Char)scannedLongLong);
+					NSString *string = [[NSString alloc] initWithBytes:&inputChar length:4 encoding:NSUTF32LittleEndianStringEncoding];
+					[output appendString:string];
+					[scanner scanString:@";" intoString:NULL];
+					matched = YES;
 				}
+			}
+			else if ([scanner scanUpToString:@";" intoString:&afterAmpersand] && [scanner scanString:@";" intoString:NULL])
+			{
+				NSString *converted = [entityLookup objectForKey:afterAmpersand];
+				
+				if (converted)
+				{
+					[output appendString:converted];
+					matched = YES;
+				}
+			}
+			
+			if (!matched)
+			{
+				[output appendString:@"&"];
+				scanner.scanLocation = originalLocation;
 			}
 		}
 	}

--- a/Test/Source/NSStringHTMLTest.m
+++ b/Test/Source/NSStringHTMLTest.m
@@ -17,11 +17,86 @@
 
 	// check encoding
 	NSString *encoded = [string stringByAddingHTMLEntities];
-	XCTAssertTrue([encoded isEqualToString:@"&#128516;"], @"Smiley is not properly encoded");
+	XCTAssertEqualObjects(encoded, @"&#128516;", @"Smiley is not properly encoded");
 
 	// check reverse
-	NSString *decoded = [string stringByReplacingHTMLEntities];
-	XCTAssertTrue([decoded isEqualToString:string], @"Smiley is not properly round trip decoded");
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, string, @"Smiley is not properly round trip decoded");
+}
+
+- (void)testHexDecoding
+{
+	NSString *encoded = @"&#x1F604;";
+	NSString *expected = @"😄";
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+- (void)testKnownEntityDecoding
+{
+	NSString *encoded = @"&lt;&gt;";
+	NSString *expected = @"<>";
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+- (void)testUnclosedDecoding
+{
+	NSString *encoded = @"&#128516test";
+	NSString *expected = @"😄test";
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+- (void)testUnclosedHexDecoding
+{
+	NSString *encoded = @"&#x1F604test";
+	NSString *expected = @"😄test";
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+/* Not implemented.
+
+- (void)testUnclosedKnownEntityDecoding
+{
+	NSString *encoded = @"&lttest";
+	NSString *expected = @"<test";
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+*/
+
+- (void)testInvalidDecoding
+{
+	NSString *encoded = @"&#hello;";
+	NSString *expected = encoded;
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+- (void)testInvalidHexDecoding
+{
+	NSString *encoded = @"&#xsup;";
+	NSString *expected = encoded;
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
+}
+
+- (void)testUnknownEntityDecoding
+{
+	NSString *encoded = @"&unknowncode;";
+	NSString *expected = encoded;
+	
+	NSString *decoded = [encoded stringByReplacingHTMLEntities];
+	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
 }
 
 @end

--- a/Test/Source/NSStringHTMLTest.m
+++ b/Test/Source/NSStringHTMLTest.m
@@ -45,7 +45,7 @@
 - (void)testUnclosedDecoding
 {
 	NSString *encoded = @"&#128516test";
-	NSString *expected = @"😄test";
+	NSString *expected = encoded;
 	
 	NSString *decoded = [encoded stringByReplacingHTMLEntities];
 	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
@@ -54,23 +54,20 @@
 - (void)testUnclosedHexDecoding
 {
 	NSString *encoded = @"&#x1F604test";
-	NSString *expected = @"😄test";
+	NSString *expected = encoded;
 	
 	NSString *decoded = [encoded stringByReplacingHTMLEntities];
 	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
 }
-
-/* Not implemented.
 
 - (void)testUnclosedKnownEntityDecoding
 {
 	NSString *encoded = @"&lttest";
-	NSString *expected = @"<test";
+	NSString *expected = encoded;
 	
 	NSString *decoded = [encoded stringByReplacingHTMLEntities];
 	XCTAssertEqualObjects(decoded, expected, @"String is not properly decoded");
 }
-*/
 
 - (void)testInvalidDecoding
 {


### PR DESCRIPTION
Added support for decoding UTF32 character codes, hexadecimal character codes, and numeric character codes that don't end with semicolons. (e.g., "&#97bc" to "abc")

One HTML feature not supported here is known entities that don't end with semicolons.  E.g., "&ltpre&gt" should turn into "&lt;pre>".  That is a more complex problem.