### PR TITLE
CSS Parser: skip unpaired bracket } & fix NSUInteger underflow

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -547,7 +547,9 @@ extern unsigned int default_css_len;
 
 - (void)parseStyleBlock:(NSString*)css
 {
-	NSUInteger braceLevel = 0, braceMarker = 0;
+	NSUInteger braceMarker = 0;
+	
+	NSInteger braceLevel = 0;
 	
 	NSString* selector;
 	
@@ -636,8 +638,12 @@ extern unsigned int default_css_len;
 				
 				braceMarker = i + 1;
 			}
+			// Skip unpaired closing brace
+			else if (braceLevel < 1) {
+				braceMarker += 1;	
+			}
 			
-			braceLevel = MAX(braceLevel-1, 0ul);
+			braceLevel = MAX(braceLevel-1, 0);
 		}
 	}
 }

--- a/Test/Source/DTCSSStylesheetTest.m
+++ b/Test/Source/DTCSSStylesheetTest.m
@@ -517,4 +517,16 @@
 	XCTAssertTrue([backgroundColor isEqualToString:@"rgb(250, 250, 250)"], @"background-color should be #rgb(250, 250, 250)");
 }
 
+// issue #1045: CSS Parser: skip unpaired bracket } & fix NSUInteger underflow
+- (void)testParseStyleBlock
+{
+	for (NSString *cssStr in @[@"s1{p1:1em}s2{p2:2em}", @"s1{p1:1em}}s2{p2:2em}", @"s1{p1:1em}}}}}s2{p2:2em}}}"])
+	{
+		DTCSSStylesheet *stylesheet = [DTCSSStylesheet defaultStyleSheet];
+		[stylesheet parseStyleBlock:cssStr];
+		XCTAssertTrue([stylesheet.styles[@"s1"][@"p1"] isEqualToString:@"1em"], @"missing css style s1 when  parsing str: %@", cssStr);
+		XCTAssertTrue([stylesheet.styles[@"s2"][@"p2"] isEqualToString:@"2em"], @"missing css style s2 when parsing str %@", cssStr);
+	}
+}
+
 @end


### PR DESCRIPTION
When parsing @"s1{p1}}s2{p2}", code :

    NSUInteger  braceLevel = 0;
    ...
    braceLevel = MAX(braceLevel - 1, 0) 

will underflow, which lead to braceLevl = NSUIntegerMAX, and rest of cssString will ignore.

Trying to fix this problem.