### PR TITLE
DTTextAttachmentHTMLElement to fit 100% width

### DIFF
--- a/Core/Source/DTTextAttachmentHTMLElement.m
+++ b/Core/Source/DTTextAttachmentHTMLElement.m
@@ -100,6 +100,15 @@
 		_textAttachment.originalSize = _size;
 	}
 	
+	NSString *widthString = [styles objectForKey:@"width"];
+	
+	if (widthString.length > 1 && [widthString hasSuffix:@"%"])
+	{
+		CGFloat width = [[widthString substringToIndex:widthString.length - 1] floatValue];
+		
+		_size.width = _maxDisplaySize.width * width/100.0;
+	}
+	
 	// update the display size
 	[_textAttachment setDisplaySize:_size withMaxDisplaySize:_maxDisplaySize];
 }

--- a/Core/Source/DTTextAttachmentHTMLElement.m
+++ b/Core/Source/DTTextAttachmentHTMLElement.m
@@ -104,7 +104,7 @@
 	
 	if (widthString.length > 1 && [widthString hasSuffix:@"%"])
 	{
-		CGFloat width = [[widthString substringToIndex:widthString.length - 1] floatValue];
+		float width = [[widthString substringToIndex:widthString.length - 1] floatValue];
 		
 		_size.width = _maxDisplaySize.width * width/100.0;
 	}

--- a/Test/Source/DTHTMLElementTest.m
+++ b/Test/Source/DTHTMLElementTest.m
@@ -80,4 +80,30 @@
 	XCTAssertNil(attributedString, @"Text attachment should be invisible");
 }
 
+- (void)testAttachmentWithPercentWidth
+{
+	NSDictionary *styles1 = @{@"width" : @"100%"};
+	NSDictionary *styles2 = @{@"width" : @"80%"};
+	NSDictionary *styles3 = @{@"width" : @"110%"};
+	
+	CGSize maxImageSize = CGSizeMake(500,500);
+	
+	NSMutableDictionary *options = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+									[NSValue valueWithCGSize:maxImageSize], DTMaxImageSize,
+									[NSNumber numberWithFloat:16.0],DTDefaultFontSize,
+									nil];
+	
+	DTHTMLElement *attachment = [DTHTMLElement elementWithName:@"img" attributes:nil options:options];
+	
+	[attachment applyStyleDictionary:styles1];
+	XCTAssertEqual(attachment.textAttachment.displaySize.width, 500, @"Text attachment width incorrect");
+	
+	[attachment applyStyleDictionary:styles2];
+	XCTAssertEqual(attachment.textAttachment.displaySize.width, 400, @"Text attachment width incorrect");
+	
+	[attachment applyStyleDictionary:styles3];
+	XCTAssertEqual(attachment.textAttachment.displaySize.width, 500, @"Text attachment width incorrect");
+	
+}
+
 @end


### PR DESCRIPTION
If CSS use `width:100%` the DTTextAttachmentHTMLElement render wrong width.