### PR TITLE
add NSString type of protection in DTCSSStylesheet

### DIFF
--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -99,7 +99,7 @@ extern unsigned int default_css_len;
 	// list-style shorthand
 	NSString *shortHand = [[styles objectForKey:@"list-style"] lowercaseString];
 	
-	if (shortHand)
+	if (shortHand && [shortHand isKindOfClass:[NSString class]])
 	{
 		[styles removeObjectForKey:@"list-style"];
 		
@@ -166,7 +166,7 @@ extern unsigned int default_css_len;
 	// font shorthand, see http://www.w3.org/TR/CSS21/fonts.html#font-shorthand
 	shortHand = [styles objectForKey:@"font"];
 	
-	if (shortHand)
+	if (shortHand && [shortHand isKindOfClass:[NSString class]])
 	{
 		NSString *fontStyle = @"normal";
 		NSArray *validFontStyles = [NSArray arrayWithObjects:@"italic", @"oblique", nil];
@@ -277,7 +277,7 @@ extern unsigned int default_css_len;
 	
 	shortHand = [styles objectForKey:@"margin"];
 	
-	if (shortHand)
+	if (shortHand && [shortHand isKindOfClass:[NSString class]])
 	{
 		NSArray *parts = [shortHand componentsSeparatedByString:@" "];
 		
@@ -345,7 +345,7 @@ extern unsigned int default_css_len;
 	
 	shortHand = [styles objectForKey:@"padding"];
 	
-	if (shortHand)
+	if (shortHand && [shortHand isKindOfClass:[NSString class]])
 	{
 		NSArray *parts = [shortHand componentsSeparatedByString:@" "];
 		
@@ -413,7 +413,7 @@ extern unsigned int default_css_len;
 
 	shortHand = [styles objectForKey:@"background"];
 
-	if (shortHand)
+	if (shortHand && [shortHand isKindOfClass:[NSString class]])
 	{
 		// ignore most tokens except background-color
 		


### PR DESCRIPTION
I got a lot of crash in my product what like this:

![dtcssstylesheet](https://cloud.githubusercontent.com/assets/5188604/25161972/b0af693c-24f1-11e7-9c54-32bacb13df49.png)

I don't know the specific cause so add type of protection.