### PR TITLE
public func `abortParsing` in `DTHTMLParser`

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -15,6 +15,11 @@
  */
 typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
 
+/**
+ The block that gets executed whenever html tag parsing error
+ */
+typedef void(^DTHTMLAttributedStringBuilderParseErrorCallback)(NSAttributedString *attr, NSError *);
+
 
 /**
  Class for building an `NSAttributedString` from an HTML document.
@@ -71,10 +76,19 @@ typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
  This block is called before the element is written to the output attributed string
  */
 @property (nonatomic, copy) DTHTMLAttributedStringBuilderWillFlushCallback willFlushCallback;
+/**
+ The block that gets executed whenever html tag parsing error
+ */
+@property (nonatomic, copy) DTHTMLAttributedStringBuilderParseErrorCallback parseErrorCallback;
 
 /**
  Setting this property to `YES` causes the tree of parse nodes to be preserved until the end of the generation process. This allows to output the HTML structure of the document for debugging.
  */
 @property (nonatomic, assign) BOOL shouldKeepDocumentNodeTree;
+
+/**
+ This func can abort AttributedString building.
+ */
+- (void)abortParsing;
 
 @end


### PR DESCRIPTION

User can set `parseErrorCallback` to handle parse error and execute `abortPasing` to abort the paring.

User need keep the `DTHTMLAttributedStringBuilder`'s instance to abort.

So the  `parseErrorCallback` can not set in `NSAttributedString (HTML)` with `options`.