### PR TITLE
public func abortParsing in DTHTMLParser

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -15,6 +15,11 @@
  */
 typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
 
+/**
+ The block that gets executed whenever html tag parsing error
+ */
+typedef void(^DTHTMLAttributedStringBuilderParseErrorCallback)(NSAttributedString *attr, NSError *);
+
 
 /**
  Class for building an `NSAttributedString` from an HTML document.
@@ -71,10 +76,19 @@ typedef void(^DTHTMLAttributedStringBuilderWillFlushCallback)(DTHTMLElement *);
  This block is called before the element is written to the output attributed string
  */
 @property (nonatomic, copy) DTHTMLAttributedStringBuilderWillFlushCallback willFlushCallback;
+/**
+ The block that gets executed whenever html tag parsing error
+ */
+@property (nonatomic, copy) DTHTMLAttributedStringBuilderParseErrorCallback parseErrorCallback;
 
 /**
  Setting this property to `YES` causes the tree of parse nodes to be preserved until the end of the generation process. This allows to output the HTML structure of the document for debugging.
  */
 @property (nonatomic, assign) BOOL shouldKeepDocumentNodeTree;
+
+/**
+ This func can abort AttributedString building.
+ */
+- (void)abortParsing;
 
 @end

--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -73,6 +73,8 @@
 	NSMutableDictionary *_tagEndHandlers;
 	
 	DTHTMLAttributedStringBuilderWillFlushCallback _willFlushCallback;
+	DTHTMLAttributedStringBuilderParseErrorCallback _parseErrorCallback;
+
 	BOOL _shouldProcessCustomHTMLAttributes;
 	
 	// new parsing
@@ -82,6 +84,8 @@
 	BOOL _ignoreParseEvents; // ignores events from parser after first HTML tag was finished
 	BOOL _ignoreInlineStyles; // ignores style blocks attached on elements
 	BOOL _preserverDocumentTrailingSpaces; // don't remove spaces at end of document
+	
+	DTHTMLParser  *_parser;
 }
 
 - (id)initWithHTML:(NSData *)data options:(NSDictionary *)options documentAttributes:(NSDictionary * __autoreleasing*)docAttributes
@@ -93,6 +97,17 @@
 		_options = options;
 		
 		// documentAttributes ignored for now
+		// Specify the appropriate text encoding for the passed data, default is UTF8
+		NSString *textEncodingName = [_options objectForKey:NSTextEncodingNameDocumentOption];
+		NSStringEncoding encoding = NSUTF8StringEncoding; // default
+		
+		if (textEncodingName)
+		{
+			CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)textEncodingName);
+			encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+		}
+		_parser = [[DTHTMLParser alloc] initWithData:_data encoding:encoding];
+		_parser.delegate = (id)self;
 		
 		// GCD setup
 		_stringAssemblyQueue = dispatch_queue_create("DTHTMLAttributedStringBuilder", 0);
@@ -134,16 +149,6 @@
 	// register default handlers
 	[self _registerTagStartHandlers];
 	[self _registerTagEndHandlers];
-	
- 	// Specify the appropriate text encoding for the passed data, default is UTF8
-	NSString *textEncodingName = [_options objectForKey:NSTextEncodingNameDocumentOption];
-	NSStringEncoding encoding = NSUTF8StringEncoding; // default
-	
-	if (textEncodingName)
-	{
-		CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)textEncodingName);
-		encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
-	}
 	
 #if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
 	
@@ -339,12 +344,8 @@
 	// don't remove spaces at end of document
 	_preserverDocumentTrailingSpaces = [[_options objectForKey:DTDocumentPreserveTrailingSpaces] boolValue];
 	
-	// create a parser
-	DTHTMLParser *parser = [[DTHTMLParser alloc] initWithData:_data encoding:encoding];
-	parser.delegate = (id)self;
-	
 	__block BOOL result;
-	dispatch_group_async(_dataParsingGroup, _dataParsingQueue, ^{ result = [parser parse]; });
+	dispatch_group_async(_dataParsingGroup, _dataParsingQueue, ^{ result = [_parser parse]; });
 	
 	// wait until all string assembly is complete
 	dispatch_group_wait(_dataParsingGroup, DISPATCH_TIME_FOREVER);
@@ -999,9 +1000,22 @@
 	});
 }
 
+- (void)parser:(DTHTMLParser *)parser parseErrorOccurred:(NSError *)parseError;
+{
+	if(_parseErrorCallback)
+	{
+		_parseErrorCallback(_tmpString,parseError);
+	}
+}
+			  
+- (void)abortParsing
+{
+	[_parser abortParsing];
+}
 #pragma mark Properties
 
 @synthesize willFlushCallback = _willFlushCallback;
 @synthesize shouldKeepDocumentNodeTree = _shouldKeepDocumentNodeTree;
+@synthesize parseErrorCallback = _parseErrorCallback;
 
 @end


### PR DESCRIPTION
User can set `parseErrorCallback` to handle parse error and execute `abortPasing` to abort the paring.

User need keep the `DTHTMLAttributedStringBuilder`'s instance to abort.

So the `parseErrorCallback` can not set in `NSAttributedString (HTML)` with options.

If user abort the parsing that error is `nil`.

By the way I think set a special error is better, but need change `DTFoundation`. https://github.com/Cocoanetics/DTCoreText/pull/1076


