### PR TITLE
stop drawing when DTAttributedTextContentView dealloc

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -165,6 +165,12 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)dealloc
 {
+	if (_isTiling)
+	{
+		self.layer.contents = nil;
+		self.layer.delegate = nil;
+	}
+
 	[self removeAllCustomViews];
 }
 


### PR DESCRIPTION
fix this issue:

CATiledLayer or DTTiledLayerWithoutFade draws text asynchronously

0 libobjc.A.dylib | objc_msgSend + 16
1 quan | -[DTCoreTextLayoutFrame drawInContext:options:] (DTCoreTextLayoutFrame.m:1311)
2 quan | -[DTAttributedTextContentView drawLayer:inContext:] (DTAttributedTextContentView.m:489)
3 QuartzCore | -[CALayer drawInContext:] + 260
4 QuartzCore | tiled_layer_render(_CAImageProvider*, unsigned int, unsigned int, unsigned int, unsigned int, void*) + 1332
5 QuartzCore | CAImageProviderThread(unsigned int*, bool) + 552
6 libdispatch.dylib | 0x000000018bcc9000 + 6560
7 libdispatch.dylib | 0x000000018bcc9000 + 65748
8 libdispatch.dylib | 0x000000018bcc9000 + 72272
9 libdispatch.dylib | 0x000000018bcc9000 + 71632
10 libsystem_pthread.dylib | _pthread_wqthread + 1096