### PR TITLE
Hotfix/ should cache layout frames causes high calculation error

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -165,6 +165,12 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)dealloc
 {
+	if (_isTiling)
+	{
+		self.layer.contents = nil;
+		self.layer.delegate = nil;
+	}
+
 	[self removeAllCustomViews];
 }
 

--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -1909,6 +1909,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		_numberOfLines = numberOfLines;
         // clear lines cache
         _lines = nil;
+		_frame.size.height = CGFLOAT_HEIGHT_UNKNOWN;
     }
 }
 
@@ -1919,6 +1920,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
         _lineBreakMode = lineBreakMode;
         // clear lines cache
         _lines = nil;
+		_frame.size.height = CGFLOAT_HEIGHT_UNKNOWN;
     }
 }
 
@@ -1932,6 +1934,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		{
             // clear lines cache
             _lines = nil;
+			_frame.size.height = CGFLOAT_HEIGHT_UNKNOWN;
         }
     }
 }
@@ -1944,6 +1947,7 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 		
         // clear lines cache
         _lines = nil;
+		_frame.size.height = CGFLOAT_HEIGHT_UNKNOWN;
     }
 }
 


### PR DESCRIPTION
issues 1:
when use **CATiledLayer** or **DTTiledLayerWithoutFade**, text is drawn asynchronously.
it could cause crash when dealloc
0 libobjc.A.dylib | objc_msgSend + 16
1 quan | -[DTCoreTextLayoutFrame drawInContext:options:] (DTCoreTextLayoutFrame.m:1311)
2 quan | -[DTAttributedTextContentView drawLayer:inContext:] (DTAttributedTextContentView.m:489)
3 QuartzCore | -[CALayer drawInContext:] + 260
4 QuartzCore | tiled_layer_render(_CAImageProvider*, unsigned int, unsigned int, unsigned int, unsigned int, void*) + 1332
5 QuartzCore | CAImageProviderThread(unsigned int*, bool) + 552
6 libdispatch.dylib | 0x000000018bcc9000 + 6560
7 libdispatch.dylib | 0x000000018bcc9000 + 65748
8 libdispatch.dylib | 0x000000018bcc9000 + 72272
9 libdispatch.dylib | 0x000000018bcc9000 + 71632
10 libsystem_pthread.dylib | _pthread_wqthread + 1096

issues 2:
if set **_shouldCacheLayoutFrames** YES , **DTCoreTextLayoutFrame** will be cached.
so when **numberOfLines** or **lineBreakMode** or **truncationString** changed,  call **suggestedFrameSizeToFitEntireStringConstraintedToWidth** always return old size.