### PR TITLE
Crash workaround

### DIFF
--- a/Demo/Source/DemoTextViewController.m
+++ b/Demo/Source/DemoTextViewController.m
@@ -258,6 +258,8 @@
 		[player stop];
 	}
 	
+	_textView.textDelegate = nil;
+	
 	[super viewWillDisappear:animated];
 }
 


### PR DESCRIPTION
This workaround related to the issue https://github.com/Cocoanetics/DTCoreText/issues/1123. As long as you have a link in `DTAttributedTextView` it causes a crash (at least on iOS 9, 10) after closing the page with the view. Setting `DTAttributedTextContentViewDelegate` of the view to `nil` somehow prevents from crashing.