### PR TITLE
Image in <li> crash workaround 

### DIFF
--- a/Core/Source/DTListItemHTMLElement.m
+++ b/Core/Source/DTListItemHTMLElement.m
@@ -253,6 +253,11 @@
 		}
 	}
 	
+	if (!prefix)
+	{
+		return nil;
+	}
+	
 	NSMutableAttributedString *tmpStr = [[NSMutableAttributedString alloc] initWithString:prefix attributes:newAttributes];
 	
 	if (image)

--- a/Test/Source/DTHTMLAttributedStringBuilderTest.m
+++ b/Test/Source/DTHTMLAttributedStringBuilderTest.m
@@ -1241,4 +1241,17 @@
 	XCTAssertEqualObjects(hexColor, @"0000ff", @"Color should be blue because inline style should be processed through lack of ignore option");
 }
 
+- (void)testBase64imageInLiElement
+{
+	NSAttributedString *attributedString = [self attributedStringFromHTMLString:@"<ul style=\"list-style: none;\">\n<li style=\"color: #333; list-style-image: url(\'data:image/png;base64,ABCDEF\');\">Li item</li></ul>" options:NULL];
+	
+	NSDictionary *attributes = [attributedString attributesAtIndex:0 effectiveRange:NULL];
+
+	DTColor *color = [attributes foregroundColor];
+	NSString *hexColor = DTHexStringFromDTColor(color);
+	
+	XCTAssertEqualObjects(hexColor, @"333333", @"Color attribute lost");
+	XCTAssertEqualObjects([attributedString string], @"Li item\n");
+}
+
 @end


### PR DESCRIPTION
When you try to get attributed string from html below you receive a crash in line `NSMutableAttributedString *tmpStr = [[NSMutableAttributedString alloc] initWithString:prefix attributes:newAttributes];` (`DTListItemHTMLElement`) because `prefix` is nil.
```
<ul style=\"list-style: none;\">
     <li style=\"list-style-image: url(\'data:image/png;base64,ABCDEF\');\">Li item</li>
</ul>
```