### PR TITLE
Add support for new CocoaPods 1.7.x `:generate_multiple_pod_projects`…

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -14,7 +14,8 @@
 #import "DTAccessibilityViewProxy.h"
 #import "DTAccessibilityElement.h"
 #import "DTCoreTextLayoutFrameAccessibilityElementGenerator.h"
-#import "DTBlockFunctions.h"
+
+#import <DTFoundation/DTBlockFunctions.h>
 
 #if !__has_feature(objc_arc)
 #error THIS CODE MUST BE COMPILED WITH ARC ENABLED!

--- a/Core/Source/DTAttributedTextView.m
+++ b/Core/Source/DTAttributedTextView.m
@@ -10,9 +10,9 @@
 
 #import "DTAttributedTextView.h"
 #import "DTCoreText.h"
-#import "DTBlockFunctions.h"
 
 #import <DTFoundation/DTTiledLayerWithoutFade.h>
+#import <DTFoundation/DTBlockFunctions.h>
 
 
 @interface DTAttributedTextView ()

--- a/Core/Source/DTCoreTextFunctions.m
+++ b/Core/Source/DTCoreTextFunctions.m
@@ -7,7 +7,8 @@
 //
 
 #import "DTCoreTextFunctions.h"
-#import "DTLog.h"
+
+#import <DTFoundation/DTLog.h>
 
 #if TARGET_OS_IPHONE
 CTFontRef DTCTFontCreateWithUIFont(UIFont *font)

--- a/Core/Source/DTCoreTextGlyphRun.m
+++ b/Core/Source/DTCoreTextGlyphRun.m
@@ -15,7 +15,8 @@
 #import "DTCoreTextFunctions.h"
 #import "NSDictionary+DTCoreText.h"
 #import "DTWeakSupport.h"
-#import "DTLog.h"
+
+#import <DTFoundation/DTLog.h>
 
 @implementation DTCoreTextGlyphRun
 {

--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -7,7 +7,6 @@
 //
 
 #import "DTHTMLWriter.h"
-#import "DTVersion.h"
 #import "NSDictionary+DTCoreText.h"
 #import "DTCSSListStyle.h"
 #import "DTCoreTextConstants.h"
@@ -19,6 +18,7 @@
 #import "NSString+HTML.h"
 #import "DTColorFunctions.h"
 
+#import <DTFoundation/DTVersion.h>
 
 
 @implementation DTHTMLWriter

--- a/Core/Source/DTTextAttachment.m
+++ b/Core/Source/DTTextAttachment.m
@@ -7,7 +7,6 @@
 //
 
 #import "DTTextAttachment.h"
-#import "DTCoreGraphicsUtils.h"
 #import "DTHTMLElement.h"
 #import "DTDictationPlaceholderTextAttachment.h"
 #import "DTIframeTextAttachment.h"
@@ -17,6 +16,7 @@
 #import "NSCoder+DTCompatibility.h"
 
 #import <DTFoundation/DTLog.h>
+#import <DTFoundation/DTCoreGraphicsUtils.h>
 
 
 static NSMutableDictionary *_classForTagNameLookup = nil;


### PR DESCRIPTION
Only change required was to properly include `DTFoundation` headers using:

    #import <DTFoundation/...>

instead of:

    #include "..."