### PR TITLE
 fix css attribute parse error

### DIFF
--- a/Core/Source/NSScanner+HTML.m
+++ b/Core/Source/NSScanner+HTML.m
@@ -57,7 +57,7 @@
 	NSMutableArray *results = [NSMutableArray array];
 	BOOL nextIterationAddsNewEntry = YES;
 	
-	while (![self isAtEnd] && ![self scanString:@";" intoString:NULL])
+    while (![self isAtEnd] && ![self scanString:@";" intoString:NULL] && ![self scanString:@"'';" intoString:NULL] && ![self scanString:@"\"\";" intoString:NULL])
 	{
 		// skip whitespace
 		[self scanCharactersFromSet:whiteCharacterSet intoString:NULL];


### PR DESCRIPTION
 fix css attribute like.
 p.Text {   
    font-family:'' ;
    font-size: 1em;
    line-height: 1.5em;
    text-align: left;
    text-indent: 2em;
    margin: 0.6em 0;
    letter-spacing: auto;
}