### PR TITLE
Fix: Fixing iOS 14 implict conversion error from NSWritingDirection to CTWritingDirection

### DIFF
--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1572,15 +1572,15 @@ NSDictionary *_classesForNames = nil;
 		
 		if ([directionStr isEqualToString:@"rtl"])
 		{
-			_paragraphStyle.baseWritingDirection = NSWritingDirectionRightToLeft;
+			_paragraphStyle.baseWritingDirection = kCTWritingDirectionRightToLeft;
 		}
 		else if ([directionStr isEqualToString:@"ltr"])
 		{
-			_paragraphStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
+			_paragraphStyle.baseWritingDirection = kCTWritingDirectionLeftToRight;
 		}
 		else if ([directionStr isEqualToString:@"auto"])
 		{
-			_paragraphStyle.baseWritingDirection = NSWritingDirectionNatural; // that's also default
+			_paragraphStyle.baseWritingDirection = kCTWritingDirectionNatural; // that's also default
 		}
 		else
 		{


### PR DESCRIPTION
This is the error message: Implicit conversion from enumeration type **enum NSWritingDirection** to different enumeration type **CTWritingDirection**

This error happens when trying to build the pod with XCode 12 beta.