### PR TITLE
Introduced SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 project.xcworkspace
 xcuserdata
 .svn
+.swiftpm/
+.build/

--- a/Core/Source/DTAccessibilityElement.h
+++ b/Core/Source/DTAccessibilityElement.h
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 3/13/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <UIKit/UIKit.h>
 
@@ -30,3 +31,5 @@
 - (id)initWithParentView:(UIView *)parentView;
 
 @end
+
+#endif

--- a/Core/Source/DTAccessibilityElement.m
+++ b/Core/Source/DTAccessibilityElement.m
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 3/13/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTAccessibilityElement.h"
 
@@ -48,3 +49,5 @@ static const CGPoint DTAccessibilityElementNullActivationPoint = {CGFLOAT_MAX, C
 }
 
 @end
+
+#endif

--- a/Core/Source/DTAccessibilityViewProxy.h
+++ b/Core/Source/DTAccessibilityViewProxy.h
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 5/6/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <Foundation/Foundation.h>
 #import "DTTextAttachment.h"
@@ -52,3 +53,5 @@
 
 - (UIView *)viewForTextAttachment:(DTTextAttachment *)attachment proxy:(DTAccessibilityViewProxy *)proxy;
 @end
+
+#endif

--- a/Core/Source/DTAccessibilityViewProxy.m
+++ b/Core/Source/DTAccessibilityViewProxy.m
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 5/6/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTAccessibilityViewProxy.h"
 
@@ -56,3 +57,5 @@
 }
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedLabel.h
+++ b/Core/Source/DTAttributedLabel.h
@@ -5,6 +5,7 @@
 //  Created by Brian Kenny on 1/17/13.
 //  Copyright (c) 2013 Cocoanetics.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTAttributedTextContentView.h"
 
@@ -36,3 +37,5 @@
 @property(nonatomic, strong) NSAttributedString *truncationString;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedLabel.m
+++ b/Core/Source/DTAttributedLabel.m
@@ -5,6 +5,7 @@
 //  Created by Brian Kenny on 1/17/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTAttributedLabel.h"
 #import "DTCoreTextLayoutFrame.h"
@@ -118,3 +119,5 @@
 
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedLabel.m
+++ b/Core/Source/DTAttributedLabel.m
@@ -38,6 +38,19 @@
 	return self;
 }
 
+- (id) initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+
+    if (self != nil)
+    {
+        [self setupAttributedLabel];
+    }
+
+    return self;
+}
+
+
+
 - (void) awakeFromNib
 {
 	[super awakeFromNib];

--- a/Core/Source/DTAttributedTextCell.h
+++ b/Core/Source/DTAttributedTextCell.h
@@ -5,6 +5,9 @@
 //  Created by Oliver Drobnik on 8/4/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
+
+#import <UIKit/UIKit.h>
 
 #import "DTAttributedTextContentView.h"
 #import <DTFoundation/DTWeakSupport.h>
@@ -83,3 +86,5 @@
 @property (nonatomic, readonly) DTAttributedTextContentView *attributedTextContextView;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextCell.m
+++ b/Core/Source/DTAttributedTextCell.m
@@ -5,6 +5,7 @@
 //  Created by Oliver Drobnik on 8/4/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTCoreText.h"
 #import "DTAttributedTextCell.h"
@@ -267,3 +268,5 @@
 @synthesize textDelegate = _textDelegate;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextContentView.h
+++ b/Core/Source/DTAttributedTextContentView.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import "DTCoreTextLayoutFrame.h"
 #import <DTFoundation/DTWeakSupport.h>
 
@@ -362,3 +364,5 @@ typedef NSUInteger DTAttributedTextContentViewRelayoutMask;
 - (CGRect)cursorRectAtIndex:(NSInteger)index;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import <QuartzCore/QuartzCore.h>
 
 #import "DTCoreText.h"
@@ -1109,3 +1111,5 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 }
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextView.h
+++ b/Core/Source/DTAttributedTextView.h
@@ -5,6 +5,9 @@
 //  Created by Oliver Drobnik on 1/12/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
+
+#import <UIKit/UIKit.h>
 
 #import "DTAttributedTextContentView.h"
 
@@ -126,3 +129,5 @@
 - (CGRect)cursorRectAtIndex:(NSInteger)index;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextView.m
+++ b/Core/Source/DTAttributedTextView.m
@@ -5,6 +5,7 @@
 //  Created by Oliver Drobnik on 1/12/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <QuartzCore/QuartzCore.h>
 
@@ -417,3 +418,5 @@
 @synthesize shouldDrawLinks = _shouldDrawLinks;
 
 @end
+
+#endif

--- a/Core/Source/DTAttributedTextView.m
+++ b/Core/Source/DTAttributedTextView.m
@@ -387,7 +387,7 @@
 - (void)setTextDelegate:(id<DTAttributedTextContentViewDelegate>)aTextDelegate
 {
 	// store unsafe pointer to delegate because we might not have a contentView yet
-	textDelegate = aTextDelegate;
+	self->_textDelegate = aTextDelegate;
 	
 	// set it if possible, otherwise it will be set in contentView lazy property
 	_attributedTextContentView.delegate = aTextDelegate;
@@ -395,7 +395,7 @@
 
 - (id<DTAttributedTextContentViewDelegate>)textDelegate
 {
-	return _attributedTextContentView.delegate;
+	return _attributedTextContentView.delegate ?: self->_textDelegate;;
 }
 
 - (void)setShouldDrawLinks:(BOOL)shouldDrawLinks

--- a/Core/Source/DTCSSListStyle.h
+++ b/Core/Source/DTCSSListStyle.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 /**
  List Styles
  */

--- a/Core/Source/DTCSSStylesheet.m
+++ b/Core/Source/DTCSSStylesheet.m
@@ -38,17 +38,23 @@
 	{
 		if (!defaultDTCSSStylesheet)
 		{
-			NSBundle *bundle = [NSBundle bundleForClass:self];
-			NSString *path = [bundle pathForResource:@"default" ofType:@"css"];
-			// Cocoapods uses a separate Resources bundle to include default.css
-			if (!path)
-			{
-				NSString *resourcesBundlePath = [bundle pathForResource:@"Resources" ofType:@"bundle"];
-				NSBundle *resourcesBundle = [NSBundle bundleWithPath:resourcesBundlePath];
-				path = [resourcesBundle pathForResource:@"default" ofType:@"css"];
-			}
-			NSString *cssString = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
-			
+
+#if SWIFT_PACKAGE // Temporaray fix, since resources in SPM are only supported starting with Swift 5.3
+            NSString* cssString = @"html{display:block}head{display:none}title{display:none}style{display:none}body{display:block}article,aside,footer,header,hgroup,nav,section{display:block}p{display:block;-webkit-margin-before:1em;-webkit-margin-after:1em;-webkit-margin-start:0;-webkit-margin-end:0}ul,menu,dir{display:block;list-style-type:disc;-webkit-margin-before:1em;-webkit-margin-after:1em;-webkit-margin-start:0;-webkit-margin-end:0;-webkit-padding-start:27px}li{display:list-item}ol{display:block;list-style-type:decimal;-webkit-margin-before:1em;-webkit-margin-after:1em;-webkit-margin-start:0;-webkit-margin-end:0;-webkit-padding-start:27px}ul ul,ol ul{list-style-type:circle}ol ol ul,ol ul ul,ul ol ul,ul ul ul{list-style-type:square}code{font-family:Courier}pre,xmp,plaintext,listing{display:block;font-family:monospace;white-space:pre;margin:1em 0px}a{color:#0000EE;text-decoration:underline}a:active{color:#FF0000}center{text-align:center;display:block}strong,b{font-weight:bolder}i,em{font-style:italic}u{text-decoration:underline}big{font-size:bigger}small{font-size:smaller}sub{font-size:smaller;vertical-align:sub}sup{font-size:smaller;vertical-align:super}s,strike,del{text-decoration:line-through}tt,code,kbd,samp{font-family:monospace}pre,xmp,plaintext,listing{display:block;font-family:monospace;white-space:pre;margin-top:1em;margin-right:0;margin-bottom:1em;margin-left:0}h1{display:block;font-size:2em;-webkit-margin-before:.67em;-webkit-margin-after:.67em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}h2{display:block;font-size:1.5em;-webkit-margin-before:.83em;-webkit-margin-after:.83em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}h3{display:block;font-size:1.17em;-webkit-margin-before:1em;-webkit-margin-after:1em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}h4{display:block;-webkit-margin-before:1.33em;-webkit-margin-after:1.33em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}h5{display:block;font-size:.83em;-webkit-margin-before:1.67em;-webkit-margin-after:1.67em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}h6{display:block;font-size:.67em;-webkit-margin-before:2.33em;-webkit-margin-after:2.33em;-webkit-margin-start:0;-webkit-margin-end:0;font-weight:bold}div{display:block}link{display:none}meta{display:none}script{display:none}hr{display:block;-webkit-margin-before:0.5em;-webkit-margin-after:0.5em;-webkit-margin-start:auto;-webkit-margin-end:auto;border-style:inset;border-width:1px}table{display:table;border-collapse:separate;border-spacing:2px;border-color:gray}";
+
+#else
+            NSBundle *bundle = [NSBundle bundleForClass:self];
+            NSString *path = [bundle pathForResource:@"default" ofType:@"css"];
+            // Cocoapods uses a separate Resources bundle to include default.css
+            if (!path)
+            {
+                NSString *resourcesBundlePath = [bundle pathForResource:@"Resources" ofType:@"bundle"];
+                NSBundle *resourcesBundle = [NSBundle bundleWithPath:resourcesBundlePath];
+                path = [resourcesBundle pathForResource:@"default" ofType:@"css"];
+            }
+            NSString *cssString = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+#endif
+
 			defaultDTCSSStylesheet = [[DTCSSStylesheet alloc] initWithStyleBlock:cssString];
 		}
 	}

--- a/Core/Source/DTColor+Compatibility.h
+++ b/Core/Source/DTColor+Compatibility.h
@@ -26,8 +26,9 @@
 
 @end
 
-#else
+#endif
 
+#if TARGET_OS_OSX
 #import <AppKit/NSColor.h>
 
 /**

--- a/Core/Source/DTColorFunctions.h
+++ b/Core/Source/DTColorFunctions.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
 
-@class DTColor;
+#import "DTCompatibility.h"
 
 /**
  Takes a CSS color string ('333', 'F9FFF9'), determines the RGB values used, and returns a UIColor object of that color.

--- a/Core/Source/DTCompatibility.h
+++ b/Core/Source/DTCompatibility.h
@@ -6,9 +6,13 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #pragma mark - iOS
 
 #if TARGET_OS_IPHONE
+
+#import <UIKit/UIKit.h>
 
 	// Compatibility Aliases
 	#define DTColor UIColor
@@ -87,6 +91,9 @@
 
 
 #if !TARGET_OS_IPHONE
+
+
+#import <AppKit/AppKit.h>
 
 	// Compatibility Aliases
 	#define DTColor NSColor

--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 // unicode characters
 
 #define UNICODE_OBJECT_PLACEHOLDER @"\ufffc"

--- a/Core/Source/DTCoreTextFontCollection.h
+++ b/Core/Source/DTCoreTextFontCollection.h
@@ -6,6 +6,7 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 
 
 @class DTCoreTextFontDescriptor;

--- a/Core/Source/DTCoreTextFontDescriptor.h
+++ b/Core/Source/DTCoreTextFontDescriptor.h
@@ -6,6 +6,9 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+
 
 /**
  This class describes the attributes of a font. It is used to represent fonts throughout the parsing and when needed is able to generated matching `CTFont` instances.

--- a/Core/Source/DTCoreTextFunctions.h
+++ b/Core/Source/DTCoreTextFunctions.h
@@ -5,6 +5,11 @@
 //  Created by Oliver Drobnik on 21.12.12.
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
+#import <CoreText/CoreText.h>
+
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
 
 #import "DTCompatibility.h"
 

--- a/Core/Source/DTCoreTextLayoutFrame.h
+++ b/Core/Source/DTCoreTextLayoutFrame.h
@@ -6,14 +6,17 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import "DTCoreTextConstants.h"
 
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
-#elif TARGET_OS_MAC
-#import <ApplicationServices/ApplicationServices.h>
+#import <UIKit/UIKit.h>
 #endif
 
-#import "DTCoreTextConstants.h"
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#endif
 
 @class DTCoreTextLayoutLine;
 @class DTTextBlock;

--- a/Core/Source/DTCoreTextLayoutFrameAccessibilityElementGenerator.h
+++ b/Core/Source/DTCoreTextLayoutFrameAccessibilityElementGenerator.h
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 3/13/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <Foundation/Foundation.h>
 #import "DTAccessibilityElement.h"
@@ -32,3 +33,5 @@ typedef id(^DTAttachmentViewProvider)(DTTextAttachment *textAttachment);
 - (NSArray *)accessibilityElementsForLayoutFrame:(DTCoreTextLayoutFrame *)frame view:(UIView *)view attachmentViewProvider:(DTAttachmentViewProvider)block;
 
 @end
+
+#endif

--- a/Core/Source/DTCoreTextLayoutFrameAccessibilityElementGenerator.m
+++ b/Core/Source/DTCoreTextLayoutFrameAccessibilityElementGenerator.m
@@ -5,6 +5,7 @@
 //  Created by Austen Green on 3/13/13.
 //  Copyright (c) 2013 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTCoreTextLayoutFrameAccessibilityElementGenerator.h"
 #import "DTCoreTextLayoutFrame.h"
@@ -117,3 +118,5 @@
 }
 
 @end
+
+#endif

--- a/Core/Source/DTCoreTextLayouter.h
+++ b/Core/Source/DTCoreTextLayouter.h
@@ -6,8 +6,6 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
-
-
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #elif TARGET_OS_MAC

--- a/Core/Source/DTCoreTextParagraphStyle.h
+++ b/Core/Source/DTCoreTextParagraphStyle.h
@@ -5,6 +5,8 @@
 //  Created by Oliver Drobnik on 4/14/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
 
 /**
  `DTCoreTextParagraphStyle` encapsulates the paragraph or ruler attributes used by the NSAttributedString classes on iOS. It is a replacement for `NSParagraphStyle` which is not implemented on iOS. 

--- a/Core/Source/DTDictationPlaceholderView.h
+++ b/Core/Source/DTDictationPlaceholderView.h
@@ -5,6 +5,7 @@
 //  Created by Oliver Drobnik on 05.02.13.
 //  Copyright (c) 2013 Cocoanetics. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <UIKit/UIKit.h>
 
@@ -25,3 +26,5 @@
 @property (nonatomic, strong) id context;
 
 @end
+
+#endif

--- a/Core/Source/DTDictationPlaceholderView.m
+++ b/Core/Source/DTDictationPlaceholderView.m
@@ -5,6 +5,7 @@
 //  Created by Oliver Drobnik on 05.02.13.
 //  Copyright (c) 2013 Cocoanetics. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import "DTDictationPlaceholderView.h"
 
@@ -117,3 +118,5 @@
 
 
 @end
+
+#endif

--- a/Core/Source/DTHTMLParserNode.h
+++ b/Core/Source/DTHTMLParserNode.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #import <DTFoundation/DTWeakSupport.h>
 
 @class DTHTMLParserTextNode;

--- a/Core/Source/DTHTMLParserTextNode.h
+++ b/Core/Source/DTHTMLParserTextNode.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "DTHTMLParserNode.h"
 
 /**

--- a/Core/Source/DTHTMLWriter.h
+++ b/Core/Source/DTHTMLWriter.h
@@ -6,6 +6,9 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 /**
  Class to generate HTML from `NSAttributedString` instances.
  */

--- a/Core/Source/DTImage+HTML.h
+++ b/Core/Source/DTImage+HTML.h
@@ -24,8 +24,9 @@
 
 @end
 
-#else
+#endif
 
+#if TARGET_OS_OSX
 #import <AppKit/NSImage.h>
 
 /**

--- a/Core/Source/DTImage+HTML.m
+++ b/Core/Source/DTImage+HTML.m
@@ -19,7 +19,9 @@
 
 @end
 
-#else
+#endif
+
+#if TARGET_OS_OSX
 
 @implementation NSImage (HTML)
 

--- a/Core/Source/DTLazyImageView.h
+++ b/Core/Source/DTLazyImageView.h
@@ -5,6 +5,7 @@
 //  Created by Oliver Drobnik on 5/20/11.
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
+#if TARGET_OS_IPHONE
 
 #import <DTFoundation/DTWeakSupport.h>
 #import "DTAttributedTextContentView.h"
@@ -79,3 +80,5 @@ extern NSString * const DTLazyImageViewDidFinishDownloadNotification;
 - (void)cancelLoading;
 
 @end
+
+#endif

--- a/Core/Source/DTLazyImageView.m
+++ b/Core/Source/DTLazyImageView.m
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import <ImageIO/ImageIO.h>
 #import "DTLazyImageView.h"
 #import "DTCompatibility.h"
@@ -414,3 +416,5 @@ didCompleteWithError:(nullable NSError *)error
 @synthesize urlRequest = _urlRequest;
 
 @end
+
+#endif

--- a/Core/Source/DTLinkButton.h
+++ b/Core/Source/DTLinkButton.h
@@ -10,6 +10,9 @@
  Constant for highlighting notification
  */
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+
 extern NSString *DTLinkButtonDidHighlightNotification;
 
 /**
@@ -45,3 +48,5 @@ extern NSString *DTLinkButtonDidHighlightNotification;
 
 
 @end
+
+#endif

--- a/Core/Source/DTLinkButton.m
+++ b/Core/Source/DTLinkButton.m
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import "DTLinkButton.h"
 #import "DTCoreText.h"
 
@@ -178,3 +180,5 @@ NSString *DTLinkButtonDidHighlightNotification = @"DTLinkButtonDidHighlightNotif
 @synthesize showsTouchWhenHighlighted = _showsTouchWhenHighlighted;
 
 @end
+
+#endif

--- a/Core/Source/DTTextAttachment.h
+++ b/Core/Source/DTTextAttachment.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #if TARGET_OS_IPHONE
 #elif TARGET_OS_MAC
 #import <ApplicationServices/ApplicationServices.h>

--- a/Core/Source/NSAttributedString+DTCoreText.h
+++ b/Core/Source/NSAttributedString+DTCoreText.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 @class DTCSSListStyle;
 @class DTTextBlock;
 

--- a/Core/Source/NSAttributedString+HTML.h
+++ b/Core/Source/NSAttributedString+HTML.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 @class NSAttributedString;
 
 /**

--- a/Core/Source/NSAttributedString+SmallCaps.h
+++ b/Core/Source/NSAttributedString+SmallCaps.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 /**
  Methods that generated an attributed string with Small Caps, even if the used fonts don't support them natively.
  

--- a/Core/Source/NSAttributedStringRunDelegates.h
+++ b/Core/Source/NSAttributedStringRunDelegates.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #elif TARGET_OS_MAC

--- a/Core/Source/NSCoder+DTCompatibility.h
+++ b/Core/Source/NSCoder+DTCompatibility.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "DTCompatibility.h"
 
 @interface NSCoder (DTCompatibility)

--- a/Core/Source/NSDictionary+DTCoreText.h
+++ b/Core/Source/NSDictionary+DTCoreText.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Cocoanetics. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "DTCompatibility.h"
 
 @class DTCoreTextParagraphStyle;

--- a/Core/Source/NSMutableAttributedString+HTML.h
+++ b/Core/Source/NSMutableAttributedString+HTML.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "DTCoreTextConstants.h"
 
 @class DTCoreTextParagraphStyle, DTCoreTextFontDescriptor;

--- a/Core/Source/NSMutableString+HTML.h
+++ b/Core/Source/NSMutableString+HTML.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 
 /**
  Categories needed for modifying mutable strings, as needed for DTCoreText.

--- a/Core/Source/NSScanner+HTML.h
+++ b/Core/Source/NSScanner+HTML.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 @class DTColor;
 
 /**

--- a/Core/Source/NSString+CSS.h
+++ b/Core/Source/NSString+CSS.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 @class DTColor;
 
 /**

--- a/Core/Source/NSString+HTML.h
+++ b/Core/Source/NSString+HTML.h
@@ -6,6 +6,8 @@
 //  Copyright 2011 Drobnik.com. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 /**
  Methods for making HTML strings easier and quicker to handle. 
  */

--- a/Core/Source/NSString+Paragraphs.h
+++ b/Core/Source/NSString+Paragraphs.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Cocoanetics. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 
 /**
  Methods simplifying dealing with text that is in paragraphs.

--- a/Core/Source/UIFont+DTCoreText.h
+++ b/Core/Source/UIFont+DTCoreText.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import <CoreText/CoreText.h>
 
 /**
@@ -22,3 +24,5 @@
 + (UIFont *)fontWithCTFont:(CTFontRef)ctFont;
 
 @end
+
+#endif

--- a/Core/Source/UIFont+DTCoreText.m
+++ b/Core/Source/UIFont+DTCoreText.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+#if TARGET_OS_IPHONE
+
 #import "UIFont+DTCoreText.h"
 
 @implementation UIFont (DTCoreText)
@@ -27,3 +29,5 @@
 }
 
 @end
+
+#endif

--- a/Core/include/DTCoreText/CTLineUtils.h
+++ b/Core/include/DTCoreText/CTLineUtils.h
@@ -1,0 +1,1 @@
+../../Source/CTLineUtils.h

--- a/Core/include/DTCoreText/DTAccessibilityElement.h
+++ b/Core/include/DTCoreText/DTAccessibilityElement.h
@@ -1,0 +1,1 @@
+../../Source/DTAccessibilityElement.h

--- a/Core/include/DTCoreText/DTAccessibilityViewProxy.h
+++ b/Core/include/DTCoreText/DTAccessibilityViewProxy.h
@@ -1,0 +1,1 @@
+../../Source/DTAccessibilityViewProxy.h

--- a/Core/include/DTCoreText/DTAnchorHTMLElement.h
+++ b/Core/include/DTCoreText/DTAnchorHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTAnchorHTMLElement.h

--- a/Core/include/DTCoreText/DTAttributedLabel.h
+++ b/Core/include/DTCoreText/DTAttributedLabel.h
@@ -1,0 +1,1 @@
+../../Source/DTAttributedLabel.h

--- a/Core/include/DTCoreText/DTAttributedTextCell.h
+++ b/Core/include/DTCoreText/DTAttributedTextCell.h
@@ -1,0 +1,1 @@
+../../Source/DTAttributedTextCell.h

--- a/Core/include/DTCoreText/DTAttributedTextContentView.h
+++ b/Core/include/DTCoreText/DTAttributedTextContentView.h
@@ -1,0 +1,1 @@
+../../Source/DTAttributedTextContentView.h

--- a/Core/include/DTCoreText/DTAttributedTextView.h
+++ b/Core/include/DTCoreText/DTAttributedTextView.h
@@ -1,0 +1,1 @@
+../../Source/DTAttributedTextView.h

--- a/Core/include/DTCoreText/DTBreakHTMLElement.h
+++ b/Core/include/DTCoreText/DTBreakHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTBreakHTMLElement.h

--- a/Core/include/DTCoreText/DTCSSListStyle.h
+++ b/Core/include/DTCoreText/DTCSSListStyle.h
@@ -1,0 +1,1 @@
+../../Source/DTCSSListStyle.h

--- a/Core/include/DTCoreText/DTCSSStylesheet.h
+++ b/Core/include/DTCoreText/DTCSSStylesheet.h
@@ -1,0 +1,1 @@
+../../Source/DTCSSStylesheet.h

--- a/Core/include/DTCoreText/DTColor+Compatibility.h
+++ b/Core/include/DTCoreText/DTColor+Compatibility.h
@@ -1,0 +1,1 @@
+../../Source/DTColor+Compatibility.h

--- a/Core/include/DTCoreText/DTColorFunctions.h
+++ b/Core/include/DTCoreText/DTColorFunctions.h
@@ -1,0 +1,1 @@
+../../Source/DTColorFunctions.h

--- a/Core/include/DTCoreText/DTCompatibility.h
+++ b/Core/include/DTCoreText/DTCompatibility.h
@@ -1,0 +1,1 @@
+../../Source/DTCompatibility.h

--- a/Core/include/DTCoreText/DTCoreTextConstants.h
+++ b/Core/include/DTCoreText/DTCoreTextConstants.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextConstants.h

--- a/Core/include/DTCoreText/DTCoreTextFontCollection.h
+++ b/Core/include/DTCoreText/DTCoreTextFontCollection.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextFontCollection.h

--- a/Core/include/DTCoreText/DTCoreTextFontDescriptor.h
+++ b/Core/include/DTCoreText/DTCoreTextFontDescriptor.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextFontDescriptor.h

--- a/Core/include/DTCoreText/DTCoreTextFunctions.h
+++ b/Core/include/DTCoreText/DTCoreTextFunctions.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextFunctions.h

--- a/Core/include/DTCoreText/DTCoreTextGlyphRun.h
+++ b/Core/include/DTCoreText/DTCoreTextGlyphRun.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextGlyphRun.h

--- a/Core/include/DTCoreText/DTCoreTextLayoutFrame+Cursor.h
+++ b/Core/include/DTCoreText/DTCoreTextLayoutFrame+Cursor.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextLayoutFrame+Cursor.h

--- a/Core/include/DTCoreText/DTCoreTextLayoutFrame.h
+++ b/Core/include/DTCoreText/DTCoreTextLayoutFrame.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextLayoutFrame.h

--- a/Core/include/DTCoreText/DTCoreTextLayoutFrameAccessibilityElementGenerator.h
+++ b/Core/include/DTCoreText/DTCoreTextLayoutFrameAccessibilityElementGenerator.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextLayoutFrameAccessibilityElementGenerator.h

--- a/Core/include/DTCoreText/DTCoreTextLayoutLine.h
+++ b/Core/include/DTCoreText/DTCoreTextLayoutLine.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextLayoutLine.h

--- a/Core/include/DTCoreText/DTCoreTextLayouter.h
+++ b/Core/include/DTCoreText/DTCoreTextLayouter.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextLayouter.h

--- a/Core/include/DTCoreText/DTCoreTextMacros.h
+++ b/Core/include/DTCoreText/DTCoreTextMacros.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextMacros.h

--- a/Core/include/DTCoreText/DTCoreTextParagraphStyle.h
+++ b/Core/include/DTCoreText/DTCoreTextParagraphStyle.h
@@ -1,0 +1,1 @@
+../../Source/DTCoreTextParagraphStyle.h

--- a/Core/include/DTCoreText/DTDictationPlaceholderTextAttachment.h
+++ b/Core/include/DTCoreText/DTDictationPlaceholderTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTDictationPlaceholderTextAttachment.h

--- a/Core/include/DTCoreText/DTDictationPlaceholderView.h
+++ b/Core/include/DTCoreText/DTDictationPlaceholderView.h
@@ -1,0 +1,1 @@
+../../Source/DTDictationPlaceholderView.h

--- a/Core/include/DTCoreText/DTHTMLAttributedStringBuilder.h
+++ b/Core/include/DTCoreText/DTHTMLAttributedStringBuilder.h
@@ -1,0 +1,1 @@
+../../Source/DTHTMLAttributedStringBuilder.h

--- a/Core/include/DTCoreText/DTHTMLElement.h
+++ b/Core/include/DTCoreText/DTHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTHTMLElement.h

--- a/Core/include/DTCoreText/DTHTMLParserNode.h
+++ b/Core/include/DTCoreText/DTHTMLParserNode.h
@@ -1,0 +1,1 @@
+../../Source/DTHTMLParserNode.h

--- a/Core/include/DTCoreText/DTHTMLParserTextNode.h
+++ b/Core/include/DTCoreText/DTHTMLParserTextNode.h
@@ -1,0 +1,1 @@
+../../Source/DTHTMLParserTextNode.h

--- a/Core/include/DTCoreText/DTHTMLWriter.h
+++ b/Core/include/DTCoreText/DTHTMLWriter.h
@@ -1,0 +1,1 @@
+../../Source/DTHTMLWriter.h

--- a/Core/include/DTCoreText/DTHorizontalRuleHTMLElement.h
+++ b/Core/include/DTCoreText/DTHorizontalRuleHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTHorizontalRuleHTMLElement.h

--- a/Core/include/DTCoreText/DTIframeTextAttachment.h
+++ b/Core/include/DTCoreText/DTIframeTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTIframeTextAttachment.h

--- a/Core/include/DTCoreText/DTImage+HTML.h
+++ b/Core/include/DTCoreText/DTImage+HTML.h
@@ -1,0 +1,1 @@
+../../Source/DTImage+HTML.h

--- a/Core/include/DTCoreText/DTImageTextAttachment.h
+++ b/Core/include/DTCoreText/DTImageTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTImageTextAttachment.h

--- a/Core/include/DTCoreText/DTLazyImageView.h
+++ b/Core/include/DTCoreText/DTLazyImageView.h
@@ -1,0 +1,1 @@
+../../Source/DTLazyImageView.h

--- a/Core/include/DTCoreText/DTLinkButton.h
+++ b/Core/include/DTCoreText/DTLinkButton.h
@@ -1,0 +1,1 @@
+../../Source/DTLinkButton.h

--- a/Core/include/DTCoreText/DTListItemHTMLElement.h
+++ b/Core/include/DTCoreText/DTListItemHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTListItemHTMLElement.h

--- a/Core/include/DTCoreText/DTObjectTextAttachment.h
+++ b/Core/include/DTCoreText/DTObjectTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTObjectTextAttachment.h

--- a/Core/include/DTCoreText/DTStylesheetHTMLElement.h
+++ b/Core/include/DTCoreText/DTStylesheetHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTStylesheetHTMLElement.h

--- a/Core/include/DTCoreText/DTTextAttachment.h
+++ b/Core/include/DTCoreText/DTTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTTextAttachment.h

--- a/Core/include/DTCoreText/DTTextAttachmentHTMLElement.h
+++ b/Core/include/DTCoreText/DTTextAttachmentHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTTextAttachmentHTMLElement.h

--- a/Core/include/DTCoreText/DTTextBlock.h
+++ b/Core/include/DTCoreText/DTTextBlock.h
@@ -1,0 +1,1 @@
+../../Source/DTTextBlock.h

--- a/Core/include/DTCoreText/DTTextHTMLElement.h
+++ b/Core/include/DTCoreText/DTTextHTMLElement.h
@@ -1,0 +1,1 @@
+../../Source/DTTextHTMLElement.h

--- a/Core/include/DTCoreText/DTVideoTextAttachment.h
+++ b/Core/include/DTCoreText/DTVideoTextAttachment.h
@@ -1,0 +1,1 @@
+../../Source/DTVideoTextAttachment.h

--- a/Core/include/DTCoreText/DTWeakSupport.h
+++ b/Core/include/DTCoreText/DTWeakSupport.h
@@ -1,0 +1,1 @@
+../../Source/DTWeakSupport.h

--- a/Core/include/DTCoreText/NSAttributedString+DTCoreText.h
+++ b/Core/include/DTCoreText/NSAttributedString+DTCoreText.h
@@ -1,0 +1,1 @@
+../../Source/NSAttributedString+DTCoreText.h

--- a/Core/include/DTCoreText/NSAttributedString+DTDebug.h
+++ b/Core/include/DTCoreText/NSAttributedString+DTDebug.h
@@ -1,0 +1,1 @@
+../../Source/NSAttributedString+DTDebug.h

--- a/Core/include/DTCoreText/NSAttributedString+HTML.h
+++ b/Core/include/DTCoreText/NSAttributedString+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSAttributedString+HTML.h

--- a/Core/include/DTCoreText/NSAttributedString+SmallCaps.h
+++ b/Core/include/DTCoreText/NSAttributedString+SmallCaps.h
@@ -1,0 +1,1 @@
+../../Source/NSAttributedString+SmallCaps.h

--- a/Core/include/DTCoreText/NSAttributedStringRunDelegates.h
+++ b/Core/include/DTCoreText/NSAttributedStringRunDelegates.h
@@ -1,0 +1,1 @@
+../../Source/NSAttributedStringRunDelegates.h

--- a/Core/include/DTCoreText/NSCharacterSet+HTML.h
+++ b/Core/include/DTCoreText/NSCharacterSet+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSCharacterSet+HTML.h

--- a/Core/include/DTCoreText/NSCoder+DTCompatibility.h
+++ b/Core/include/DTCoreText/NSCoder+DTCompatibility.h
@@ -1,0 +1,1 @@
+../../Source/NSCoder+DTCompatibility.h

--- a/Core/include/DTCoreText/NSDictionary+DTCoreText.h
+++ b/Core/include/DTCoreText/NSDictionary+DTCoreText.h
@@ -1,0 +1,1 @@
+../../Source/NSDictionary+DTCoreText.h

--- a/Core/include/DTCoreText/NSMutableAttributedString+HTML.h
+++ b/Core/include/DTCoreText/NSMutableAttributedString+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSMutableAttributedString+HTML.h

--- a/Core/include/DTCoreText/NSMutableString+HTML.h
+++ b/Core/include/DTCoreText/NSMutableString+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSMutableString+HTML.h

--- a/Core/include/DTCoreText/NSScanner+HTML.h
+++ b/Core/include/DTCoreText/NSScanner+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSScanner+HTML.h

--- a/Core/include/DTCoreText/NSString+CSS.h
+++ b/Core/include/DTCoreText/NSString+CSS.h
@@ -1,0 +1,1 @@
+../../Source/NSString+CSS.h

--- a/Core/include/DTCoreText/NSString+HTML.h
+++ b/Core/include/DTCoreText/NSString+HTML.h
@@ -1,0 +1,1 @@
+../../Source/NSString+HTML.h

--- a/Core/include/DTCoreText/NSString+Paragraphs.h
+++ b/Core/include/DTCoreText/NSString+Paragraphs.h
@@ -1,0 +1,1 @@
+../../Source/NSString+Paragraphs.h

--- a/Core/include/DTCoreText/UIFont+DTCoreText.h
+++ b/Core/include/DTCoreText/UIFont+DTCoreText.h
@@ -1,0 +1,1 @@
+../../Source/UIFont+DTCoreText.h

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "DTCoreText",
+    platforms: [
+        .iOS(.v8),         //.v8 - .v13
+        .macOS(.v10_10),    //.v10_10 - .v10_15
+        .tvOS(.v9),        //.v9 - .v13
+    ],
+    products: [
+        .library(
+            name: "DTCoreText",
+            targets: ["DTCoreText"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/nostradani/DTFoundation.git", from: "1.7.15"),
+    ],
+    targets: [
+        .target(
+            name: "DTCoreText",
+            dependencies: [
+                .product(name: "DTFoundation", package: "DTFoundation"),
+            ],
+            path: "Core"),
+        .testTarget(
+            name: "DTCoreTextTests",
+            dependencies: ["DTCoreText"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# DTCoreText
+
+A description of this package.

--- a/Tests/DTCoreTextTests/DTCoreTextTests.swift
+++ b/Tests/DTCoreTextTests/DTCoreTextTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import DTCoreText
+
+final class DTCoreTextTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(DTCoreText().text, "Hello, World!")
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Tests/DTCoreTextTests/XCTestManifests.swift
+++ b/Tests/DTCoreTextTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(DTCoreTextTests.allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import DTCoreTextTests
+
+var tests = [XCTestCaseEntry]()
+tests += DTCoreTextTests.allTests()
+XCTMain(tests)


### PR DESCRIPTION
Currently this commit uses my fork for the DTFoundation SPM dependency.
I would prefer it if that change got merged and we use a dependency using the original repo from Cocoanetics

Also this PR contains a temporary workaround where we put the default.css as String into the code since SPM only supports resources with Swift 5.3, which hasn't been released yet. However I'm intending to remove this fix as soon as Swift 5.3 is released