### PR TITLE
Fix the default font for text from Italic to regular on iOS 14

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -231,7 +231,10 @@
 	if (defaultFontName) {
 		_defaultFontDescriptor.fontName = defaultFontName;
 	}
-
+	else
+    {
+        _defaultFontDescriptor.fontName = @"TimesNewRomanPSMT";
+    }
 	
 	_defaultLinkColor = [_options objectForKey:DTDefaultLinkColor];
 	


### PR DESCRIPTION
From iOS 14 onwards, the default font name for "Times new roman" font family is "TimesNewRomanPS-ItalicMT" where until iOS 13, it was "TimesNewRomanPSMT". It could be possible the default font name is picked alphabetically now from iOS 14. Specifically mentioning the font name would make sure the italic style font is not set by default.

closes #1199 

