### PR TITLE
Select Font with Matching Traits when Multiple are Available

### DIFF
--- a/Core/Source/DTCoreTextFontDescriptor.m
+++ b/Core/Source/DTCoreTextFontDescriptor.m
@@ -534,6 +534,7 @@ static BOOL _needsChineseFontCascadeFix = NO;
 {
 	CTFontDescriptorRef searchingFontDescriptor = NULL;
 	CTFontDescriptorRef matchingFontDescriptor = NULL;
+	CFArrayRef matchingFontDescriptors = NULL;
 	CTFontRef matchingFont = NULL;
 	
 	// check the cache first
@@ -602,8 +603,34 @@ static BOOL _needsChineseFontCascadeFix = NO;
 			[mandatoryAttributes addObject:(id)kCTFontFeaturesAttribute];
 		}
 		
-		// do the search
-		matchingFontDescriptor = CTFontDescriptorCreateMatchingFontDescriptor(searchingFontDescriptor, (__bridge CFSetRef)mandatoryAttributes);
+		matchingFontDescriptors = CTFontDescriptorCreateMatchingFontDescriptors(searchingFontDescriptor, (__bridge CFSetRef)mandatoryAttributes);
+		
+		if (matchingFontDescriptors) {
+			CFIndex count = CFArrayGetCount(matchingFontDescriptors);
+			if (count == 1) {
+				matchingFontDescriptor = CTFontDescriptorCreateMatchingFontDescriptor(searchingFontDescriptor, (__bridge CFSetRef)mandatoryAttributes);
+			} else {
+				CFIndex i = 0;
+				CFDictionaryRef traits = NULL;
+				CTFontDescriptorRef currentFontDescriptor = NULL;
+				for (i=0; i<count; i++) {
+					currentFontDescriptor = CFArrayGetValueAtIndex(matchingFontDescriptors, i);
+					traits = CTFontDescriptorCopyAttribute(currentFontDescriptor, kCTFontTraitsAttribute);
+					NSDictionary *traitsDictionary = CFBridgingRelease(traits);
+					
+					BOOL hasSlantValue = [traitsDictionary[@"NSCTFontSlantTrait"] boolValue];
+					BOOL hasBoldValue = [traitsDictionary[@"NSCTFontWeightTrait"] boolValue];
+					
+					BOOL hasMatchingBoldTrait = hasBoldValue == self.boldTrait;
+					BOOL hasMatchingItalicTrait = hasSlantValue == self.italicTrait;
+					
+					if (hasMatchingBoldTrait && hasMatchingItalicTrait) {
+						matchingFontDescriptor = currentFontDescriptor;
+					}
+				}
+				CFRelease(currentFontDescriptor);
+			}
+		}
 		
 		if (!matchingFontDescriptor)
 		{


### PR DESCRIPTION
This resolves an issue where DTCoreText is italicizing bolded text. When the framework looks for a font descriptor for a set of attributes (font family, size, bold, italic) etc. It uses a function `CTFontDescriptorCreateMatchingFontDescriptor` which returns the first font descriptor that it finds matching the attributes.

The issue is that it will return any font descriptor that matches them even if it also has extra attributes, in this case italic. 
```
CTFontDescriptorCreateMatchingFontDescriptor
Returns the single preferred matching font descriptor based on the original descriptor and system precedence.
```
It seems that in iOS 14 the "system precedence" has changed to pick italic-bold over just bold. 

The "solution" here is to get all the matching font descriptors. There are two in this case. And filter out the one that has an italic trait, if we haven't specified it.
