### PR TITLE
Select correct fallbackFont with matching traits

### DIFF
--- a/DTCoreText.podspec
+++ b/DTCoreText.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'DTCoreText'
-  spec.version      = '1.6.25'
+  spec.version      = '1.6.26'
   spec.platforms    = {:ios => '4.3', :tvos => '9.0' }
   spec.license      = 'BSD'
   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }

--- a/Test/Source/DTCoreTextFontDescriptorTest.m
+++ b/Test/Source/DTCoreTextFontDescriptorTest.m
@@ -36,7 +36,7 @@
 
 - (void)testFallbackFamily
 {
-	[DTCoreTextFontDescriptor setFallbackFontFamily:@"Helvetica"];
+	[DTCoreTextFontDescriptor setFallbackFontFamily:@"Arial"];
 	
 	NSAttributedString *attributedString = [super attributedStringFromHTMLString:@"<span style=\"font-family:FooBar\">text</span>" options:nil];
 	XCTAssertNotNil(attributedString, @"There should be an attributed string");
@@ -49,7 +49,64 @@
 	XCTAssertEqual(expectedRange.location, effectiveRange.location, @"Attributes should be entire range");
 	
 	DTCoreTextFontDescriptor *fontDescriptor = [attributes fontDescriptor];
-	XCTAssertEqualObjects(fontDescriptor.fontFamily, @"Helvetica", @"Font should have fallen back to Helvetica");
+	XCTAssertEqualObjects(fontDescriptor.fontFamily, @"Arial", @"Font should have fallen back to Arial");
+}
+
+- (void)testFallbackFontFamilyWithoutFontTraits
+{
+    [DTCoreTextFontDescriptor setFallbackFontFamily:@"Arial"];
+
+    NSAttributedString *attributedString = [super attributedStringFromHTMLString:@"<span style=\"font-family:FooBar\"><p>text</p></span>" options:nil];
+    XCTAssertNotNil(attributedString, @"There should be an attributed string");
+
+	UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+
+	UIFontDescriptor *descriptor = [font fontDescriptor];
+	BOOL isBold = (descriptor.symbolicTraits & UIFontDescriptorTraitBold) != 0;
+	XCTAssertFalse(isBold);
+
+	BOOL isItalic = (descriptor.symbolicTraits & UIFontDescriptorTraitItalic) != 0;
+	XCTAssertFalse(isItalic);
+
+	XCTAssertTrue([font.familyName isEqualToString:@"Arial"]);
+}
+
+- (void)testFallbackFontFamilyWithBoldFontTrait
+{
+	[DTCoreTextFontDescriptor setFallbackFontFamily:@"Arial"];
+
+	NSAttributedString *attributedString = [super attributedStringFromHTMLString:@"<span style=\"font-family:FooBar\"><b>text</b></span>" options:nil];
+	XCTAssertNotNil(attributedString, @"There should be an attributed string");
+
+	UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+
+	UIFontDescriptor *descriptor = [font fontDescriptor];
+	BOOL isBold = (descriptor.symbolicTraits & UIFontDescriptorTraitBold) != 0;
+	XCTAssertTrue(isBold);
+
+	BOOL isItalic = (descriptor.symbolicTraits & UIFontDescriptorTraitItalic) != 0;
+	XCTAssertFalse(isItalic);
+
+	XCTAssertTrue([font.familyName isEqualToString:@"Arial"]);
+}
+
+- (void)testFallbackFontFamilyWithItalicFontTrait
+{
+	[DTCoreTextFontDescriptor setFallbackFontFamily:@"Arial"];
+
+	NSAttributedString *attributedString = [super attributedStringFromHTMLString:@"<span style=\"font-family:FooBar\"><em>text</em></span>" options:nil];
+	XCTAssertNotNil(attributedString, @"There should be an attributed string");
+
+	UIFont *font = [attributedString attribute:NSFontAttributeName atIndex:0 effectiveRange:NULL];
+
+	UIFontDescriptor *descriptor = [font fontDescriptor];
+	BOOL isBold = (descriptor.symbolicTraits & UIFontDescriptorTraitBold) != 0;
+	XCTAssertFalse(isBold);
+
+	BOOL isItalic = (descriptor.symbolicTraits & UIFontDescriptorTraitItalic) != 0;
+	XCTAssertTrue(isItalic);
+
+	XCTAssertTrue([font.familyName isEqualToString:@"Arial"]);
 }
 
 - (void)testNilFallbackFamily


### PR DESCRIPTION
This resolves an issue with incorrect font attributes when Arial font is used as a fallbackFontFamily on text without any font traits.
On iOS 14 function CTFontDescriptorCreateMatchingFontDescriptor return first font that match descriptor even if it contains extra attributes, in this case Bold and Italic.

Solution is based on the #1207