### PR TITLE
Add ability to pass in a UIFontDescriptor for DTHTMLAttributedStringBuilder

### DIFF
--- a/Core/Source/DTCoreTextConstants.h
+++ b/Core/Source/DTCoreTextConstants.h
@@ -47,6 +47,7 @@ extern NSString * const DTMaxImageSize;
 extern NSString * const DTDefaultFontFamily;
 extern NSString * const DTDefaultFontName;
 extern NSString * const DTDefaultFontSize;
+extern NSString * const DTDefaultFontDescriptor;
 extern NSString * const DTDefaultTextColor;
 extern NSString * const DTDefaultLinkColor;
 extern NSString * const DTDefaultLinkDecoration;

--- a/Core/Source/DTCoreTextConstants.m
+++ b/Core/Source/DTCoreTextConstants.m
@@ -19,6 +19,7 @@ NSString * const DTMaxImageSize = @"DTMaxImageSize";
 NSString * const DTDefaultFontFamily = @"DTDefaultFontFamily";
 NSString * const DTDefaultFontName = @"DTDefaultFontName";
 NSString * const DTDefaultFontSize = @"DTDefaultFontSize";
+NSString * const DTDefaultFontDescriptor = @"DTDefaultFontDescriptor";
 NSString * const DTDefaultTextColor = @"DTDefaultTextColor";
 NSString * const DTDefaultLinkColor = @"DTDefaultLinkColor";
 NSString * const DTDefaultLinkHighlightColor = @"DTDefaultLinkHighlightColor";

--- a/Core/Source/DTCoreTextFontDescriptor.h
+++ b/Core/Source/DTCoreTextFontDescriptor.h
@@ -48,6 +48,14 @@
 - (id)initWithCTFontDescriptor:(CTFontDescriptorRef)ctFontDescriptor;
 
 /**
+ Creates a font descriptor from a UI font descriptor. This UIFontDescriptor
+ overrides the other properties.
+ @param uiFontDescriptor The UIFontDescriptor
+ @returns An initialized font descriptor
+ */
+- (id)initWithUIFontDescriptor:(UIFontDescriptor *)uiFontDescriptor;
+
+/**
  Creates a font descriptor from a Core Text font
  @param ctFont The Core Text font
  @returns An initialized font descriptor

--- a/Core/Source/DTCoreTextFontDescriptor.m
+++ b/Core/Source/DTCoreTextFontDescriptor.m
@@ -32,7 +32,9 @@ static BOOL _needsChineseFontCascadeFix = NO;
 {
 	NSString *_fontFamily;
 	NSString *_fontName;
-	
+
+	UIFontDescriptor *_uiFontDescriptor;
+
 	CGFloat _pointSize;
 	
 	CTFontSymbolicTraits _stylisticTraits;
@@ -274,7 +276,13 @@ static BOOL _needsChineseFontCascadeFix = NO;
 		CFStringRef familyName = CTFontDescriptorCopyAttribute(ctFontDescriptor, kCTFontFamilyNameAttribute);
 		self.fontFamily = CFBridgingRelease(familyName);
 	}
-	
+
+	return self;
+}
+
+- (id)initWithUIFontDescriptor:(UIFontDescriptor *)uiFontDescriptor {
+	self = [self initWithCTFontDescriptor:(CTFontDescriptorRef)uiFontDescriptor];
+	_uiFontDescriptor = uiFontDescriptor;
 	return self;
 }
 
@@ -547,6 +555,11 @@ static BOOL _needsChineseFontCascadeFix = NO;
 		return cachedFont;
 	}
 	
+	// If we have a UIFontDescriptor, we should directly instantiate using that. This overrides all.
+	if (_uiFontDescriptor) {
+		matchingFontDescriptor = (__bridge CTFontDescriptorRef)_uiFontDescriptor;
+	}
+
 	// check the override table that has all preinstalled fonts plus the ones the user registered
 	NSString *overrideName = nil;
 	
@@ -572,7 +585,7 @@ static BOOL _needsChineseFontCascadeFix = NO;
 		
 		matchingFont = CTFontCreateWithName((__bridge CFStringRef)usedName, _pointSize, NULL);
 	}
-	else
+	else if (matchingFontDescriptor != NULL)
 	{
 		// we need to search for a suitable font
 		

--- a/Core/Source/DTHTMLAttributedStringBuilder.h
+++ b/Core/Source/DTHTMLAttributedStringBuilder.h
@@ -39,6 +39,7 @@ typedef void(^DTHTMLAttributedStringBuilderParseErrorCallback)(NSAttributedStrin
  - DTDefaultFontFamily: the default font family to use instead of Times New Roman
  - DTDefaultFontName: the default font face to use instead of Times New Roman
  - DTDefaultFontSize: the default font size to use instead of 12
+ - DTDefaultFontDescriptor: the default font descriptor. This supercedes font family/name
  - DTDefaultTextColor: the default text color
  - DTDefaultLinkColor: the default color for hyperlink text
  - DTDefaultLinkDecoration: the default decoration for hyperlinks

--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -232,6 +232,10 @@
 		_defaultFontDescriptor.fontName = defaultFontName;
 	}
 
+	UIFontDescriptor *const defaultUIFontDescriptor = [_options objectForKey:DTDefaultFontDescriptor];
+	if (defaultUIFontDescriptor) {
+		_defaultFontDescriptor = [[DTCoreTextFontDescriptor alloc] initWithUIFontDescriptor:defaultUIFontDescriptor];
+	}
 	
 	_defaultLinkColor = [_options objectForKey:DTDefaultLinkColor];
 	


### PR DESCRIPTION
* See #1168 for reference
* Basically, using system fonts will yield a font family name that we cannot directly instantiate from.
* Instead, we need to use the font descriptor and create using that. This should be mutually exclusive with font family/name