### PR TITLE
let the DTTextAttachment be a subclass of the NSTextAttachment

### DIFF
--- a/Core/Source/DTTextAttachment.h
+++ b/Core/Source/DTTextAttachment.h
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSUInteger, DTTextAttachmentVerticalAlignment)
 /**
  An object to represent an attachment in an HTML/rich text view.  
  */
-@interface DTTextAttachment : NSObject <NSCoding>
+@interface DTTextAttachment : NSTextAttachment
 {
 	CGSize _displaySize;  // the display dimensions of the attachment
 	CGSize _originalSize; // the original dimensions of the attachment


### PR DESCRIPTION
fix #1249 crash