### PR TITLE
remove warning of non-tiled layer 

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -438,7 +438,22 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 	{
 		if (![self.layer isKindOfClass:[CATiledLayer class]])
 		{
-			NSLog(@"Warning: A %@ with size %@ is using a non-tiled layer. Set the layer class to a CATiledLayer subclass with [DTAttributedTextContentView setLayerClass:[DTTiledLayerWithoutFade class]].", NSStringFromClass([self class]), NSStringFromCGSize(self.bounds.size));
+            BOOL isContainedInTableViewCell = NO;
+            UIView* parentView = self.superview;
+            for (; parentView != nil ; parentView = parentView.superview)
+            {
+                if ([parentView isKindOfClass:[UITableViewCell class]])
+                {
+                    isContainedInTableViewCell = YES;
+                    break;
+                }
+            }
+            
+            if (isContainedInTableViewCell == NO)
+            {
+                NSLog(@"Warning: A %@ with size %@ is using a non-tiled layer. Set the layer class to a CATiledLayer subclass with [DTAttributedTextContentView setLayerClass:[DTTiledLayerWithoutFade class]].", NSStringFromClass([self class]), NSStringFromCGSize(self.bounds.size));
+
+            }
 		}
 	}
 	


### PR DESCRIPTION
remove warning of non-tiled layer when the DTAttributedTextContentView is using in UITableViewCell