### PR TITLE
Rename isNumeric to keep it from clashing with FMCore

### DIFF
--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1220,7 +1220,7 @@ NSDictionary *_classesForNames = nil;
 		{
 			// no op, we already inherited it
 		}
-		else if ([lineHeight isNumeric])
+		else if ([lineHeight dt_isNumeric])
 		{
 			self.paragraphStyle.lineHeightMultiple = [lineHeight floatValue];
 		}
@@ -1245,7 +1245,7 @@ NSDictionary *_classesForNames = nil;
         {
             // no op, we already inherited it
         }
-        else if ([minimumLineHeight isNumeric])
+        else if ([minimumLineHeight dt_isNumeric])
         {
             self.paragraphStyle.minimumLineHeight = [minimumLineHeight floatValue];
         }
@@ -1267,7 +1267,7 @@ NSDictionary *_classesForNames = nil;
         {
             // no op, we already inherited it
         }
-        else if ([maximumLineHeight isNumeric])
+        else if ([maximumLineHeight dt_isNumeric])
         {
             self.paragraphStyle.minimumLineHeight = [maximumLineHeight floatValue];
         }

--- a/Core/Source/NSString+HTML.h
+++ b/Core/Source/NSString+HTML.h
@@ -24,7 +24,7 @@
  Test whether or not this string is numeric only.
  @returns If this string consists only of numeric characters 0-9. 
  */
-- (BOOL)isNumeric;
+- (BOOL)dt_isNumeric;
 
 /**
  Test whether the entire receiver consists of only whitespace characters.

--- a/Core/Source/NSString+HTML.m
+++ b/Core/Source/NSString+HTML.m
@@ -23,7 +23,7 @@ static NSDictionary *entityReverseLookup = nil;
 	return (NSUInteger)result;
 }
 
-- (BOOL)isNumeric
+- (BOOL)dt_isNumeric
 {
 	const char *s = [self UTF8String];
 	


### PR DESCRIPTION
We're using a style sheet that specifies `line-height: 1.4;` in the stylesheet, which works fine.
However, we noticed a strange behavior, where the line-height was always 0 (and DTCoreText instead set the maximum/minimumLineHeight values) after opening an UIActivityViewController. This bug only happens on a real device, not when using the simulator.

This is due to the share sheet loading the private FMCore framework, [which also contains an extension on NSString ](https://github.com/nst/iOS-Runtime-Headers/blob/master/Frameworks/Foundation.framework/NSString.h#L1228) with the name `isNumeric`, so the implementation from DTCoreText is overwritten and won't work as expected anymore.

Renaming the method fixes this problem.