### PR TITLE
XCode 14.3: Fix warning in DTCompatibility.h

### DIFF
--- a/Core/Source/DTCompatibility.h
+++ b/Core/Source/DTCompatibility.h
@@ -58,7 +58,7 @@
 
 
 	// runtime-check if NS-style attributes are allowed
-	static inline BOOL DTCoreTextModernAttributesPossible()
+	static inline BOOL DTCoreTextModernAttributesPossible(void)
 	{
 #if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
 		if (floor(NSFoundationVersionNumber) >= DTNSFoundationVersionNumber_iOS_6_0)
@@ -70,7 +70,7 @@
 	}
 
 	// runtime-check if CoreText draws underlines
-	static inline BOOL DTCoreTextDrawsUnderlinesWithGlyphs()
+	static inline BOOL DTCoreTextDrawsUnderlinesWithGlyphs(void)
 	{
 		if (floor(NSFoundationVersionNumber) >= DTNSFoundationVersionNumber_iOS_7_0)
 		{


### PR DESCRIPTION
Building DTCoreText with XCode 14.3 is generating a warning in DTCompatibility.h

Warning: `A function declaration without a prototype is deprecated in all versions of C`

XCode is able to suggest a fix for the warning:

\-       static inline BOOL DTCoreTextModernAttributesPossible()
\+       static inline BOOL DTCoreTextModernAttributesPossible(void)

\-       static inline BOOL DTCoreTextDrawsUnderlinesWithGlyphs()
\+       static inline BOOL DTCoreTextDrawsUnderlinesWithGlyphs(void)

This fixes issue #1267 