### PR TITLE
Fix Unsafe Style Parsing

### DIFF
--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1006,9 +1006,10 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
 	
-	NSString *fontStyle = [[styles objectForKey:@"font-style"] lowercaseString];
-	if (fontStyle && [fontStyle isKindOfClass:[NSString class]])
+	NSString *fontStyleObject = [styles objectForKey:@"font-style"];
+	if (fontStyleObject && [fontStyleObject isKindOfClass:[NSString class]])
 	{
+        NSString *fontStyle = [fontSizeObj lowercaseString];
 		// remove font name since this would cause font creation to ignore the trait
 		_fontDescriptor.fontName = nil;
 		
@@ -1026,9 +1027,10 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
 	
-	NSString *fontWeight = [[styles objectForKey:@"font-weight"] lowercaseString];
-	if (fontWeight && [fontWeight isKindOfClass:[NSString class]])
+	NSString *fontWeightObject = [styles objectForKey:@"font-weight"];
+	if (fontWeightObject && [fontWeightObject isKindOfClass:[NSString class]])
 	{
+        NSString *fontWeight = [fontWeightObject lowercaseString];
 		// remove font name since this would cause font creation to ignore the trait
 		_fontDescriptor.fontName = nil;
 		
@@ -1065,9 +1067,11 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
 	
-	NSString *decoration = [[styles objectForKey:@"text-decoration"] lowercaseString];
-	if (decoration && [decoration isKindOfClass:[NSString class]])
+	NSString *decorationObject = [styles objectForKey:@"text-decoration"];
+	if (decorationObject && [decorationObject isKindOfClass:[NSString class]])
 	{
+        NSString *decoration = [decorationObject lowercaseString];
+
 		if ([decoration isEqualToString:@"underline"])
 		{
 			self.underlineStyle = kCTUnderlineStyleSingle;
@@ -1096,15 +1100,17 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
     
-    NSString *decorationColor = [[styles objectForKey:@"text-decoration-color"] lowercaseString];
-    if (decorationColor && [decorationColor isKindOfClass:[NSString class]])
+    NSString *decorationColorObject = [styles objectForKey:@"text-decoration-color"];
+    if (decorationColorObject && [decorationColorObject isKindOfClass:[NSString class]])
     {
-        self.underlineColor = DTColorCreateWithHTMLName(decorationColor);
+        self.underlineColor = DTColorCreateWithHTMLName([decorationColorObject lowercaseString]);
     }
 	
-	NSString *alignment = [[styles objectForKey:@"text-align"] lowercaseString];
-	if (alignment && [alignment isKindOfClass:[NSString class]])
+	NSString *alignmentObject = [styles objectForKey:@"text-align"];
+	if (alignmentObject && [alignmentObject isKindOfClass:[NSString class]])
 	{
+        NSString *alignment = [alignmentObject lowercaseString];
+
 		if ([alignment isEqualToString:@"left"])
 		{
 #if DTCORETEXT_SUPPORT_NS_ATTRIBUTES
@@ -1143,9 +1149,11 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
 	
-	NSString *verticalAlignment = [[styles objectForKey:@"vertical-align"] lowercaseString];
-	if (verticalAlignment && [verticalAlignment isKindOfClass:[NSString class]])
+	NSString *verticalAlignmentObject = [styles objectForKey:@"vertical-align"];
+	if (verticalAlignmentObject && [verticalAlignmentObject isKindOfClass:[NSString class]])
 	{
+        NSString *verticalAlignment = [verticalAlignmentObject lowercaseString];
+
 		if ([verticalAlignment isEqualToString:@"sub"])
 		{
 			self.superscriptStyle = -1;
@@ -1180,9 +1188,11 @@ NSDictionary *_classesForNames = nil;
 		}
 	}
 	
-	NSString *letterSpacing = [[styles objectForKey:@"letter-spacing"] lowercaseString];
-	if (letterSpacing && [letterSpacing isKindOfClass:[NSString class]])
+	NSString *letterSpacingObject = [styles objectForKey:@"letter-spacing"];
+	if (letterSpacingObject && [letterSpacingObject isKindOfClass:[NSString class]])
 	{
+        NSString *letterSpacing = [letterSpacingObject lowercaseString];
+
 		if ([letterSpacing isEqualToString:@"normal"])
 		{
 			_letterSpacing = 0;
@@ -1207,9 +1217,11 @@ NSDictionary *_classesForNames = nil;
 		self.shadows = [shadow arrayOfCSSShadowsWithCurrentTextSize:_fontDescriptor.pointSize currentColor:_textColor];
 	}
 	
-	NSString *lineHeight = [[styles objectForKey:@"line-height"] lowercaseString];
-	if (lineHeight && [lineHeight isKindOfClass:[NSString class]])
+	NSString *lineHeightObject = [styles objectForKey:@"line-height"];
+	if (lineHeightObject && [lineHeightObject isKindOfClass:[NSString class]])
 	{
+        NSString *lineHeight = [lineHeightObject lowercaseString];
+
 		if ([lineHeight isEqualToString:@"normal"])
 		{
 			self.paragraphStyle.lineHeightMultiple = 0.0; // default
@@ -1234,9 +1246,11 @@ NSDictionary *_classesForNames = nil;
     
     // Specializations on line-height:
     
-    NSString *minimumLineHeight = [[styles objectForKey:@"minimum-line-height"] lowercaseString];
-    if (minimumLineHeight && [minimumLineHeight isKindOfClass:[NSString class]])
+    NSString *minimumLineHeightObject = [styles objectForKey:@"minimum-line-height"];
+    if (minimumLineHeightObject && [minimumLineHeightObject isKindOfClass:[NSString class]])
     {
+        NSString *minimumLineHeight = [minimumLineHeightObject lowercaseString];
+
         if ([minimumLineHeight isEqualToString:@"normal"])
         {
             // no op, that was already done above
@@ -1256,9 +1270,11 @@ NSDictionary *_classesForNames = nil;
         }
     }
 
-    NSString *maximumLineHeight = [[styles objectForKey:@"maximum-line-height"] lowercaseString];
-    if (maximumLineHeight && [maximumLineHeight isKindOfClass:[NSString class]])
+    NSString *maximumLineHeightObject = [styles objectForKey:@"maximum-line-height"];
+    if (maximumLineHeightObject && [maximumLineHeightObject isKindOfClass:[NSString class]])
     {
+        NSString *maximumLineHeight = [maximumLineHeightObject lowercaseString];
+
         if ([maximumLineHeight isEqualToString:@"normal"])
         {
             // no op, that was already done above
@@ -1281,10 +1297,11 @@ NSDictionary *_classesForNames = nil;
     
     // End Specializations on line-height
 
-	
-	NSString *fontVariantStr = [[styles objectForKey:@"font-variant"] lowercaseString];
-	if (fontVariantStr && [fontVariantStr isKindOfClass:[NSString class]])
+	NSString *fontVariantStringObject = [styles objectForKey:@"font-variant"];
+	if (fontVariantStringObject && [fontVariantStringObject isKindOfClass:[NSString class]])
 	{
+        NSString *fontVariantStr = [fontVariantStringObject lowercaseString];
+
 		if ([fontVariantStr isEqualToString:@"small-caps"])
 		{
 			_fontVariant = DTHTMLElementFontVariantSmallCaps;
@@ -1344,7 +1361,7 @@ NSDictionary *_classesForNames = nil;
 		{
 			_displayStyle = DTHTMLElementDisplayStyleTable;
 		}
-		else if ([verticalAlignment isEqualToString:@"inherit"])
+		else if ([verticalAlignmentObject isEqualToString:@"inherit"])
 		{
 			// nothing to do
 		}
@@ -1355,18 +1372,18 @@ NSDictionary *_classesForNames = nil;
 	{
 		self.backgroundStrokeColor = DTColorCreateWithHTMLName(borderColor);
 	}
-	NSString *borderWidth = [[styles objectForKey:@"border-width"] lowercaseString];
+	NSString *borderWidth = [styles objectForKey:@"border-width"];
 	if (borderWidth && [borderWidth isKindOfClass:[NSString class]])
 	{
-		_backgroundStrokeWidth = [borderWidth floatValue];
+		_backgroundStrokeWidth = [[borderWidth lowercaseString] floatValue];
 	}
 	else {
 		_backgroundStrokeWidth = 0.0f;
 	}
-    NSString *cornerRadiusObject = [styles objectForKey:@"border-radius"];
-	if (cornerRadiusObject && [cornerRadiusObject isKindOfClass:[NSString class]])
+    NSString *cornerRadius = [styles objectForKey:@"border-radius"];
+	if (cornerRadius && [cornerRadius isKindOfClass:[NSString class]])
 	{
-		_backgroundCornerRadius = [[cornerRadiusObject lowercaseString] floatValue];
+		_backgroundCornerRadius = [[cornerRadius lowercaseString] floatValue];
 	}
 	else {
 		_backgroundCornerRadius = 0.0f;

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1380,7 +1380,7 @@ NSDictionary *_classesForNames = nil;
 	else {
 		_backgroundStrokeWidth = 0.0f;
 	}
-    NSString *cornerRadiusObject = [styles objectForKey:@"border-radius"];
+	NSString *cornerRadiusObject = [styles objectForKey:@"border-radius"];
 	if (cornerRadiusObject && [cornerRadiusObject isKindOfClass:[NSString class]])
 	{
 		_backgroundCornerRadius = [[cornerRadiusObject lowercaseString] floatValue];

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1372,18 +1372,18 @@ NSDictionary *_classesForNames = nil;
 	{
 		self.backgroundStrokeColor = DTColorCreateWithHTMLName(borderColor);
 	}
-	NSString *borderWidth = [styles objectForKey:@"border-width"];
-	if (borderWidth && [borderWidth isKindOfClass:[NSString class]])
+	NSString *borderWidthObject = [styles objectForKey:@"border-width"];
+	if (borderWidthObject && [borderWidthObject isKindOfClass:[NSString class]])
 	{
-		_backgroundStrokeWidth = [[borderWidth lowercaseString] floatValue];
+		_backgroundStrokeWidth = [[borderWidthObject lowercaseString] floatValue];
 	}
 	else {
 		_backgroundStrokeWidth = 0.0f;
 	}
-    NSString *cornerRadius = [styles objectForKey:@"border-radius"];
-	if (cornerRadius && [cornerRadius isKindOfClass:[NSString class]])
+    NSString *cornerRadiusObject = [styles objectForKey:@"border-radius"];
+	if (cornerRadiusObject && [cornerRadiusObject isKindOfClass:[NSString class]])
 	{
-		_backgroundCornerRadius = [[cornerRadius lowercaseString] floatValue];
+		_backgroundCornerRadius = [[cornerRadiusObject lowercaseString] floatValue];
 	}
 	else {
 		_backgroundCornerRadius = 0.0f;

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1363,10 +1363,10 @@ NSDictionary *_classesForNames = nil;
 	else {
 		_backgroundStrokeWidth = 0.0f;
 	}
-	NSString *cornerRadius = [[styles objectForKey:@"border-radius"] lowercaseString];
-	if (cornerRadius && [cornerRadius isKindOfClass:[NSString class]])
+    NSString *cornerRadiusObject = [styles objectForKey:@"border-radius"];
+	if (cornerRadiusObject && [cornerRadiusObject isKindOfClass:[NSString class]])
 	{
-		_backgroundCornerRadius = [cornerRadius floatValue];
+		_backgroundCornerRadius = [[cornerRadiusObject lowercaseString] floatValue];
 	}
 	else {
 		_backgroundCornerRadius = 0.0f;

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -1009,7 +1009,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *fontStyleObject = [styles objectForKey:@"font-style"];
 	if (fontStyleObject && [fontStyleObject isKindOfClass:[NSString class]])
 	{
-        NSString *fontStyle = [fontSizeObj lowercaseString];
+		NSString *fontStyle = [fontSizeObj lowercaseString];
 		// remove font name since this would cause font creation to ignore the trait
 		_fontDescriptor.fontName = nil;
 		
@@ -1030,7 +1030,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *fontWeightObject = [styles objectForKey:@"font-weight"];
 	if (fontWeightObject && [fontWeightObject isKindOfClass:[NSString class]])
 	{
-        NSString *fontWeight = [fontWeightObject lowercaseString];
+		NSString *fontWeight = [fontWeightObject lowercaseString];
 		// remove font name since this would cause font creation to ignore the trait
 		_fontDescriptor.fontName = nil;
 		
@@ -1070,7 +1070,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *decorationObject = [styles objectForKey:@"text-decoration"];
 	if (decorationObject && [decorationObject isKindOfClass:[NSString class]])
 	{
-        NSString *decoration = [decorationObject lowercaseString];
+		NSString *decoration = [decorationObject lowercaseString];
 
 		if ([decoration isEqualToString:@"underline"])
 		{
@@ -1109,7 +1109,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *alignmentObject = [styles objectForKey:@"text-align"];
 	if (alignmentObject && [alignmentObject isKindOfClass:[NSString class]])
 	{
-        NSString *alignment = [alignmentObject lowercaseString];
+		NSString *alignment = [alignmentObject lowercaseString];
 
 		if ([alignment isEqualToString:@"left"])
 		{
@@ -1152,7 +1152,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *verticalAlignmentObject = [styles objectForKey:@"vertical-align"];
 	if (verticalAlignmentObject && [verticalAlignmentObject isKindOfClass:[NSString class]])
 	{
-        NSString *verticalAlignment = [verticalAlignmentObject lowercaseString];
+		NSString *verticalAlignment = [verticalAlignmentObject lowercaseString];
 
 		if ([verticalAlignment isEqualToString:@"sub"])
 		{
@@ -1191,7 +1191,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *letterSpacingObject = [styles objectForKey:@"letter-spacing"];
 	if (letterSpacingObject && [letterSpacingObject isKindOfClass:[NSString class]])
 	{
-        NSString *letterSpacing = [letterSpacingObject lowercaseString];
+		NSString *letterSpacing = [letterSpacingObject lowercaseString];
 
 		if ([letterSpacing isEqualToString:@"normal"])
 		{
@@ -1220,7 +1220,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *lineHeightObject = [styles objectForKey:@"line-height"];
 	if (lineHeightObject && [lineHeightObject isKindOfClass:[NSString class]])
 	{
-        NSString *lineHeight = [lineHeightObject lowercaseString];
+		NSString *lineHeight = [lineHeightObject lowercaseString];
 
 		if ([lineHeight isEqualToString:@"normal"])
 		{
@@ -1249,7 +1249,7 @@ NSDictionary *_classesForNames = nil;
     NSString *minimumLineHeightObject = [styles objectForKey:@"minimum-line-height"];
     if (minimumLineHeightObject && [minimumLineHeightObject isKindOfClass:[NSString class]])
     {
-        NSString *minimumLineHeight = [minimumLineHeightObject lowercaseString];
+		NSString *minimumLineHeight = [minimumLineHeightObject lowercaseString];
 
         if ([minimumLineHeight isEqualToString:@"normal"])
         {
@@ -1273,7 +1273,7 @@ NSDictionary *_classesForNames = nil;
     NSString *maximumLineHeightObject = [styles objectForKey:@"maximum-line-height"];
     if (maximumLineHeightObject && [maximumLineHeightObject isKindOfClass:[NSString class]])
     {
-        NSString *maximumLineHeight = [maximumLineHeightObject lowercaseString];
+		NSString *maximumLineHeight = [maximumLineHeightObject lowercaseString];
 
         if ([maximumLineHeight isEqualToString:@"normal"])
         {
@@ -1300,7 +1300,7 @@ NSDictionary *_classesForNames = nil;
 	NSString *fontVariantStringObject = [styles objectForKey:@"font-variant"];
 	if (fontVariantStringObject && [fontVariantStringObject isKindOfClass:[NSString class]])
 	{
-        NSString *fontVariantStr = [fontVariantStringObject lowercaseString];
+		NSString *fontVariantStr = [fontVariantStringObject lowercaseString];
 
 		if ([fontVariantStr isEqualToString:@"small-caps"])
 		{


### PR DESCRIPTION
Hello!

We have identified a crash in production caused by malformed CSS styling in the HTML being rendered. The issue arises from calling `lowercaseString` on an object expected to be an `NSString`, but which is actually an `NSMutableArray`.

The crash can be observed in the following screenshots:

<img width="1172" alt="Screenshot 2024-08-06 at 1 17 23 PM" src="https://github.com/user-attachments/assets/a3d71f6a-b5ab-4f0a-bc8d-4fa638adfe92">

<img width="1727" alt="Screenshot 2024-08-06 at 1 23 42 PM" src="https://github.com/user-attachments/assets/b2b0a5a8-fec6-4a90-971f-996eb6e6918d">

<img width="1368" alt="355585552-079e66b7-4aef-4505-9c91-dfa91568bd0e" src="https://github.com/user-attachments/assets/c186a5c2-164f-43df-9969-4b67f26d5ae1">

My proposed fix is straightforward.
I have updated the code so that the call to `lowercaseString` on `[style objectForKey: @"border-radius"]` is made only after the `NSString` type check.  This resolves the crash for us.

Best,

~ Cameron




