### PR TITLE
fix: `fontWithCTFont` not return the correct font

### DIFF
--- a/Core/Source/UIFont+DTCoreText.m
+++ b/Core/Source/UIFont+DTCoreText.m
@@ -14,7 +14,7 @@
 
 + (UIFont *)fontWithCTFont:(CTFontRef)ctFont
 {
-	NSString *fontName = (__bridge_transfer NSString *)CTFontCopyName(ctFont, kCTFontPostScriptNameKey);
+	NSString *fontName = (__bridge_transfer NSString *)CTFontCopyName(ctFont, kCTFontFullNameKey);
 
 	CGFloat fontSize = CTFontGetSize(ctFont);
 	UIFont *font = [UIFont fontWithName:fontName size:fontSize];


### PR DESCRIPTION
When using this `DTDefaultFontFamily: UIFont.systemFont(ofSize: UIFont.systemFontSize).familyName` , `fontWithCTFont` was always returning Times New Roman