### PR TITLE
fix appendString defined duplicated in iOS18

### DIFF
--- a/Core/Source/DTHTMLAttributedStringBuilder.m
+++ b/Core/Source/DTHTMLAttributedStringBuilder.m
@@ -876,7 +876,7 @@
 											[strongSelf->_tmpString deleteCharactersInRange:NSMakeRange([strongSelf->_tmpString length]-1, 1)];
 										}
 										
-										[strongSelf->_tmpString appendString:@"\n"];
+										[strongSelf->_tmpString dt_appendString:@"\n"];
 									}
 								}
 								

--- a/Core/Source/DTHTMLElement.m
+++ b/Core/Source/DTHTMLElement.m
@@ -490,7 +490,7 @@ NSDictionary *_classesForNames = nil;
 						}
 						
 						// paragraph break
-						[tmpString appendString:@"\n"];
+						[tmpString dt_appendString:@"\n"];
 					}
 				}
 				

--- a/Core/Source/DTTextAttachmentHTMLElement.m
+++ b/Core/Source/DTTextAttachmentHTMLElement.m
@@ -69,7 +69,7 @@
 		// block-level elements get space trimmed and a newline
 		if (self.displayStyle != DTHTMLElementDisplayStyleInline)
 		{
-			[tmpString appendString:@"\n"];
+			[tmpString dt_appendString:@"\n"];
 		}
 		
 		return tmpString;

--- a/Core/Source/NSMutableAttributedString+HTML.h
+++ b/Core/Source/NSMutableAttributedString+HTML.h
@@ -23,6 +23,7 @@
  If the last character of the receiver contains a placeholder for a <DTTextAttachment> it is removed from the appended string. Also fields (e.g. list prefixes) are not extended
  @param string The string to be appended to this string. */
 - (void)appendString:(NSString *)string;
+- (void)dt_appendString:(NSString *)string;// added this prefix version of appendString ,because the appendString method defined duplication in iOS18 ,appendString will also defined in ScreenReaderCore.framework
 
 /** 
  Appends a string with a given paragraph style and font to this string. 

--- a/Core/Source/NSMutableAttributedString+HTML.m
+++ b/Core/Source/NSMutableAttributedString+HTML.m
@@ -19,6 +19,39 @@
 
 @implementation NSMutableAttributedString (HTML)
 
+// the same as appendString just to avoid method repeat problem in iOS18 . If everything works well for somethime , the original appendString can be removed
+- (void)dt_appendString:(NSString *)string
+{
+    NSParameterAssert(string);
+    
+    NSUInteger length = [self length];
+    NSAttributedString *appendString = nil;
+    
+    if (length)
+    {
+        // get attributes at end of self
+        NSMutableDictionary *attributes = [[self attributesAtIndex:length-1 effectiveRange:NULL] mutableCopy];
+        
+        // we need to remove the image placeholder (if any) to prevent duplication
+        [attributes removeObjectForKey:NSAttachmentAttributeName];
+        [attributes removeObjectForKey:(id)kCTRunDelegateAttributeName];
+        
+        // we also remove field attribute, because appending plain strings should never extend an field
+        [attributes removeObjectForKey:DTFieldAttribute];
+        
+        // create a temp attributed string from the appended part
+        appendString = [[NSAttributedString alloc] initWithString:string attributes:attributes];
+    }
+    else
+    {
+        // no attributes to extend
+        appendString = [[NSAttributedString alloc] initWithString:string];
+    }
+
+    [self appendAttributedString:appendString];
+}
+
+
 
 // appends a plain string extending the attributes at this position
 - (void)appendString:(NSString *)string


### PR DESCRIPTION
fix appendString defined duplicated in iOS18