### PR TITLE
Prefix rangeOfTextLists method to avoid accidental call by UIKit

### DIFF
--- a/Core/Source/DTHTMLWriter.m
+++ b/Core/Source/DTHTMLWriter.m
@@ -411,7 +411,7 @@
 				
 				for (DTCSSListStyle *oneList in currentListStyles)
 				{
-					NSRange listRange = [_attributedString rangeOfTextList:oneList atIndex:paragraphRange.location];
+					NSRange listRange = [_attributedString _DTRangeOfTextList:oneList atIndex:paragraphRange.location];
 					
 					if (listRange.location == paragraphRange.location)
 					{

--- a/Core/Source/NSAttributedString+DTCoreText.h
+++ b/Core/Source/NSAttributedString+DTCoreText.h
@@ -49,11 +49,14 @@
 /**
  Returns the range of the given text list that contains the given location.
  
+ Prefix is used to avoid a presumed naming collision that causes this method
+ to be called unexpectedly by internal UIKit logic.
+
  @param list The text list.
  @param location The location in the text.
  @returns The range of the given text list containing the location.
  */
-- (NSRange)rangeOfTextList:(DTCSSListStyle *)list atIndex:(NSUInteger)location;
+- (NSRange)_DTRangeOfTextList:(DTCSSListStyle *)list atIndex:(NSUInteger)location;
 
 /**
  Returns the range of the given text block that contains the given location.

--- a/Core/Source/NSAttributedString+DTCoreText.m
+++ b/Core/Source/NSAttributedString+DTCoreText.m
@@ -84,7 +84,7 @@
 	DTCSSListStyle *outermostList = [textListsAtIndex objectAtIndex:0];
 	
 	// get the range of all lists
-	NSRange totalRange = [self rangeOfTextList:outermostList atIndex:location];
+	NSRange totalRange = [self _DTRangeOfTextList:outermostList atIndex:location];
 	
 	// get naked NSString
     NSString *string = [[self string] substringWithRange:totalRange];
@@ -212,7 +212,7 @@
 	}
 }
 
-- (NSRange)rangeOfTextList:(DTCSSListStyle *)list atIndex:(NSUInteger)location
+- (NSRange)_DTRangeOfTextList:(DTCSSListStyle *)list atIndex:(NSUInteger)location
 {
 	NSParameterAssert(list);
 	

--- a/Test/Source/DTHTMLAttributedStringBuilderTest.m
+++ b/Test/Source/DTHTMLAttributedStringBuilderTest.m
@@ -882,7 +882,7 @@
 	
 	DTCSSListStyle *outerList = [lists lastObject];
 	
-	NSRange list1Range = [attributedString rangeOfTextList:outerList atIndex:0];
+	NSRange list1Range = [attributedString _DTRangeOfTextList:outerList atIndex:0];
 	
 	XCTAssertTrue(!list1Range.location, @"lists should start at index 0");
 	XCTAssertTrue(list1Range.length, @"lists should range for entire string");
@@ -897,7 +897,7 @@
 		XCTAssertTrue([innerLists objectAtIndex:0] == outerList , @"list at index 0 in inner lists should be same as outer list");
 	}
 	
-	NSRange list2Range = [attributedString rangeOfTextList:[innerLists lastObject] atIndex:innerRange.location];
+	NSRange list2Range = [attributedString _DTRangeOfTextList:[innerLists lastObject] atIndex:innerRange.location];
 	NSRange innerParagraph = [[attributedString string] paragraphRangeForRange:innerRange];
 	
 	XCTAssertTrue(NSEqualRanges(innerParagraph, list2Range), @"Inner list range should be equal to inner paragraph");
@@ -919,7 +919,7 @@
 	
 	[firstParagraphLists enumerateObjectsUsingBlock:^(DTCSSListStyle *oneList, NSUInteger idx, BOOL *stop) {
 		
-		NSRange listRange = [attributedString rangeOfTextList:oneList atIndex:firstParagraphRange.location];
+		NSRange listRange = [attributedString _DTRangeOfTextList:oneList atIndex:firstParagraphRange.location];
 		
 		NSRange commonRange = NSIntersectionRange(listRange, firstParagraphRange);
 		
@@ -937,7 +937,7 @@
 	
 	[secondParagraphLists enumerateObjectsUsingBlock:^(DTCSSListStyle *oneList, NSUInteger idx, BOOL *stop) {
 		
-		NSRange listRange = [attributedString rangeOfTextList:oneList atIndex:secondParagraphRange.location];
+		NSRange listRange = [attributedString _DTRangeOfTextList:oneList atIndex:secondParagraphRange.location];
 		
 		NSRange commonRange = NSIntersectionRange(listRange, secondParagraphRange);
 		

--- a/Test/Source/NSAttributedStringDTCoreTextTest.m
+++ b/Test/Source/NSAttributedStringDTCoreTextTest.m
@@ -82,22 +82,22 @@
 	XCTAssertFalse(effectiveList == newListStyle, @"Copy should have produced a different instance");
 	
 	// test new list inside range
-	NSRange nonFoundRange = [attributedString rangeOfTextList:newListStyle atIndex:innerRange.location];
+	NSRange nonFoundRange = [attributedString _DTRangeOfTextList:newListStyle atIndex:innerRange.location];
 	NSRange expectedRange = NSMakeRange(NSNotFound, 0);
 	XCTAssertTrue(NSEqualRanges(nonFoundRange, expectedRange), @"Should not find other list inside");
 
 	// test new list outside range
-	nonFoundRange = [attributedString rangeOfTextList:newListStyle atIndex:1];
+	nonFoundRange = [attributedString _DTRangeOfTextList:newListStyle atIndex:1];
 	expectedRange = NSMakeRange(NSNotFound, 0);
 	XCTAssertTrue(NSEqualRanges(nonFoundRange, expectedRange), @"Should not find other list at index 1");
 
 	// test effective list inside range
-	NSRange foundRange = [attributedString rangeOfTextList:effectiveList atIndex:innerRange.location];
+	NSRange foundRange = [attributedString _DTRangeOfTextList:effectiveList atIndex:innerRange.location];
 	expectedRange = [[attributedString string] paragraphRangeForRange:innerRange];
 	XCTAssertTrue(NSEqualRanges(foundRange, expectedRange), @"Should find effective list around 'inner'");
 	
 	// test effective list outside range
-	nonFoundRange = [attributedString rangeOfTextList:effectiveList atIndex:1];
+	nonFoundRange = [attributedString _DTRangeOfTextList:effectiveList atIndex:1];
 	expectedRange = NSMakeRange(NSNotFound, 0);
 	XCTAssertTrue(NSEqualRanges(nonFoundRange, expectedRange), @"Should not find effective list at index 1");
 }


### PR DESCRIPTION
As described in #1289, this `NSAttributedString` category method is unexpectedly being called by internal TextKit logic, perhaps checking for method availability rather than platform. Since categories cannot be un-defined by consumers of `DTCoreText`, there is no workaround for this situation.

This PR adds a prefix to avoid this naming collision. Ideally, we could define the old name as deprecated/renamed to indicate to the consumer of the library that this change has been made, but that is not possible as any inclusion of a method with this name will cause the problem.