### PR TITLE
Add HTML table support with NSTextTable-compatible model, layout and round-trip

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,9 +3,11 @@ name: Swift
 on:
   push:
     branches:
+      - develop
       - v2
   pull_request:
     branches:
+      - develop
       - v2
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/DTCoreText.xcodeproj/project.pbxproj
+++ b/DTCoreText.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		A76C23D618353EFE00F54F02 /* Oliver.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A788CA2814863EF100E1AFD9 /* Oliver.jpg */; };
 		A76C23D718353F0A00F54F02 /* Oliver@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = A76C23B1183535A300F54F02 /* Oliver@2x.jpg */; };
 		A788CA3A14863EF100E1AFD9 /* Alignment.html in Resources */ = {isa = PBXBuildFile; fileRef = A788CA1B14863EF100E1AFD9 /* Alignment.html */; };
+		A77AB1E00000000000000811 /* TableBorders.html in Resources */ = {isa = PBXBuildFile; fileRef = A77AB1E00000000000000700 /* TableBorders.html */; };
+		A77AB1E00000000000000211 /* Tables.html in Resources */ = {isa = PBXBuildFile; fileRef = A77AB1E00000000000000100 /* Tables.html */; };
+		A77AB1E00000000000000411 /* TableAlignment.html in Resources */ = {isa = PBXBuildFile; fileRef = A77AB1E00000000000000300 /* TableAlignment.html */; };
+		A77AB1E00000000000000611 /* TableWidths.html in Resources */ = {isa = PBXBuildFile; fileRef = A77AB1E00000000000000500 /* TableWidths.html */; };
 		A788CA3B14863EF100E1AFD9 /* APOD.html in Resources */ = {isa = PBXBuildFile; fileRef = A788CA1C14863EF100E1AFD9 /* APOD.html */; };
 		A788CA3C14863EF100E1AFD9 /* ArabicTest.html in Resources */ = {isa = PBXBuildFile; fileRef = A788CA1D14863EF100E1AFD9 /* ArabicTest.html */; };
 		A788CA3E14863EF100E1AFD9 /* CurrentTest.html in Resources */ = {isa = PBXBuildFile; fileRef = A788CA1F14863EF100E1AFD9 /* CurrentTest.html */; };
@@ -100,6 +104,10 @@
 		A740369016E51C9800ECCDE0 /* About.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = About.html; sourceTree = "<group>"; };
 		A76C23B1183535A300F54F02 /* Oliver@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "Oliver@2x.jpg"; sourceTree = "<group>"; };
 		A788CA1B14863EF100E1AFD9 /* Alignment.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Alignment.html; sourceTree = "<group>"; };
+		A77AB1E00000000000000700 /* TableBorders.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = TableBorders.html; sourceTree = "<group>"; };
+		A77AB1E00000000000000100 /* Tables.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Tables.html; sourceTree = "<group>"; };
+		A77AB1E00000000000000300 /* TableAlignment.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = TableAlignment.html; sourceTree = "<group>"; };
+		A77AB1E00000000000000500 /* TableWidths.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = TableWidths.html; sourceTree = "<group>"; };
 		A788CA1C14863EF100E1AFD9 /* APOD.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = APOD.html; sourceTree = "<group>"; };
 		A788CA1D14863EF100E1AFD9 /* ArabicTest.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ArabicTest.html; sourceTree = "<group>"; };
 		A788CA1F14863EF100E1AFD9 /* CurrentTest.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = CurrentTest.html; sourceTree = "<group>"; };
@@ -225,6 +233,10 @@
 				A7CFACA72A59BEB000EFA9FA /* Launch.storyboard */,
 				A788CA2A14863EF100E1AFD9 /* Snippets.plist */,
 				A788CA1B14863EF100E1AFD9 /* Alignment.html */,
+				A77AB1E00000000000000700 /* TableBorders.html */,
+				A77AB1E00000000000000100 /* Tables.html */,
+				A77AB1E00000000000000300 /* TableAlignment.html */,
+				A77AB1E00000000000000500 /* TableWidths.html */,
 				A788CA1C14863EF100E1AFD9 /* APOD.html */,
 				A788CA1D14863EF100E1AFD9 /* ArabicTest.html */,
 				A788CA1F14863EF100E1AFD9 /* CurrentTest.html */,
@@ -355,6 +367,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A788CA3A14863EF100E1AFD9 /* Alignment.html in Resources */,
+				A77AB1E00000000000000811 /* TableBorders.html in Resources */,
+				A77AB1E00000000000000211 /* Tables.html in Resources */,
+				A77AB1E00000000000000411 /* TableAlignment.html in Resources */,
+				A77AB1E00000000000000611 /* TableWidths.html in Resources */,
 				A788CA3B14863EF100E1AFD9 /* APOD.html in Resources */,
 				A788CA3C14863EF100E1AFD9 /* ArabicTest.html in Resources */,
 				A788CA3E14863EF100E1AFD9 /* CurrentTest.html in Resources */,

--- a/Demo/Resources/Snippets.plist
+++ b/Demo/Resources/Snippets.plist
@@ -28,6 +28,38 @@
 	</dict>
 	<dict>
 		<key>Description</key>
+		<string>Demonstrates HTML tables: headers, spans, backgrounds, collapsed borders, nesting, captions and empty cells.</string>
+		<key>File</key>
+		<string>Tables.html</string>
+		<key>Title</key>
+		<string>Tables</string>
+	</dict>
+	<dict>
+		<key>Description</key>
+		<string>Demonstrates horizontal and vertical alignment in table cells, including justify and first-baseline alignment.</string>
+		<key>File</key>
+		<string>TableAlignment.html</string>
+		<key>Title</key>
+		<string>Tables — Alignment</string>
+	</dict>
+	<dict>
+		<key>Description</key>
+		<string>Demonstrates table sizing: shrink-to-fit, percentage and absolute widths, col elements and fixed table layout.</string>
+		<key>File</key>
+		<string>TableWidths.html</string>
+		<key>Title</key>
+		<string>Tables — Widths</string>
+	</dict>
+	<dict>
+		<key>Description</key>
+		<string>Demonstrates border styles (solid, dashed, dotted, double), width keywords, per-edge longhands and 1-4 value CSS lists.</string>
+		<key>File</key>
+		<string>TableBorders.html</string>
+		<key>Title</key>
+		<string>Tables — Borders</string>
+	</dict>
+	<dict>
+		<key>Description</key>
 		<string>Demonstrates setting of Line Height</string>
 		<key>File</key>
 		<string>LineHeight.html</string>

--- a/Demo/Resources/TableAlignment.html
+++ b/Demo/Resources/TableAlignment.html
@@ -1,0 +1,41 @@
+<h2>Alignment in Table Cells</h2>
+
+<p>Horizontal alignment via <code>text-align</code>:</p>
+
+<table border="1" width="100%" cellpadding="4">
+	<tr>
+		<td style="text-align: left">left</td>
+		<td style="text-align: center">center</td>
+		<td style="text-align: right">right</td>
+	</tr>
+	<tr>
+		<td colspan="3" style="text-align: justify">Justified text inside a table cell stretches every full line so that both edges are flush with the cell padding, exactly like justified paragraphs outside of tables. Only the last line stays ragged.</td>
+	</tr>
+</table>
+
+<p>Vertical alignment via <code>valign</code> and <code>vertical-align</code>:</p>
+
+<table border="1" cellpadding="4">
+	<tr>
+		<td>three<br>lines<br>tall</td>
+		<td valign="top">top</td>
+		<td>middle is the default</td>
+		<td valign="bottom">bottom</td>
+	</tr>
+</table>
+
+<p>Baseline alignment — adjacent cells align at the baseline of their first line, regardless of font size:</p>
+
+<table border="1" cellpadding="4">
+	<tr>
+		<td style="vertical-align: baseline; font-size: 32px">Large</td>
+		<td style="vertical-align: baseline">regular</td>
+		<td style="vertical-align: baseline; font-size: 9px">tiny</td>
+	</tr>
+</table>
+
+<p>Header cells are bold and centered by default:</p>
+
+<table border="1" cellpadding="4" width="100%">
+	<tr><th>centered header</th><td>regular cell</td></tr>
+</table>

--- a/Demo/Resources/TableBorders.html
+++ b/Demo/Resources/TableBorders.html
@@ -1,0 +1,56 @@
+<h2>Table Borders and CSS</h2>
+
+<p>Border styles via the <code>border</code> shorthand:</p>
+
+<table cellspacing="6" cellpadding="6">
+	<tr>
+		<td style="border: 2px solid #333333">solid</td>
+		<td style="border: 2px dashed #CC0000">dashed</td>
+		<td style="border: 2px dotted #0066CC">dotted</td>
+		<td style="border: 6px double #008800">double</td>
+	</tr>
+</table>
+
+<p>Width keywords <code>thin</code>, <code>medium</code> and <code>thick</code>:</p>
+
+<table cellspacing="6" cellpadding="6">
+	<tr>
+		<td style="border: thin solid #333333">thin</td>
+		<td style="border: medium solid #333333">medium</td>
+		<td style="border: thick solid #333333">thick</td>
+	</tr>
+</table>
+
+<p>Per-edge longhands — every edge different:</p>
+
+<table cellspacing="6" cellpadding="8">
+	<tr>
+		<td style="border-top: 4px solid #CC0000; border-right: 4px dashed #008800; border-bottom: 4px dotted #0066CC; border-left: 8px double #CC8800">four different edges</td>
+	</tr>
+</table>
+
+<p>1–4 value lists (<code>border-width</code>, <code>border-style</code>, <code>border-color</code>):</p>
+
+<table cellspacing="6" cellpadding="6">
+	<tr>
+		<td style="border-width: 1px 3px 5px 7px; border-style: solid; border-color: #CC0000 #008800">widths 1/3/5/7, colors red/green</td>
+	</tr>
+</table>
+
+<p>Removing one edge with <code>border-left: none</code>:</p>
+
+<table cellspacing="6" cellpadding="6">
+	<tr>
+		<td style="border: 2px solid #333333; border-left: none">open on the left</td>
+	</tr>
+</table>
+
+<p>Legacy <code>border</code> attribute and collapsed borders:</p>
+
+<table border="2" cellpadding="4">
+	<tr><td>separated</td><td>borders</td></tr>
+</table>
+
+<table border="1" style="border-collapse: collapse" cellpadding="4">
+	<tr><td>collapsed</td><td>borders</td></tr>
+</table>

--- a/Demo/Resources/TableWidths.html
+++ b/Demo/Resources/TableWidths.html
@@ -1,0 +1,40 @@
+<h2>Table and Column Widths</h2>
+
+<p>A table without any widths shrinks to fit its content:</p>
+
+<table border="1" cellpadding="4">
+	<tr><td>compact</td><td>table</td></tr>
+</table>
+
+<p>Percentage table width with percentage columns (25% / 50% / rest):</p>
+
+<table width="100%" border="1" cellpadding="3">
+	<tr>
+		<td width="25%" bgcolor="#FFE8E8">25%</td>
+		<td width="50%" bgcolor="#E8FFE8">50%</td>
+		<td bgcolor="#E8E8FF">rest</td>
+	</tr>
+</table>
+
+<p>An absolute cell width forces long content to wrap:</p>
+
+<table border="1" cellpadding="3">
+	<tr>
+		<td width="150" bgcolor="#FFF8E0">This long text wraps because the column is fixed at 150 points wide.</td>
+		<td valign="top">narrow</td>
+	</tr>
+</table>
+
+<p>Column widths from <code>&lt;col&gt;</code> elements (120 / 60):</p>
+
+<table border="1" cellpadding="3">
+	<colgroup><col width="120"><col width="60"></colgroup>
+	<tr><td>first</td><td>second</td></tr>
+	<tr><td>120 wide</td><td>60</td></tr>
+</table>
+
+<p>Fixed table layout splits the width evenly, ignoring content:</p>
+
+<table style="table-layout: fixed; width: 100%" border="1" cellpadding="3">
+	<tr><td>equal</td><td>columns</td><td>regardless of content length in them</td></tr>
+</table>

--- a/Demo/Resources/Tables.html
+++ b/Demo/Resources/Tables.html
@@ -1,0 +1,56 @@
+<h2>HTML Tables</h2>
+
+<p>A table with header cells, borders and cell padding:</p>
+
+<table border="1" cellpadding="4">
+	<thead>
+		<tr><th>Planet</th><th>Diameter</th><th>Moons</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Mercury</td><td>4.879 km</td><td>0</td></tr>
+		<tr><td>Venus</td><td>12.104 km</td><td>0</td></tr>
+		<tr><td>Earth</td><td>12.742 km</td><td>1</td></tr>
+		<tr><td>Mars</td><td>6.779 km</td><td>2</td></tr>
+	</tbody>
+</table>
+
+<p>Column and row spans:</p>
+
+<table border="1" cellpadding="4">
+	<tr><td colspan="2" bgcolor="#FFD8A8">Spans two columns</td><td rowspan="2" bgcolor="#A8D8FF">Spans<br>two<br>rows</td></tr>
+	<tr><td>A2</td><td>B2</td></tr>
+	<tr><td>A3</td><td>B3</td><td>C3</td></tr>
+</table>
+
+<p>Backgrounds on table, rows and cells, with cell spacing:</p>
+
+<table bgcolor="#EEEEEE" cellspacing="4" cellpadding="5">
+	<tr bgcolor="#D8E8FF"><td>row color</td><td>row color</td><td bgcolor="#FFE8D8">cell color</td></tr>
+	<tr><td bgcolor="#E8FFD8">cell color</td><td>table shows through</td><td>here too</td></tr>
+</table>
+
+<p>Collapsed borders:</p>
+
+<table border="1" style="border-collapse: collapse" cellpadding="4">
+	<tr><th>Quarter</th><th>Revenue</th></tr>
+	<tr><td>Q1</td><td>1.000</td></tr>
+	<tr><td>Q2</td><td>1.250</td></tr>
+</table>
+
+<p>A table nested inside a cell:</p>
+
+<table border="1" cellpadding="5" bgcolor="#F4F4F4">
+	<tr>
+		<td>Before
+			<table border="1" bgcolor="#FFF8E0" cellpadding="3"><tr><td>nested 1</td><td>nested 2</td></tr></table>
+		after</td>
+		<td bgcolor="#E8F8E8">Second column</td>
+	</tr>
+</table>
+
+<p>Caption and an empty cell:</p>
+
+<table border="1" cellpadding="4">
+	<caption>Table captions are centered paragraphs</caption>
+	<tr><td></td><td>next to an empty cell</td></tr>
+</table>

--- a/Sources/DTCoreText/AttributedString+DTCoreText.swift
+++ b/Sources/DTCoreText/AttributedString+DTCoreText.swift
@@ -51,9 +51,24 @@ public enum DTHorizontalRuleStyleKey: AttributedStringKey {
   public static let name = DTHorizontalRuleStyleAttribute
 }
 
-public enum DTTextBlocksKey: AttributedStringKey {
-  public typealias Value = NSArray
+/// The text blocks containing a run, outermost first — plain ``TextBlock`` for padded
+/// or backgrounded blocks, ``TextTableBlock`` for table cells.
+public enum DTTextBlocksKey: ObjectiveCConvertibleAttributedStringKey {
+  public typealias Value = [TextBlock]
+  public typealias ObjectiveCValue = NSArray
+
   public static let name = DTTextBlocksAttribute
+
+  public static func objectiveCValue(for value: [TextBlock]) throws -> NSArray {
+    return value as NSArray
+  }
+
+  public static func value(for object: NSArray) throws -> [TextBlock] {
+    guard let blocks = object as? [TextBlock] else {
+      throw CocoaError(.coderInvalidValue)
+    }
+    return blocks
+  }
 }
 
 public enum DTFieldKey: AttributedStringKey {

--- a/Sources/DTCoreText/BuilderState+Tables.swift
+++ b/Sources/DTCoreText/BuilderState+Tables.swift
@@ -1,0 +1,542 @@
+//
+//  BuilderState+Tables.swift
+//  DTCoreText
+//
+//  Created by Oliver Drobnik on 11.06.26.
+//  Copyright (c) 2026 Drobnik.com. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Per-`<table>` state while building, kept on a stack to support nested tables.
+internal final class TableBuildContext {
+
+  /// The shared table instance that all cell blocks of this table reference.
+  let table: TextTable
+
+  /// The `<table>` element this context belongs to.
+  let tableElement: HTMLElement
+
+  /// The current row index; -1 before the first `<tr>`.
+  var currentRowIndex = -1
+
+  /// The next free column in the current row, before rowspan occupancy is considered.
+  var nextColumnInRow = 0
+
+  /// The highest grid column count seen so far.
+  var maxColumns = 0
+
+  /// Grid occupancy from rowspans: column index → last row index covered.
+  var occupiedUntilRow = [Int: Int]()
+
+  /// All cell blocks of this table, in document order.
+  var cells = [TextTableBlock]()
+
+  /// Raw width attribute strings from `<col>` elements, by column index.
+  var columnWidths = [String]()
+
+  /// Cell padding from the `cellpadding` attribute, when present.
+  var cellPaddingAttribute: CGFloat?
+
+  /// Margin to apply to every cell edge (half of the cell spacing).
+  var cellMargin: CGFloat = 0.5
+
+  /// Border width each cell gets when the table has a `border` attribute.
+  var impliedCellBorderWidth: CGFloat = 0
+
+  init(table: TextTable, tableElement: HTMLElement) {
+    self.table = table
+    self.tableElement = tableElement
+  }
+}
+
+// MARK: - Table Tag Handling
+
+extension BuilderState {
+
+  private static let cssBorderStyleKeywords: Set<String> = [
+    "none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset",
+  ]
+
+  // MARK: Tag Handlers
+
+  /// Handles the start of a `<table>` element: creates the shared ``TextTable`` and
+  /// pushes a build context.
+  func handleTableStart(_ tag: HTMLElement) {
+    let table = TextTable()
+    let styles = tag.currentStyles ?? [:]
+
+    // the system importer always sets black border colors, even at zero width
+    table.setBorderColor(DTColor.black)
+
+    // background color: CSS background-color was already interpreted into the element;
+    // legacy bgcolor attribute is the fallback. It lives on the table block, not on
+    // text runs, so take it off the element before children inherit it.
+    if let backgroundColor = tag.backgroundColor {
+      table.backgroundColor = backgroundColor
+      tag.backgroundColor = nil
+    } else if let bgColorName = tag.attributeForKey("bgcolor"),
+      let color = DTColorCreateWithHTMLName(bgColorName)
+    {
+      table.backgroundColor = color
+    }
+
+    // border attribute: N pt border on the table itself plus a 1 pt border on each cell
+    var impliedCellBorderWidth: CGFloat = 0
+    if let borderString = tag.attributeForKey("border") {
+      let borderWidth = CGFloat(Double(borderString) ?? 1)
+      if borderWidth > 0 {
+        table.setWidth(borderWidth, type: .absoluteValueType, for: .border)
+        impliedCellBorderWidth = 1
+      }
+    }
+
+    // CSS borders, padding and margins on the table element
+    applyCSSBorders(from: styles, to: table, element: tag)
+
+    // border CSS was consumed into the block model; clear the background stroke
+    // properties so descendants do not inherit them and create spurious blocks
+    clearBackgroundStrokeProperties(of: tag)
+
+    if stylesContainKey(styles, prefix: "padding") {
+      table.padding = tag.padding
+    }
+
+    if stylesContainKey(styles, prefix: "margin") {
+      let margins = tag.margins
+      table.setWidth(margins.top, type: .absoluteValueType, for: .margin, edge: .minYEdge)
+      table.setWidth(margins.left, type: .absoluteValueType, for: .margin, edge: .minXEdge)
+      table.setWidth(margins.bottom, type: .absoluteValueType, for: .margin, edge: .maxYEdge)
+      table.setWidth(margins.right, type: .absoluteValueType, for: .margin, edge: .maxXEdge)
+    }
+
+    // width from CSS or the legacy attribute
+    applyWidthDimensions(to: table, element: tag, styles: styles)
+
+    if (styles["border-collapse"] as? String)?.lowercased() == "collapse" {
+      table.collapsesBorders = true
+    }
+    if (styles["empty-cells"] as? String)?.lowercased() == "hide" {
+      table.hidesEmptyCells = true
+    }
+    if (styles["table-layout"] as? String)?.lowercased() == "fixed" {
+      table.layoutAlgorithm = .fixedLayoutAlgorithm
+    }
+
+    let context = TableBuildContext(table: table, tableElement: tag)
+    context.impliedCellBorderWidth = impliedCellBorderWidth
+
+    if let cellPaddingString = tag.attributeForKey("cellpadding"),
+      let cellPadding = Double(cellPaddingString)
+    {
+      context.cellPaddingAttribute = CGFloat(cellPadding)
+    }
+
+    if table.collapsesBorders {
+      // collapsed tables have no spacing between cells
+      context.cellMargin = 0
+    } else if let cellSpacingString = tag.attributeForKey("cellspacing"),
+      let cellSpacing = Double(cellSpacingString)
+    {
+      // the spacing is split between the two adjacent cells
+      context.cellMargin = CGFloat(cellSpacing) / 2
+    }
+
+    tableStack.append(context)
+  }
+
+  /// Handles the end of a `<table>` element: finalizes the column count and applies
+  /// `<col>` widths.
+  func handleTableEnd() {
+    guard let context = tableStack.popLast() else { return }
+
+    context.table.numberOfColumns = context.maxColumns
+
+    // apply <col> widths to single-span cells that have no width of their own
+    guard !context.columnWidths.isEmpty else { return }
+
+    for cell in context.cells {
+      guard cell.columnSpan == 1,
+        cell.value(for: .width) == 0,
+        cell.startingColumn < context.columnWidths.count
+      else { continue }
+
+      let widthString = context.columnWidths[cell.startingColumn]
+      if !widthString.isEmpty {
+        applyDimension(.width, value: widthString, to: cell, element: context.tableElement)
+      }
+    }
+  }
+
+  /// Handles the start of a `<tr>` element.
+  func handleTableRowStart(_ tag: HTMLElement) {
+    guard let context = tableStack.last else { return }
+
+    context.currentRowIndex += 1
+    context.nextColumnInRow = 0
+  }
+
+  /// Handles a `<col>` element, recording its width for the corresponding column.
+  func handleTableColumnStart(_ tag: HTMLElement) {
+    guard let context = tableStack.last else { return }
+
+    let span = max(Int(tag.attributeForKey("span") ?? "") ?? 1, 1)
+    let width = tag.attributeForKey("width") ?? ""
+
+    for _ in 0..<span {
+      context.columnWidths.append(width)
+    }
+  }
+
+  /// Handles the start of a `<td>` or `<th>` element: determines the grid position,
+  /// creates the cell block with all box properties and attaches it to the element's
+  /// paragraph style so that all descendants inherit it.
+  func handleTableCellStart(_ tag: HTMLElement) {
+    guard let context = tableStack.last else { return }
+
+    // tolerate a missing <tr>
+    if context.currentRowIndex < 0 {
+      context.currentRowIndex = 0
+    }
+
+    // find the next free grid column, skipping positions covered by rowspans
+    var column = context.nextColumnInRow
+    while let occupied = context.occupiedUntilRow[column], occupied >= context.currentRowIndex {
+      column += 1
+    }
+
+    let columnSpan = max(Int(tag.attributeForKey("colspan") ?? "") ?? 1, 1)
+    let rowSpan = max(Int(tag.attributeForKey("rowspan") ?? "") ?? 1, 1)
+
+    let cell = TextTableBlock(
+      table: context.table,
+      startingRow: context.currentRowIndex,
+      rowSpan: rowSpan,
+      startingColumn: column,
+      columnSpan: columnSpan)
+
+    if rowSpan > 1 {
+      for coveredColumn in column..<(column + columnSpan) {
+        context.occupiedUntilRow[coveredColumn] = context.currentRowIndex + rowSpan - 1
+      }
+    }
+
+    context.nextColumnInRow = column + columnSpan
+    context.maxColumns = max(context.maxColumns, column + columnSpan)
+
+    configureCellBlock(cell, for: tag, context: context)
+
+    context.cells.append(cell)
+
+    // attach to the paragraph style; descendants inherit the array (outermost first)
+    var textBlocks = tag.paragraphStyle.textBlocks ?? []
+    textBlocks.append(cell)
+    tag.paragraphStyle.textBlocks = textBlocks
+  }
+
+  // MARK: Cell Configuration
+
+  private func configureCellBlock(
+    _ cell: TextTableBlock, for tag: HTMLElement, context: TableBuildContext
+  ) {
+    let styles = tag.currentStyles ?? [:]
+
+    // padding: own CSS > cellpadding attribute > 1 pt importer default
+    if stylesContainKey(styles, prefix: "padding") {
+      cell.padding = tag.padding
+    } else if let cellPadding = context.cellPaddingAttribute {
+      cell.setWidth(cellPadding, type: .absoluteValueType, for: .padding)
+    } else {
+      cell.setWidth(1, type: .absoluteValueType, for: .padding)
+    }
+
+    // margins express the cell spacing, split between neighbors
+    if context.cellMargin > 0 {
+      cell.setWidth(context.cellMargin, type: .absoluteValueType, for: .margin)
+    }
+
+    // borders: black by default, 1 pt when the table has a border attribute, CSS overrides
+    cell.setBorderColor(DTColor.black)
+
+    if context.impliedCellBorderWidth > 0 {
+      cell.setWidth(context.impliedCellBorderWidth, type: .absoluteValueType, for: .border)
+    }
+
+    applyCSSBorders(from: styles, to: cell, element: tag)
+    clearBackgroundStrokeProperties(of: tag)
+
+    // background: CSS (own or inherited from the row) is already on the element;
+    // legacy bgcolor attributes on the cell or an ancestor row are the fallback.
+    // It lives on the block, so take it off the element before children inherit it.
+    if let backgroundColor = tag.backgroundColor {
+      cell.backgroundColor = backgroundColor
+      tag.backgroundColor = nil
+    } else if let attributeColor = legacyBackgroundColor(for: tag, context: context) {
+      cell.backgroundColor = attributeColor
+    }
+
+    // vertical alignment: CSS > valign attribute (own or row) > middle importer default
+    cell.verticalAlignment = .middleAlignment
+
+    if let valign = legacyVerticalAlignment(for: tag, context: context) {
+      cell.verticalAlignment = valign
+    }
+
+    if let cssAlignment = (styles["vertical-align"] as? String)?.lowercased() {
+      switch cssAlignment {
+      case "top": cell.verticalAlignment = .topAlignment
+      case "middle": cell.verticalAlignment = .middleAlignment
+      case "bottom": cell.verticalAlignment = .bottomAlignment
+      case "baseline": cell.verticalAlignment = .baselineAlignment
+      default: break
+      }
+    }
+
+    // width, min-width, max-width
+    applyWidthDimensions(to: cell, element: tag, styles: styles)
+  }
+
+  /// The background color from legacy `bgcolor` attributes: the cell's own, or the
+  /// nearest ancestor row/row group within the same table.
+  private func legacyBackgroundColor(for tag: HTMLElement, context: TableBuildContext) -> DTColor?
+  {
+    var element: HTMLElement? = tag
+
+    while let currentElement = element, currentElement !== context.tableElement {
+      if let colorName = currentElement.attributeForKey("bgcolor"),
+        let color = DTColorCreateWithHTMLName(colorName)
+      {
+        return color
+      }
+      element = currentElement.parentElement()
+    }
+
+    return nil
+  }
+
+  /// The vertical alignment from legacy `valign` attributes: the cell's own, or the
+  /// nearest ancestor row within the same table.
+  private func legacyVerticalAlignment(for tag: HTMLElement, context: TableBuildContext)
+    -> TextBlock.VerticalAlignment?
+  {
+    var element: HTMLElement? = tag
+
+    while let currentElement = element, currentElement !== context.tableElement {
+      if let valign = currentElement.attributeForKey("valign")?.lowercased() {
+        switch valign {
+        case "top": return .topAlignment
+        case "middle", "center": return .middleAlignment
+        case "bottom": return .bottomAlignment
+        case "baseline": return .baselineAlignment
+        default: break
+        }
+      }
+      element = currentElement.parentElement()
+    }
+
+    return nil
+  }
+
+  // MARK: CSS Helpers
+
+  /// Border CSS on table elements is represented in the block model; remove the
+  /// background stroke interpretation so descendants don't inherit it.
+  private func clearBackgroundStrokeProperties(of tag: HTMLElement) {
+    tag.backgroundStrokeColor = nil
+    tag.backgroundStrokeWidth = 0
+    tag.backgroundCornerRadius = 0
+  }
+
+  private func stylesContainKey(_ styles: [String: Any], prefix: String) -> Bool {
+    return styles.keys.contains { $0.hasPrefix(prefix) }
+  }
+
+  /// Applies width/min-width/max-width from CSS styles or the legacy `width` attribute
+  /// as dimensions on the block. Percentages are preserved as percentage value types.
+  private func applyWidthDimensions(
+    to block: TextBlock, element: HTMLElement, styles: [String: Any]
+  ) {
+    if let widthString = styles["width"] as? String, widthString.lowercased() != "auto" {
+      applyDimension(.width, value: widthString, to: block, element: element)
+    } else if let widthAttribute = element.attributeForKey("width") {
+      applyDimension(.width, value: widthAttribute, to: block, element: element)
+    }
+
+    if let minWidthString = styles["min-width"] as? String {
+      applyDimension(.minimumWidth, value: minWidthString, to: block, element: element)
+    }
+    if let maxWidthString = styles["max-width"] as? String {
+      applyDimension(.maximumWidth, value: maxWidthString, to: block, element: element)
+    }
+  }
+
+  /// Sets a single dimension from a CSS measure or legacy attribute value, keeping
+  /// percentages as percentage value types.
+  func applyDimension(
+    _ dimension: TextBlock.Dimension, value: String, to block: TextBlock, element: HTMLElement
+  ) {
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+
+    if trimmed.hasSuffix("%") {
+      if let percentage = Double(trimmed.dropLast().trimmingCharacters(in: .whitespaces)) {
+        block.setValue(CGFloat(percentage), type: .percentageValueType, for: dimension)
+      }
+      return
+    }
+
+    let points = (trimmed as NSString).pixelSizeOfCSSMeasure(
+      relativeToCurrentTextSize: element.fontDescriptor.pointSize, textScale: element.textScale)
+
+    if points > 0 {
+      block.setValue(points, type: .absoluteValueType, for: dimension)
+    }
+  }
+
+  /// Maps a CSS border style keyword to the block model. `none`/`hidden` return nil
+  /// (the border is removed); the 3D styles render as solid.
+  private func borderStyle(forKeyword keyword: String) -> TextBlock.BorderStyle? {
+    switch keyword {
+    case "dashed": return .dashed
+    case "dotted": return .dotted
+    case "double": return .double
+    case "solid", "groove", "ridge", "inset", "outset": return .solid
+    default: return nil  // none, hidden
+    }
+  }
+
+  /// Resolves a CSS border width component, including the keyword widths.
+  private func borderWidth(fromComponent component: String, element: HTMLElement) -> CGFloat? {
+    switch component {
+    case "thin": return 1
+    case "medium": return 3
+    case "thick": return 5
+    default:
+      guard let firstCharacter = component.first, firstCharacter.isNumber || firstCharacter == "."
+      else { return nil }
+      return (component as NSString).pixelSizeOfCSSMeasure(
+        relativeToCurrentTextSize: element.fontDescriptor.pointSize,
+        textScale: element.textScale)
+    }
+  }
+
+  /// Expands a 1–4 value CSS list to exactly four values in top/right/bottom/left order.
+  private func expandFourValues(_ value: String) -> [String] {
+    let parts = value.lowercased().components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+
+    switch parts.count {
+    case 1: return [parts[0], parts[0], parts[0], parts[0]]
+    case 2: return [parts[0], parts[1], parts[0], parts[1]]
+    case 3: return [parts[0], parts[1], parts[2], parts[1]]
+    case 4...: return Array(parts[0..<4])
+    default: return []
+    }
+  }
+
+  /// Applies CSS border properties (shorthands, 1–4 value lists and per-edge longhands)
+  /// to the block's border layer, border colors and border styles.
+  private func applyCSSBorders(from styles: [String: Any], to block: TextBlock, element: HTMLElement) {
+    // CSS list order: top, right, bottom, left
+    let edges: [(CGRectEdge, String)] = [
+      (.minYEdge, "top"), (.maxXEdge, "right"), (.maxYEdge, "bottom"), (.minXEdge, "left"),
+    ]
+
+    func applyShorthand(_ value: String, to edgesToApply: [CGRectEdge]) {
+      var width: CGFloat?
+      var color: DTColor?
+      var style: TextBlock.BorderStyle?
+      var isHidden = false
+
+      for component in value.lowercased().components(separatedBy: .whitespaces)
+      where !component.isEmpty {
+        if Self.cssBorderStyleKeywords.contains(component) {
+          if let mappedStyle = borderStyle(forKeyword: component) {
+            style = mappedStyle
+          } else {
+            isHidden = true
+          }
+          continue
+        }
+
+        if let parsedWidth = borderWidth(fromComponent: component, element: element) {
+          width = parsedWidth
+        } else if let parsedColor = DTColorCreateWithHTMLName(component) {
+          color = parsedColor
+        }
+      }
+
+      // CSS draws a medium (3px) border when a style is given without a width
+      if width == nil && style != nil {
+        width = 3
+      }
+
+      for edge in edgesToApply {
+        if isHidden {
+          block.setWidth(0, type: .absoluteValueType, for: .border, edge: edge)
+          continue
+        }
+        if let width {
+          block.setWidth(width, type: .absoluteValueType, for: .border, edge: edge)
+        }
+        if let color {
+          block.setBorderColor(color, for: edge)
+        }
+        if let style {
+          block.setBorderStyle(style, for: edge)
+        }
+      }
+    }
+
+    if let allBorders = styles["border"] as? String {
+      applyShorthand(allBorders, to: edges.map { $0.0 })
+    }
+
+    // 1–4 value lists in top/right/bottom/left order
+    if let widthList = styles["border-width"] as? String {
+      for (index, component) in expandFourValues(widthList).enumerated() {
+        if let width = borderWidth(fromComponent: component, element: element) {
+          block.setWidth(width, type: .absoluteValueType, for: .border, edge: edges[index].0)
+        }
+      }
+    }
+    if let styleList = styles["border-style"] as? String {
+      for (index, component) in expandFourValues(styleList).enumerated() {
+        if let style = borderStyle(forKeyword: component) {
+          block.setBorderStyle(style, for: edges[index].0)
+          if block.width(for: .border, edge: edges[index].0) == 0 {
+            block.setWidth(3, type: .absoluteValueType, for: .border, edge: edges[index].0)
+          }
+        } else if component == "none" || component == "hidden" {
+          block.setWidth(0, type: .absoluteValueType, for: .border, edge: edges[index].0)
+        }
+      }
+    }
+    if let colorList = styles["border-color"] as? String {
+      for (index, component) in expandFourValues(colorList).enumerated() {
+        if let color = DTColorCreateWithHTMLName(component) {
+          block.setBorderColor(color, for: edges[index].0)
+        }
+      }
+    }
+
+    for (edge, edgeName) in edges {
+      if let edgeShorthand = styles["border-\(edgeName)"] as? String {
+        applyShorthand(edgeShorthand, to: [edge])
+      }
+      if let edgeWidth = styles["border-\(edgeName)-width"] as? String,
+        let width = borderWidth(fromComponent: edgeWidth.lowercased(), element: element)
+      {
+        block.setWidth(width, type: .absoluteValueType, for: .border, edge: edge)
+      }
+      if let edgeStyle = styles["border-\(edgeName)-style"] as? String {
+        applyShorthand(edgeStyle, to: [edge])
+      }
+      if let edgeColor = styles["border-\(edgeName)-color"] as? String,
+        let color = DTColorCreateWithHTMLName(edgeColor.lowercased())
+      {
+        block.setBorderColor(color, for: edge)
+      }
+    }
+  }
+}

--- a/Sources/DTCoreText/BuilderState.swift
+++ b/Sources/DTCoreText/BuilderState.swift
@@ -28,6 +28,9 @@ internal actor BuilderState {
   // Output
   var tmpString = NSMutableAttributedString()
 
+  // Stack of open tables (innermost last), for building text table blocks
+  var tableStack: [TableBuildContext] = []
+
   // Config (set once before parsing)
   var textScale: CGFloat = 1.0
   var defaultLinkColor: PlatformColor?
@@ -56,6 +59,7 @@ internal actor BuilderState {
     currentTag = nil
     ignoreParseEvents = false
     tmpString = NSMutableAttributedString()
+    tableStack = []
 
     self.options = options
     self.shouldKeepDocumentNodeTree = shouldKeepDocumentNodeTree
@@ -307,6 +311,18 @@ internal actor BuilderState {
         tag.paragraphStyle.firstLineHeadIndent = tag.paragraphStyle.headIndent + tag.pTextIndent
       }
 
+    case "table":
+      handleTableStart(tag)
+
+    case "tr":
+      handleTableRowStart(tag)
+
+    case "td", "th":
+      handleTableCellStart(tag)
+
+    case "col":
+      handleTableColumnStart(tag)
+
     default:
       break
     }
@@ -449,6 +465,9 @@ internal actor BuilderState {
       if let content = try? String(contentsOf: stylesheetURL, encoding: .utf8) {
         globalStyleSheet.mergeStylesheet(CSSStylesheet(styleBlock: content))
       }
+
+    case "table":
+      handleTableEnd()
 
     default:
       break

--- a/Sources/DTCoreText/CoreTextLayoutFrame.swift
+++ b/Sources/DTCoreText/CoreTextLayoutFrame.swift
@@ -390,7 +390,9 @@ open class CoreTextLayoutFrame: NSObject {
           startingAt: lineRange.location,
           availableWidth: _frame.size.width,
           originX: _frame.origin.x,
-          topY: tableTop)
+          topY: tableTop,
+          maximumY: maxY,
+          mustConsumeFirstRow: typesetLines.isEmpty)
 
         if result.range.length > 0 {
           typesetLines.append(contentsOf: result.lines)
@@ -400,8 +402,20 @@ open class CoreTextLayoutFrame: NSObject {
           fittingLength += result.range.length
           lineRange.location = NSMaxRange(result.range)
           previousLine = result.lines.last ?? previousLine
+
+          if result.isPartial {
+            // the remaining rows belong to a continuation frame
+            break
+          }
           continue
         }
+
+        if result.scannedLength > 0 {
+          // a table starts here but not even its first row fits into the
+          // remaining space — it goes entirely to a continuation frame
+          break
+        }
+        // no cells found: treat the content as normal text below
       }
 
       var headIndent: CGFloat = 0
@@ -1418,7 +1432,14 @@ extension CoreTextLayoutFrame {
     var tableFrames = [(table: TextTable, rect: CGRect, level: Int)]()
     var suppressedBorderEdges = [ObjectIdentifier: UInt]()
     var bottomY: CGFloat = 0
+    /// The string range consumed by this frame — trimmed when only part of the
+    /// table fits (`isPartial`), zero-length when no row fits at all.
     var range = NSRange(location: 0, length: 0)
+    /// The full extent of the table found at the start location, regardless of fit.
+    var scannedLength = 0
+    /// True when rows were cut off because they exceed the frame's maximum Y;
+    /// the remaining rows belong to a continuation frame.
+    var isPartial = false
   }
 
   private func _textBlocks(at location: Int) -> [TextBlock]? {
@@ -1760,7 +1781,8 @@ extension CoreTextLayoutFrame {
   /// are border-box rects for background/border drawing.
   private func _layoutTable(
     _ table: TextTable, level: Int, startingAt location: Int, availableWidth: CGFloat,
-    originX: CGFloat, topY: CGFloat
+    originX: CGFloat, topY: CGFloat, maximumY: CGFloat = .greatestFiniteMagnitude,
+    mustConsumeFirstRow: Bool = true
   ) -> _TableLayoutResult {
     var result = _TableLayoutResult()
 
@@ -1793,6 +1815,7 @@ extension CoreTextLayoutFrame {
     guard !cells.isEmpty else { return result }
 
     result.range = NSRange(location: location, length: scanLocation - location)
+    result.scannedLength = scanLocation - location
 
     // 2. the table's own box
     let marginLeft = table.width(for: .margin, edge: .minXEdge)
@@ -1940,7 +1963,40 @@ extension CoreTextLayoutFrame {
       rowTops[row + 1] = rowTops[row] + rowHeights[row]
     }
 
-    for var layout in cellLayouts {
+    // pagination: only the leading rows that fit within maximumY are consumed by
+    // this frame; the rest goes to a continuation frame starting at the first
+    // excluded cell. When the frame is otherwise empty, the first row is consumed
+    // regardless, so that pagination always makes progress.
+    var includedRowCount = rowCount
+
+    if rowTops[rowCount] > maximumY {
+      includedRowCount = 0
+      while includedRowCount < rowCount, rowTops[includedRowCount + 1] <= maximumY {
+        includedRowCount += 1
+      }
+
+      if includedRowCount == 0 && mustConsumeFirstRow {
+        includedRowCount = 1
+      }
+    }
+
+    result.isPartial = includedRowCount < rowCount
+
+    if includedRowCount == 0 {
+      result.range = NSRange(location: location, length: 0)
+      return result
+    }
+
+    if result.isPartial {
+      let cutLocation =
+        cells
+        .filter { $0.block.startingRow >= includedRowCount }
+        .map { $0.range.location }
+        .min() ?? NSMaxRange(result.range)
+      result.range = NSRange(location: location, length: cutLocation - location)
+    }
+
+    for var layout in cellLayouts where layout.block.startingRow < includedRowCount {
       let cellBlock = layout.block
       let cellMarginTop = cellBlock.width(for: .margin, edge: .minYEdge)
       let cellMarginBottom = cellBlock.width(for: .margin, edge: .maxYEdge)
@@ -2088,15 +2144,17 @@ extension CoreTextLayoutFrame {
         cellEdge: .maxXEdge)
     }
 
-    // 7. the table's own border box, drawn beneath its cells
+    // 7. the table's own border box, drawn beneath its cells; a partial table has
+    // no bottom edge on this frame — it continues on the next one
+    let gridBottom = rowTops[includedRowCount]
     let tableRect = CGRect(
       x: originX + marginLeft,
       y: topY + marginTop,
       width: edgeLeft + gridWidth + edgeRight,
-      height: edgeTop + (rowTops[rowCount] - rowTops[0]) + edgeBottom)
+      height: edgeTop + (gridBottom - rowTops[0]) + (result.isPartial ? 0 : edgeBottom))
 
     result.tableFrames.insert((table, tableRect, level), at: 0)
-    result.bottomY = tableRect.maxY + marginBottom
+    result.bottomY = result.isPartial ? tableRect.maxY : tableRect.maxY + marginBottom
 
     return result
   }

--- a/Sources/DTCoreText/CoreTextLayoutFrame.swift
+++ b/Sources/DTCoreText/CoreTextLayoutFrame.swift
@@ -48,6 +48,15 @@ open class CoreTextLayoutFrame: NSObject {
   private var _additionalPaddingAtBottom: CGFloat = 0
   private var _numberLinesFitInFrame: Int = 0
 
+  // table layout results: border-box rects of cells/tables in text coordinates
+  private var _tableBlockFrames = [ObjectIdentifier: CGRect]()
+  private var _tablesInDrawOrder = [(table: TextTable, rect: CGRect, level: Int)]()
+  private var _maxTableBottom: CGFloat = 0
+
+  // border edges not to draw (bitmask by edge raw value), from collapsed-border
+  // resolution: only the winning border of each boundary is drawn
+  private var _suppressedBorderEdges = [ObjectIdentifier: UInt]()
+
   /// Custom handler to be executed before text belonging to a text block is drawn.
   @objc open var textBlockHandler: CoreTextLayoutFrameTextBlockHandler?
 
@@ -282,21 +291,22 @@ open class CoreTextLayoutFrame: NSObject {
       }
     }
 
+    // blocks are grouped by instance identity: equal-but-distinct blocks
+    // (e.g. adjacent table cells with the same styling) are separate blocks
+    let lineBlocks = line.textBlocks as? [TextBlock] ?? []
+    let previousLineBlocks = previousLine?.textBlocks as? [TextBlock] ?? []
+
     // add padding for closed text blocks
-    if let prevBlocks = previousLine?.textBlocks as? [TextBlock] {
-      for prevBlock in prevBlocks {
-        if !(line.textBlocks?.contains(prevBlock) ?? false) {
-          baselineOrigin.y += prevBlock.padding.bottom
-        }
+    for prevBlock in previousLineBlocks {
+      if !lineBlocks.contains(where: { $0 === prevBlock }) {
+        baselineOrigin.y += prevBlock.padding.bottom
       }
     }
 
     // add padding for newly opened text blocks
-    if let currBlocks = line.textBlocks as? [TextBlock] {
-      for currBlock in currBlocks {
-        if !(previousLine?.textBlocks?.contains(currBlock) ?? false) {
-          baselineOrigin.y += currBlock.padding.top
-        }
+    for currBlock in lineBlocks {
+      if !previousLineBlocks.contains(where: { $0 === currBlock }) {
+        baselineOrigin.y += currBlock.padding.top
       }
     }
 
@@ -335,8 +345,14 @@ open class CoreTextLayoutFrame: NSObject {
     guard let framesetter = _framesetter, let fragment = _attributedStringFragment else { return }
     let typesetter = CTFramesetterGetTypesetter(framesetter)
 
+    _tableBlockFrames.removeAll()
+    _tablesInDrawOrder.removeAll()
+    _maxTableBottom = 0
+    _suppressedBorderEdges.removeAll()
+
     var typesetLines = [CoreTextLayoutLine]()
     var previousLine: CoreTextLayoutLine? = nil
+    var minimumBaselineYAfterTable: CGFloat? = nil
 
     var paragraphRanges = (self.paragraphRanges ?? []).map { $0 }
     guard !paragraphRanges.isEmpty else { return }
@@ -357,6 +373,36 @@ open class CoreTextLayoutFrame: NSObject {
       }
 
       let isAtBeginOfParagraph = (currentParagraphRange.location == lineRange.location)
+
+      // a table starting at this paragraph is laid out as a grid in one go
+      if isAtBeginOfParagraph, let tableStart = _tableStart(at: lineRange.location) {
+        let tableTop: CGFloat
+        if let previousLine {
+          tableTop =
+            previousLine.frame.maxY + (previousLine.paragraphStyle?.paragraphSpacing ?? 0)
+        } else {
+          tableTop = _frame.origin.y
+        }
+
+        let result = _layoutTable(
+          tableStart.block.table,
+          level: tableStart.level,
+          startingAt: lineRange.location,
+          availableWidth: _frame.size.width,
+          originX: _frame.origin.x,
+          topY: tableTop)
+
+        if result.range.length > 0 {
+          typesetLines.append(contentsOf: result.lines)
+          _registerTableLayoutResult(result)
+          minimumBaselineYAfterTable = result.bottomY
+
+          fittingLength += result.range.length
+          lineRange.location = NSMaxRange(result.range)
+          previousLine = result.lines.last ?? previousLine
+          continue
+        }
+      }
 
       var headIndent: CGFloat = 0
       var tailIndent: CGFloat = 0
@@ -566,6 +612,13 @@ open class CoreTextLayoutFrame: NSObject {
 
       var newLineBaselineOrigin = _algorithmWebKit_BaselineOrigin(
         toPositionLine: newLine, afterLine: previousLine)
+
+      // following a table, flow continues below the table's lowest cell
+      if let minimumY = minimumBaselineYAfterTable {
+        newLineBaselineOrigin.y = max(newLineBaselineOrigin.y, ceil(minimumY + newLine.ascent))
+        minimumBaselineYAfterTable = nil
+      }
+
       newLineBaselineOrigin.x = lineOriginX
       newLine.baselineOrigin = newLineBaselineOrigin
 
@@ -807,7 +860,8 @@ open class CoreTextLayoutFrame: NSObject {
             in: range
           ) as? [TextBlock]
 
-        if laterBlocks?.contains(blockAtLevelToHandle) != true {
+        // compare by identity: a different-but-equal block ends this block's range
+        if laterBlocks?.contains(where: { $0 === blockAtLevelToHandle }) != true {
           break
         }
 
@@ -816,7 +870,11 @@ open class CoreTextLayoutFrame: NSObject {
       }
 
       index = searchIndex
-      let blockFrame = _blockFrame(forEffectiveRange: currentBlockEffectiveRange, level: level)
+
+      // table cells have grid-computed frames; other blocks derive theirs from lines
+      let blockFrame =
+        _tableBlockFrames[ObjectIdentifier(blockAtLevelToHandle)]
+        ?? _blockFrame(forEffectiveRange: currentBlockEffectiveRange, level: level)
 
       var shouldStop = false
       block(blockAtLevelToHandle, blockFrame, currentBlockEffectiveRange, &shouldStop)
@@ -838,13 +896,34 @@ open class CoreTextLayoutFrame: NSObject {
   }
 
   /// Draws the background / borders of visible text blocks into the context.
+  ///
+  /// Levels are drawn outermost-first; the background of a table is drawn right before
+  /// the blocks of its own level so that nested tables paint above outer cells.
   private func _drawTextBlocks(in context: CGContext, range: NSRange) {
     let clipRect = context.boundingBoxOfClipPath
+    if _lines == nil { _buildLines() }
 
-    _enumerateTextBlocks(inRange: range) { textBlock, frame, _, _ in
-      let visiblePart = frame.intersection(clipRect)
-      if visiblePart.isNull { return }
-      _drawTextBlock(textBlock, in: context, frame: frame)
+    var level = 0
+
+    while true {
+      let tablesAtLevel = _tablesInDrawOrder.filter { $0.level == level }
+
+      for entry in tablesAtLevel where !entry.rect.intersection(clipRect).isNull {
+        _drawTextBlock(entry.table, in: context, frame: entry.rect)
+      }
+
+      let foundBlocks = _enumerateTextBlocks(atLevel: level, inRange: range) {
+        textBlock, frame, _, _ in
+        let visiblePart = frame.intersection(clipRect)
+        if visiblePart.isNull { return }
+        _drawTextBlock(textBlock, in: context, frame: frame)
+      }
+
+      if !foundBlocks && tablesAtLevel.isEmpty {
+        break
+      }
+
+      level += 1
     }
   }
 
@@ -860,6 +939,90 @@ open class CoreTextLayoutFrame: NSObject {
       if let bgColor = textBlock.backgroundColor {
         context.setFillColor(bgColor.cgColor)
         context.fill(blockFrame)
+      }
+
+      // borders: filled strips inside each edge of the border box
+      let edgeStrips: [(CGRectEdge, CGRect)] = [
+        (
+          .minYEdge,
+          CGRect(
+            x: blockFrame.minX, y: blockFrame.minY, width: blockFrame.width,
+            height: textBlock.width(for: .border, edge: .minYEdge))
+        ),
+        (
+          .maxYEdge,
+          CGRect(
+            x: blockFrame.minX,
+            y: blockFrame.maxY - textBlock.width(for: .border, edge: .maxYEdge),
+            width: blockFrame.width, height: textBlock.width(for: .border, edge: .maxYEdge))
+        ),
+        (
+          .minXEdge,
+          CGRect(
+            x: blockFrame.minX, y: blockFrame.minY,
+            width: textBlock.width(for: .border, edge: .minXEdge), height: blockFrame.height)
+        ),
+        (
+          .maxXEdge,
+          CGRect(
+            x: blockFrame.maxX - textBlock.width(for: .border, edge: .maxXEdge),
+            y: blockFrame.minY, width: textBlock.width(for: .border, edge: .maxXEdge),
+            height: blockFrame.height)
+        ),
+      ]
+
+      let suppressedEdgesMask = _suppressedBorderEdges[ObjectIdentifier(textBlock)] ?? 0
+
+      for (edge, strip) in edgeStrips where !strip.isEmpty {
+        if suppressedEdgesMask & (1 << UInt(edge.rawValue)) != 0 { continue }
+
+        let borderColor = textBlock.borderColor(for: edge) ?? DTColor.black
+        let borderStyle = textBlock.borderStyle(for: edge)
+        let isHorizontal = (edge == .minYEdge || edge == .maxYEdge)
+        let borderWidth = isHorizontal ? strip.height : strip.width
+
+        switch borderStyle {
+        case .solid:
+          context.setFillColor(borderColor.cgColor)
+          context.fill(strip)
+
+        case .double:
+          // two lines of one third each with a gap between them
+          context.setFillColor(borderColor.cgColor)
+          let third = borderWidth / 3
+          if isHorizontal {
+            context.fill(CGRect(x: strip.minX, y: strip.minY, width: strip.width, height: third))
+            context.fill(
+              CGRect(x: strip.minX, y: strip.maxY - third, width: strip.width, height: third))
+          } else {
+            context.fill(CGRect(x: strip.minX, y: strip.minY, width: third, height: strip.height))
+            context.fill(
+              CGRect(x: strip.maxX - third, y: strip.minY, width: third, height: strip.height))
+          }
+
+        case .dashed, .dotted:
+          context.saveGState()
+          context.setStrokeColor(borderColor.cgColor)
+          context.setLineWidth(borderWidth)
+          context.setLineCap(.butt)
+
+          let dashLengths: [CGFloat] =
+            borderStyle == .dotted
+            ? [borderWidth, borderWidth]
+            : [borderWidth * 3, borderWidth * 3]
+          context.setLineDash(phase: 0, lengths: dashLengths)
+
+          if isHorizontal {
+            context.move(to: CGPoint(x: strip.minX, y: strip.midY))
+            context.addLine(to: CGPoint(x: strip.maxX, y: strip.midY))
+          } else {
+            context.move(to: CGPoint(x: strip.midX, y: strip.minY))
+            context.addLine(to: CGPoint(x: strip.midX, y: strip.maxY))
+          }
+
+          context.strokePath()
+          context.restoreGState()
+        }
       }
     }
 
@@ -1242,13 +1405,838 @@ open class CoreTextLayoutFrame: NSObject {
 // Extension to compute the frame property correctly
 extension CoreTextLayoutFrame {
 
+  // MARK: - Table Layout
+
+  private struct _TableStart {
+    let block: TextTableBlock
+    let level: Int
+  }
+
+  private struct _TableLayoutResult {
+    var lines = [CoreTextLayoutLine]()
+    var cellFrames = [(block: TextBlock, rect: CGRect, level: Int)]()
+    var tableFrames = [(table: TextTable, rect: CGRect, level: Int)]()
+    var suppressedBorderEdges = [ObjectIdentifier: UInt]()
+    var bottomY: CGFloat = 0
+    var range = NSRange(location: 0, length: 0)
+  }
+
+  private func _textBlocks(at location: Int) -> [TextBlock]? {
+    guard let fragment = _attributedStringFragment, location < fragment.length else { return nil }
+    return fragment.attribute(
+      NSAttributedString.Key(rawValue: DTTextBlocksAttribute), at: location, effectiveRange: nil)
+      as? [TextBlock]
+  }
+
+  /// The outermost table block at the given location, if any.
+  private func _tableStart(at location: Int) -> _TableStart? {
+    return _tableStart(at: location, atOrDeeperThan: 0)
+  }
+
+  /// The first table block at or after the given nesting level, for tables nested
+  /// inside cells (or inside other blocks).
+  private func _tableStart(at location: Int, atOrDeeperThan level: Int) -> _TableStart? {
+    guard let blocks = _textBlocks(at: location), blocks.count > level else { return nil }
+
+    for index in level..<blocks.count {
+      if let tableBlock = blocks[index] as? TextTableBlock {
+        return _TableStart(block: tableBlock, level: index)
+      }
+    }
+
+    return nil
+  }
+
+  private func _registerTableLayoutResult(_ result: _TableLayoutResult) {
+    for entry in result.cellFrames {
+      _tableBlockFrames[ObjectIdentifier(entry.block)] = entry.rect
+    }
+
+    _tablesInDrawOrder.append(contentsOf: result.tableFrames)
+    _suppressedBorderEdges.merge(result.suppressedBorderEdges) { $0 | $1 }
+    _maxTableBottom = max(_maxTableBottom, result.bottomY)
+  }
+
+  private func _horizontalBoxExtras(of block: TextBlock) -> CGFloat {
+    return block.width(for: .padding, edge: .minXEdge) + block.width(for: .padding, edge: .maxXEdge)
+      + block.width(for: .border, edge: .minXEdge) + block.width(for: .border, edge: .maxXEdge)
+      + block.width(for: .margin, edge: .minXEdge) + block.width(for: .margin, edge: .maxXEdge)
+  }
+
+  /// The widest single-line width of the paragraphs in the given range, used as the
+  /// natural (content-determined) width during automatic column sizing. A nested table
+  /// counts as one unbreakable unit as wide as the sum of its natural column widths.
+  private func _naturalContentWidth(ofParagraphsIn range: NSRange, level: Int) -> CGFloat {
+    guard let framesetter = _framesetter, let fragment = _attributedStringFragment else {
+      return 0
+    }
+
+    let typesetter = CTFramesetterGetTypesetter(framesetter)
+    let nsString = fragment.string as NSString
+
+    var maxWidth: CGFloat = 0
+    var location = range.location
+
+    while location < NSMaxRange(range) {
+      if let nested = _tableStart(at: location, atOrDeeperThan: level) {
+        let (nestedWidth, nestedRange) = _naturalTableWidth(
+          nested.block.table, level: nested.level, startingAt: location)
+
+        if nestedRange.length > 0 {
+          maxWidth = max(maxWidth, nestedWidth)
+          location = NSMaxRange(nestedRange)
+          continue
+        }
+      }
+
+      let paragraphRange = nsString.paragraphRange(for: NSRange(location: location, length: 0))
+      let usableLength =
+        min(NSMaxRange(paragraphRange), NSMaxRange(range)) - paragraphRange.location
+
+      if usableLength > 0 {
+        let line = CTTypesetterCreateLine(
+          typesetter, CFRangeMake(paragraphRange.location, usableLength))
+        let width = CGFloat(
+          CTLineGetTypographicBounds(line, nil, nil, nil)
+            - CTLineGetTrailingWhitespaceWidth(line))
+        maxWidth = max(maxWidth, width)
+      }
+
+      location = NSMaxRange(paragraphRange)
+    }
+
+    return maxWidth
+  }
+
+  /// The natural width of a whole table: the sum of its columns' natural widths plus
+  /// the table's own box extras. Used when a table is nested inside a cell.
+  private func _naturalTableWidth(_ table: TextTable, level: Int, startingAt location: Int)
+    -> (width: CGFloat, range: NSRange)
+  {
+    guard let fragment = _attributedStringFragment else {
+      return (0, NSRange(location: location, length: 0))
+    }
+
+    let nsString = fragment.string as NSString
+    var cells = [(block: TextTableBlock, range: NSRange)]()
+    var scanLocation = location
+
+    while scanLocation < fragment.length {
+      let paragraphRange = nsString.paragraphRange(for: NSRange(location: scanLocation, length: 0))
+
+      guard let blocks = _textBlocks(at: paragraphRange.location),
+        blocks.count > level,
+        let cellBlock = blocks[level] as? TextTableBlock,
+        cellBlock.table === table
+      else { break }
+
+      if let lastIndex = cells.indices.last, cells[lastIndex].block === cellBlock {
+        cells[lastIndex].range = NSUnionRange(cells[lastIndex].range, paragraphRange)
+      } else {
+        cells.append((cellBlock, paragraphRange))
+      }
+
+      scanLocation = NSMaxRange(paragraphRange)
+    }
+
+    let scannedRange = NSRange(location: location, length: scanLocation - location)
+    guard !cells.isEmpty else { return (0, scannedRange) }
+
+    let columnCount = max(
+      table.numberOfColumns, cells.map { $0.block.startingColumn + $0.block.columnSpan }.max() ?? 0)
+    guard columnCount > 0 else { return (0, scannedRange) }
+
+    var columnWidths = [CGFloat](repeating: 0, count: columnCount)
+
+    for (cellBlock, cellRange) in cells
+    where cellBlock.columnSpan == 1 && cellBlock.startingColumn < columnCount {
+      let extras = _horizontalBoxExtras(of: cellBlock)
+      var natural: CGFloat
+
+      let widthValue = cellBlock.value(for: .width)
+      if widthValue > 0, cellBlock.valueType(for: .width) == .absoluteValueType {
+        natural = widthValue + extras
+      } else {
+        natural = _naturalContentWidth(ofParagraphsIn: cellRange, level: level + 1) + extras
+      }
+
+      columnWidths[cellBlock.startingColumn] = max(
+        columnWidths[cellBlock.startingColumn], natural)
+    }
+
+    let tableExtras =
+      table.width(for: .margin, edge: .minXEdge) + table.width(for: .margin, edge: .maxXEdge)
+      + table.width(for: .border, edge: .minXEdge) + table.width(for: .border, edge: .maxXEdge)
+      + table.width(for: .padding, edge: .minXEdge) + table.width(for: .padding, edge: .maxXEdge)
+
+    return (columnWidths.reduce(0, +) + tableExtras, scannedRange)
+  }
+
+  /// Resolves the grid column widths for a table: explicit widths (absolute or
+  /// percentage) win, otherwise content-measured natural widths, scaled to fit the
+  /// table's explicit width or the available width. This is a simplified version of
+  /// the automatic/fixed algorithms documented for the system classes.
+  private func _resolveColumnWidths(
+    for table: TextTable, cells: [(block: TextTableBlock, range: NSRange)], columnCount: Int,
+    innerAvailableWidth: CGFloat, level: Int
+  ) -> [CGFloat] {
+    var explicitTableWidth: CGFloat = 0
+    let tableWidthValue = table.value(for: .width)
+
+    if tableWidthValue > 0 {
+      switch table.valueType(for: .width) {
+      case .percentageValueType:
+        explicitTableWidth = innerAvailableWidth * tableWidthValue / 100
+      case .absoluteValueType:
+        explicitTableWidth = min(tableWidthValue, innerAvailableWidth)
+      }
+    }
+
+    let baseWidth = explicitTableWidth > 0 ? explicitTableWidth : innerAvailableWidth
+    let usesFixedLayout = (table.layoutAlgorithm == .fixedLayoutAlgorithm)
+
+    var specifiedWidths = [CGFloat](repeating: 0, count: columnCount)
+    var naturalWidths = [CGFloat](repeating: 0, count: columnCount)
+
+    for (cellBlock, cellRange) in cells {
+      guard cellBlock.columnSpan == 1, cellBlock.startingColumn < columnCount else { continue }
+      if usesFixedLayout && cellBlock.startingRow > 0 { continue }
+
+      let column = cellBlock.startingColumn
+      let extras = _horizontalBoxExtras(of: cellBlock)
+
+      var specified: CGFloat = 0
+      let widthValue = cellBlock.value(for: .width)
+
+      if widthValue > 0 {
+        switch cellBlock.valueType(for: .width) {
+        case .percentageValueType:
+          specified = baseWidth * widthValue / 100
+        case .absoluteValueType:
+          specified = widthValue + extras
+        }
+      }
+
+      let minimumWidth = cellBlock.value(for: .minimumWidth)
+      if minimumWidth > 0, cellBlock.valueType(for: .minimumWidth) == .absoluteValueType {
+        specified = max(specified, minimumWidth + extras)
+      }
+
+      if specified > 0 {
+        specifiedWidths[column] = max(specifiedWidths[column], specified)
+      }
+
+      if !usesFixedLayout && specified == 0 {
+        var natural = _naturalContentWidth(ofParagraphsIn: cellRange, level: level + 1) + extras
+
+        let maximumWidth = cellBlock.value(for: .maximumWidth)
+        if maximumWidth > 0, cellBlock.valueType(for: .maximumWidth) == .absoluteValueType {
+          natural = min(natural, maximumWidth + extras)
+        }
+
+        naturalWidths[column] = max(naturalWidths[column], min(natural, baseWidth))
+      }
+    }
+
+    if usesFixedLayout {
+      // fixed layout: the first row's widths decide; remaining space is shared equally
+      var widths = [CGFloat](repeating: 0, count: columnCount)
+      var remaining = baseWidth
+      var unspecifiedColumns = 0
+
+      for column in 0..<columnCount {
+        if specifiedWidths[column] > 0 {
+          widths[column] = specifiedWidths[column]
+          remaining -= widths[column]
+        } else {
+          unspecifiedColumns += 1
+        }
+      }
+
+      if unspecifiedColumns > 0 {
+        let share = max(remaining, 0) / CGFloat(unspecifiedColumns)
+        for column in 0..<columnCount where widths[column] == 0 {
+          widths[column] = share
+        }
+      } else if remaining > 0 {
+        let share = remaining / CGFloat(columnCount)
+        for column in 0..<columnCount {
+          widths[column] += share
+        }
+      }
+
+      return widths
+    }
+
+    // an explicit width wins over the content's natural width — content wraps instead
+    var preferredWidths = [CGFloat](repeating: 0, count: columnCount)
+    for column in 0..<columnCount {
+      preferredWidths[column] =
+        specifiedWidths[column] > 0 ? specifiedWidths[column] : naturalWidths[column]
+    }
+
+    // distribute the needs of spanning cells over their columns
+    for (cellBlock, cellRange) in cells where cellBlock.columnSpan > 1 {
+      let firstColumn = cellBlock.startingColumn
+      let lastColumn = min(firstColumn + cellBlock.columnSpan, columnCount) - 1
+      guard firstColumn <= lastColumn else { continue }
+
+      let extras = _horizontalBoxExtras(of: cellBlock)
+      let needed = min(
+        _naturalContentWidth(ofParagraphsIn: cellRange, level: level + 1) + extras, baseWidth)
+      let current = preferredWidths[firstColumn...lastColumn].reduce(0, +)
+
+      if needed > current {
+        let addition = (needed - current) / CGFloat(lastColumn - firstColumn + 1)
+        for column in firstColumn...lastColumn {
+          preferredWidths[column] += addition
+        }
+      }
+    }
+
+    // columns without any sizing information (e.g. only empty cells) collapse to a
+    // small minimum, like shrink-to-fit tables in browsers
+    let fallbackShare = min(baseWidth / CGFloat(columnCount), 16)
+    for column in 0..<columnCount where preferredWidths[column] <= 0 {
+      preferredWidths[column] = fallbackShare
+    }
+
+    let total = preferredWidths.reduce(0, +)
+    guard total > 0 else {
+      return [CGFloat](repeating: baseWidth / CGFloat(columnCount), count: columnCount)
+    }
+
+    if explicitTableWidth > 0 {
+      // columns with explicit widths keep them; the leftover is distributed over the
+      // flexible columns proportionally to their preferred (content) width
+      var widths = [CGFloat](repeating: 0, count: columnCount)
+      var specifiedTotal: CGFloat = 0
+      var flexibleColumns = [Int]()
+
+      for column in 0..<columnCount {
+        if specifiedWidths[column] > 0 {
+          widths[column] = specifiedWidths[column]
+          specifiedTotal += specifiedWidths[column]
+        } else {
+          flexibleColumns.append(column)
+        }
+      }
+
+      let remaining = explicitTableWidth - specifiedTotal
+
+      if flexibleColumns.isEmpty || remaining <= 0 {
+        // only specified columns (or over-constrained): scale to fit exactly
+        let scaleBase = specifiedTotal > 0 ? specifiedTotal : 1
+        let factor = explicitTableWidth / scaleBase
+        return widths.map { $0 * factor }
+      }
+
+      let flexiblePreferredTotal = flexibleColumns.reduce(0 as CGFloat) {
+        $0 + preferredWidths[$1]
+      }
+
+      for column in flexibleColumns {
+        if flexiblePreferredTotal > 0 {
+          widths[column] = remaining * (preferredWidths[column] / flexiblePreferredTotal)
+        } else {
+          widths[column] = remaining / CGFloat(flexibleColumns.count)
+        }
+      }
+
+      return widths
+    }
+
+    if total > innerAvailableWidth {
+      let factor = innerAvailableWidth / total
+      return preferredWidths.map { $0 * factor }
+    }
+
+    // shrink-to-fit: a table without explicit width is only as wide as its content
+    return preferredWidths
+  }
+
+  /// Lays out one table (and recursively any nested tables) as a grid of cells.
+  /// Lines are returned in string order with final positions; cell and table frames
+  /// are border-box rects for background/border drawing.
+  private func _layoutTable(
+    _ table: TextTable, level: Int, startingAt location: Int, availableWidth: CGFloat,
+    originX: CGFloat, topY: CGFloat
+  ) -> _TableLayoutResult {
+    var result = _TableLayoutResult()
+
+    guard let fragment = _attributedStringFragment else { return result }
+    let nsString = fragment.string as NSString
+
+    // 1. collect the cells and their string ranges (contiguous paragraphs per cell)
+    var cells = [(block: TextTableBlock, range: NSRange)]()
+    var scanLocation = location
+    let stringLength = fragment.length
+
+    while scanLocation < stringLength {
+      let paragraphRange = nsString.paragraphRange(for: NSRange(location: scanLocation, length: 0))
+
+      guard let blocks = _textBlocks(at: paragraphRange.location),
+        blocks.count > level,
+        let cellBlock = blocks[level] as? TextTableBlock,
+        cellBlock.table === table
+      else { break }
+
+      if let lastIndex = cells.indices.last, cells[lastIndex].block === cellBlock {
+        cells[lastIndex].range = NSUnionRange(cells[lastIndex].range, paragraphRange)
+      } else {
+        cells.append((cellBlock, paragraphRange))
+      }
+
+      scanLocation = NSMaxRange(paragraphRange)
+    }
+
+    guard !cells.isEmpty else { return result }
+
+    result.range = NSRange(location: location, length: scanLocation - location)
+
+    // 2. the table's own box
+    let marginLeft = table.width(for: .margin, edge: .minXEdge)
+    let marginRight = table.width(for: .margin, edge: .maxXEdge)
+    let marginTop = table.width(for: .margin, edge: .minYEdge)
+    let marginBottom = table.width(for: .margin, edge: .maxYEdge)
+    let edgeLeft =
+      table.width(for: .border, edge: .minXEdge) + table.width(for: .padding, edge: .minXEdge)
+    let edgeRight =
+      table.width(for: .border, edge: .maxXEdge) + table.width(for: .padding, edge: .maxXEdge)
+    let edgeTop =
+      table.width(for: .border, edge: .minYEdge) + table.width(for: .padding, edge: .minYEdge)
+    let edgeBottom =
+      table.width(for: .border, edge: .maxYEdge) + table.width(for: .padding, edge: .maxYEdge)
+
+    let innerAvailableWidth = max(
+      availableWidth - marginLeft - marginRight - edgeLeft - edgeRight, 10)
+
+    let columnCount = max(
+      table.numberOfColumns, cells.map { $0.block.startingColumn + $0.block.columnSpan }.max() ?? 0)
+
+    guard columnCount > 0 else { return result }
+
+    // 3. column widths
+    let columnWidths = _resolveColumnWidths(
+      for: table, cells: cells, columnCount: columnCount,
+      innerAvailableWidth: innerAvailableWidth, level: level)
+    let gridWidth = columnWidths.reduce(0, +)
+
+    // 4. lay out every cell's content with relative y starting at 0
+    struct CellLayout {
+      var block: TextTableBlock
+      var flow: _TableLayoutResult
+      var borderBoxX: CGFloat
+      var borderBoxWidth: CGFloat
+      var contentInsetTop: CGFloat
+      var contentInsetBottom: CGFloat
+      var contentHeight: CGFloat
+    }
+
+    let gridLeft = originX + marginLeft + edgeLeft
+    var cellLayouts = [CellLayout]()
+
+    for (cellBlock, cellRange) in cells {
+      let columnX = gridLeft + columnWidths[0..<cellBlock.startingColumn].reduce(0, +)
+      let spanEnd = min(cellBlock.startingColumn + cellBlock.columnSpan, columnCount)
+      let spanWidth = columnWidths[cellBlock.startingColumn..<spanEnd].reduce(0, +)
+
+      let cellMarginLeft = cellBlock.width(for: .margin, edge: .minXEdge)
+      let cellMarginRight = cellBlock.width(for: .margin, edge: .maxXEdge)
+      let borderBoxX = columnX + cellMarginLeft
+      let borderBoxWidth = max(spanWidth - cellMarginLeft - cellMarginRight, 1)
+
+      let insetLeft =
+        cellBlock.width(for: .border, edge: .minXEdge)
+        + cellBlock.width(for: .padding, edge: .minXEdge)
+      let insetRight =
+        cellBlock.width(for: .border, edge: .maxXEdge)
+        + cellBlock.width(for: .padding, edge: .maxXEdge)
+      let insetTop =
+        cellBlock.width(for: .border, edge: .minYEdge)
+        + cellBlock.width(for: .padding, edge: .minYEdge)
+      let insetBottom =
+        cellBlock.width(for: .border, edge: .maxYEdge)
+        + cellBlock.width(for: .padding, edge: .maxYEdge)
+
+      let contentWidth = max(borderBoxWidth - insetLeft - insetRight, 1)
+      let contentX = borderBoxX + insetLeft
+
+      let flow = _layoutFlow(
+        range: cellRange, level: level + 1, width: contentWidth, originX: contentX, topY: 0)
+
+      cellLayouts.append(
+        CellLayout(
+          block: cellBlock, flow: flow, borderBoxX: borderBoxX, borderBoxWidth: borderBoxWidth,
+          contentInsetTop: insetTop, contentInsetBottom: insetBottom,
+          contentHeight: flow.bottomY))
+    }
+
+    // 5. row slot heights (cell border box plus its vertical margins fill the slot)
+    let rowCount = cells.map { $0.block.startingRow + $0.block.rowSpan }.max() ?? 1
+    var rowHeights = [CGFloat](repeating: 0, count: rowCount)
+
+    // baseline-aligned cells of one row align at the baseline of their first line
+    // (NSTextBlockVerticalAlignment documentation); the row baseline is the lowest
+    // first baseline measured from the slot top
+    var rowFirstBaselines = [CGFloat](repeating: 0, count: rowCount)
+
+    func relativeFirstBaseline(of layout: CellLayout) -> CGFloat {
+      return layout.flow.lines.first?.baselineOrigin.y ?? 0
+    }
+
+    func baselineInset(of layout: CellLayout) -> CGFloat {
+      // distance from slot top to the cell's natural first baseline
+      return layout.block.width(for: .margin, edge: .minYEdge) + layout.contentInsetTop
+        + relativeFirstBaseline(of: layout)
+    }
+
+    for layout in cellLayouts
+    where layout.block.verticalAlignment == .baselineAlignment && layout.block.rowSpan == 1 {
+      let row = layout.block.startingRow
+      guard row < rowCount else { continue }
+      rowFirstBaselines[row] = max(rowFirstBaselines[row], baselineInset(of: layout))
+    }
+
+    for layout in cellLayouts where layout.block.rowSpan == 1 {
+      let row = layout.block.startingRow
+      guard row < rowCount else { continue }
+
+      // baseline-aligned content may get pushed down to meet the row baseline
+      var baselinePushDown: CGFloat = 0
+      if layout.block.verticalAlignment == .baselineAlignment {
+        baselinePushDown = rowFirstBaselines[row] - baselineInset(of: layout)
+      }
+
+      let slotHeight =
+        layout.contentHeight + layout.contentInsetTop + layout.contentInsetBottom
+        + layout.block.width(for: .margin, edge: .minYEdge)
+        + layout.block.width(for: .margin, edge: .maxYEdge)
+        + baselinePushDown
+      rowHeights[row] = max(rowHeights[row], slotHeight)
+    }
+
+    // grow the last spanned row when a rowspan cell does not fit
+    for layout in cellLayouts where layout.block.rowSpan > 1 {
+      let firstRow = layout.block.startingRow
+      let lastRow = min(firstRow + layout.block.rowSpan, rowCount) - 1
+      guard firstRow <= lastRow else { continue }
+
+      let needed =
+        layout.contentHeight + layout.contentInsetTop + layout.contentInsetBottom
+        + layout.block.width(for: .margin, edge: .minYEdge)
+        + layout.block.width(for: .margin, edge: .maxYEdge)
+      let current = rowHeights[firstRow...lastRow].reduce(0, +)
+
+      if needed > current {
+        rowHeights[lastRow] += needed - current
+      }
+    }
+
+    // 6. final positions
+    var rowTops = [CGFloat](repeating: 0, count: rowCount + 1)
+    rowTops[0] = topY + marginTop + edgeTop
+    for row in 0..<rowCount {
+      rowTops[row + 1] = rowTops[row] + rowHeights[row]
+    }
+
+    for var layout in cellLayouts {
+      let cellBlock = layout.block
+      let cellMarginTop = cellBlock.width(for: .margin, edge: .minYEdge)
+      let cellMarginBottom = cellBlock.width(for: .margin, edge: .maxYEdge)
+
+      let firstRow = cellBlock.startingRow
+      let lastRow = min(firstRow + cellBlock.rowSpan, rowCount) - 1
+      let slotTop = rowTops[firstRow]
+      let slotHeight = rowTops[lastRow + 1] - slotTop
+
+      let borderBoxY = slotTop + cellMarginTop
+      let borderBoxHeight = max(slotHeight - cellMarginTop - cellMarginBottom, 1)
+
+      let innerHeight = borderBoxHeight - layout.contentInsetTop - layout.contentInsetBottom
+      var verticalShift = borderBoxY + layout.contentInsetTop
+
+      switch cellBlock.verticalAlignment {
+      case .middleAlignment:
+        verticalShift += max((innerHeight - layout.contentHeight) / 2, 0)
+      case .bottomAlignment:
+        verticalShift += max(innerHeight - layout.contentHeight, 0)
+      case .baselineAlignment:
+        // align the first baseline with the row's common first baseline
+        if cellBlock.rowSpan == 1, firstRow < rowCount, rowFirstBaselines[firstRow] > 0 {
+          verticalShift = slotTop + rowFirstBaselines[firstRow] - relativeFirstBaseline(of: layout)
+        }
+      default:
+        break  // top aligns at the content top
+      }
+
+      for line in layout.flow.lines {
+        var origin = line.baselineOrigin
+        origin.y = ceil(origin.y + verticalShift)
+        line.baselineOrigin = origin
+      }
+      for index in layout.flow.cellFrames.indices {
+        layout.flow.cellFrames[index].rect.origin.y += verticalShift
+      }
+      for index in layout.flow.tableFrames.indices {
+        layout.flow.tableFrames[index].rect.origin.y += verticalShift
+      }
+
+      result.lines.append(contentsOf: layout.flow.lines)
+      result.cellFrames.append(contentsOf: layout.flow.cellFrames)
+      result.tableFrames.append(contentsOf: layout.flow.tableFrames)
+      result.suppressedBorderEdges.merge(layout.flow.suppressedBorderEdges) { $0 | $1 }
+
+      result.cellFrames.append(
+        (
+          cellBlock,
+          CGRect(
+            x: layout.borderBoxX, y: borderBoxY, width: layout.borderBoxWidth,
+            height: borderBoxHeight),
+          level
+        ))
+    }
+
+    // 6.5 collapsed borders: each interior boundary keeps only the wider of the two
+    // adjacent borders; on the perimeter the wider of the table border and the outer
+    // cell borders wins — yielding a single-line grid
+    if table.collapsesBorders {
+      var grid = [[Int?]](
+        repeating: [Int?](repeating: nil, count: columnCount), count: rowCount)
+
+      for (index, layout) in cellLayouts.enumerated() {
+        let block = layout.block
+        for row in block.startingRow..<min(block.startingRow + block.rowSpan, rowCount) {
+          for column in block.startingColumn..<min(
+            block.startingColumn + block.columnSpan, columnCount)
+          {
+            grid[row][column] = index
+          }
+        }
+      }
+
+      func suppress(_ block: TextBlock, _ edge: CGRectEdge) {
+        result.suppressedBorderEdges[ObjectIdentifier(block), default: 0] |=
+          (1 << UInt(edge.rawValue))
+      }
+
+      // interior vertical boundaries
+      for row in 0..<rowCount {
+        for column in 0..<(columnCount - 1) {
+          guard let leftIndex = grid[row][column], let rightIndex = grid[row][column + 1],
+            leftIndex != rightIndex
+          else { continue }
+
+          let left = cellLayouts[leftIndex].block
+          let right = cellLayouts[rightIndex].block
+
+          if left.width(for: .border, edge: .maxXEdge)
+            >= right.width(for: .border, edge: .minXEdge)
+          {
+            suppress(right, .minXEdge)
+          } else {
+            suppress(left, .maxXEdge)
+          }
+        }
+      }
+
+      // interior horizontal boundaries
+      for column in 0..<columnCount {
+        for row in 0..<(rowCount - 1) {
+          guard let topIndex = grid[row][column], let bottomIndex = grid[row + 1][column],
+            topIndex != bottomIndex
+          else { continue }
+
+          let top = cellLayouts[topIndex].block
+          let bottom = cellLayouts[bottomIndex].block
+
+          if top.width(for: .border, edge: .maxYEdge)
+            >= bottom.width(for: .border, edge: .minYEdge)
+          {
+            suppress(bottom, .minYEdge)
+          } else {
+            suppress(top, .maxYEdge)
+          }
+        }
+      }
+
+      // perimeter sides
+      func resolvePerimeter(tableEdge: CGRectEdge, cellIndices: [Int?], cellEdge: CGRectEdge) {
+        let tableWidth = table.width(for: .border, edge: tableEdge)
+        let indices = cellIndices.compactMap { $0 }
+        let maxCellWidth = indices.map {
+          cellLayouts[$0].block.width(for: .border, edge: cellEdge)
+        }.max() ?? 0
+
+        if tableWidth >= maxCellWidth && tableWidth > 0 {
+          for index in indices {
+            suppress(cellLayouts[index].block, cellEdge)
+          }
+        } else if maxCellWidth > 0 {
+          suppress(table, tableEdge)
+        }
+      }
+
+      resolvePerimeter(tableEdge: .minYEdge, cellIndices: grid[0], cellEdge: .minYEdge)
+      resolvePerimeter(
+        tableEdge: .maxYEdge, cellIndices: grid[rowCount - 1], cellEdge: .maxYEdge)
+      resolvePerimeter(
+        tableEdge: .minXEdge, cellIndices: (0..<rowCount).map { grid[$0][0] },
+        cellEdge: .minXEdge)
+      resolvePerimeter(
+        tableEdge: .maxXEdge, cellIndices: (0..<rowCount).map { grid[$0][columnCount - 1] },
+        cellEdge: .maxXEdge)
+    }
+
+    // 7. the table's own border box, drawn beneath its cells
+    let tableRect = CGRect(
+      x: originX + marginLeft,
+      y: topY + marginTop,
+      width: edgeLeft + gridWidth + edgeRight,
+      height: edgeTop + (rowTops[rowCount] - rowTops[0]) + edgeBottom)
+
+    result.tableFrames.insert((table, tableRect, level), at: 0)
+    result.bottomY = tableRect.maxY + marginBottom
+
+    return result
+  }
+
+  /// Lays out a range of text as a vertical flow of lines with the given width — the
+  /// content of one table cell. Nested tables are laid out recursively.
+  private func _layoutFlow(
+    range: NSRange, level: Int, width: CGFloat, originX: CGFloat, topY: CGFloat
+  ) -> _TableLayoutResult {
+    var result = _TableLayoutResult()
+    result.range = range
+    result.bottomY = topY
+
+    guard let framesetter = _framesetter, let fragment = _attributedStringFragment else {
+      return result
+    }
+
+    let typesetter = CTFramesetterGetTypesetter(framesetter)
+    let maxIndex = NSMaxRange(range)
+
+    var location = range.location
+    var previousLine: CoreTextLayoutLine?
+    var minimumBaselineY: CGFloat?
+    var currentBottom = topY
+
+    while location < maxIndex {
+      // nested table starting at this paragraph?
+      if let nested = _tableStart(at: location, atOrDeeperThan: level) {
+        let nestedResult = _layoutTable(
+          nested.block.table, level: nested.level, startingAt: location,
+          availableWidth: width, originX: originX, topY: currentBottom)
+
+        if nestedResult.range.length > 0 {
+          result.lines.append(contentsOf: nestedResult.lines)
+          result.cellFrames.append(contentsOf: nestedResult.cellFrames)
+          result.tableFrames.append(contentsOf: nestedResult.tableFrames)
+          result.suppressedBorderEdges.merge(nestedResult.suppressedBorderEdges) { $0 | $1 }
+          currentBottom = nestedResult.bottomY
+          minimumBaselineY = nestedResult.bottomY
+          previousLine = nestedResult.lines.last ?? previousLine
+          location = NSMaxRange(nestedResult.range)
+          continue
+        }
+      }
+
+      var lineRange = NSRange(location: location, length: 0)
+      lineRange.length = CTTypesetterSuggestLineBreak(typesetter, location, Double(width))
+
+      if NSMaxRange(lineRange) > maxIndex {
+        lineRange.length = maxIndex - location
+      }
+
+      guard lineRange.length > 0 else { break }
+
+      var ctLine = CTTypesetterCreateLine(
+        typesetter, CFRangeMake(lineRange.location, lineRange.length))
+
+      // alignment within the cell
+      let paragraphStyle =
+        fragment.attribute(.paragraphStyle, at: location, effectiveRange: nil)
+        as? NSParagraphStyle
+
+      // justified text stretches all lines except the last of a paragraph
+      if paragraphStyle?.alignment == .justified {
+        let paragraphRange = (fragment.string as NSString).paragraphRange(
+          for: NSRange(location: location, length: 0))
+        let isLastLineInParagraph = NSMaxRange(lineRange) >= NSMaxRange(paragraphRange)
+        let lineWidth = CGFloat(CTLineGetTypographicBounds(ctLine, nil, nil, nil))
+
+        if !isLastLineInParagraph, lineWidth > justifyRatio * width,
+          let justifiedLine = CTLineCreateJustifiedLine(ctLine, 1.0, Double(width))
+        {
+          ctLine = justifiedLine
+        }
+      }
+
+      guard let newLine = CoreTextLayoutLine(line: ctLine, stringLocationOffset: 0) else {
+        location = NSMaxRange(lineRange)
+        continue
+      }
+
+      var lineOriginX = originX
+
+      if let paragraphStyle {
+        switch paragraphStyle.alignment {
+        case .right:
+          lineOriginX = originX + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(width)))
+        case .center:
+          lineOriginX = originX + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 0.5, Double(width)))
+        case .natural, .justified:
+          if paragraphStyle.baseWritingDirection == .rightToLeft {
+            lineOriginX =
+              originX + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(width)))
+          }
+        default:
+          break
+        }
+
+        newLine.writingDirectionIsRightToLeft =
+          (paragraphStyle.baseWritingDirection == .rightToLeft)
+      }
+
+      var baselineOrigin: CGPoint
+
+      if let previousLine {
+        baselineOrigin = _algorithmWebKit_BaselineOrigin(
+          toPositionLine: newLine, afterLine: previousLine)
+      } else {
+        let halfLeading = max(_algorithmWebKit_halfLeading(ofLine: newLine), 0)
+        baselineOrigin = CGPoint(x: originX, y: topY + newLine.ascent + halfLeading)
+      }
+
+      if let minimumY = minimumBaselineY {
+        baselineOrigin.y = max(baselineOrigin.y, minimumY + newLine.ascent)
+        minimumBaselineY = nil
+      }
+
+      baselineOrigin.x = lineOriginX
+      baselineOrigin.y = ceil(baselineOrigin.y)
+      newLine.baselineOrigin = baselineOrigin
+
+      result.lines.append(newLine)
+      currentBottom = max(currentBottom, newLine.frame.maxY)
+      previousLine = newLine
+      location = NSMaxRange(lineRange)
+    }
+
+    result.bottomY = currentBottom
+    return result
+  }
+
   private func _updateFrameSize() {
     guard let lines = _lines, !lines.isEmpty else { return }
 
     if _frame.size.height == CGFLOAT_HEIGHT_UNKNOWN {
       if let lastLine = lines.last {
+        // a table's lowest cell can reach below the last line of text
+        let contentBottom = max(lastLine.frame.maxY, _maxTableBottom)
         _frame.size.height = ceil(
-          lastLine.frame.maxY - _frame.origin.y + 1.5 + _additionalPaddingAtBottom)
+          contentBottom - _frame.origin.y + 1.5 + _additionalPaddingAtBottom)
       }
     }
 

--- a/Sources/DTCoreText/CoreTextParagraphStyle.swift
+++ b/Sources/DTCoreText/CoreTextParagraphStyle.swift
@@ -70,7 +70,7 @@ public class CoreTextParagraphStyle: NSObject, NSCopying {
   @objc public var textLists: [NSTextList]?
 
   /// Text blocks containing the paragraph, nested from outermost to innermost.
-  @objc public var textBlocks: [Any]?
+  @objc public var textBlocks: [TextBlock]?
 
   private var _tabStops: NSMutableArray?
 

--- a/Sources/DTCoreText/DTCoreText.docc/DTCoreText.md
+++ b/Sources/DTCoreText/DTCoreText.docc/DTCoreText.md
@@ -40,6 +40,10 @@ Use ``DTAttributedTextView`` or ``DTAttributedLabel`` to render the attributed s
 
 ## Topics
 
+### Articles
+
+- <doc:HTMLTablesOnMacOS>
+
 ### Parsing HTML
 
 - ``HTMLAttributedStringBuilder``
@@ -80,3 +84,6 @@ Use ``DTAttributedTextView`` or ``DTAttributedLabel`` to render the attributed s
 
 - ``CoreTextParagraphStyle``
 - ``TextBlock``
+- ``TextTable``
+- ``TextTableBlock``
+- ``TextBlockConverter``

--- a/Sources/DTCoreText/DTCoreText.docc/HTMLTablesOnMacOS.md
+++ b/Sources/DTCoreText/DTCoreText.docc/HTMLTablesOnMacOS.md
@@ -1,0 +1,146 @@
+# How macOS Represents HTML Tables
+
+Empirical documentation of how AppKit's HTML importer expresses tables in attributed strings, as the basis for table support in DTCoreText.
+
+## Overview
+
+On macOS, `NSAttributedString(data:options:documentAttributes:)` with `NSHTMLTextDocumentType` represents HTML tables with three AppKit classes that have existed since macOS 10.4 but were missing from iOS until iOS 27:
+
+- `NSTextBlock` — the base class. Carries six dimensions (width, minimum/maximum width, height, minimum/maximum height, each with an absolute-or-percentage value type), per-edge widths for three box layers (padding, border, margin), per-edge border colors, a background color, and a vertical alignment.
+- `NSTextTable` (subclass of `NSTextBlock`) — one instance per table. Adds `numberOfColumns`, `layoutAlgorithm` (automatic/fixed), `collapsesBorders`, and `hidesEmptyCells`.
+- `NSTextTableBlock` (subclass of `NSTextBlock`) — one instance per cell. Adds a reference to its `table` plus the grid position: `startingRow`, `rowSpan`, `startingColumn`, `columnSpan`.
+
+These objects live in `NSParagraphStyle.textBlocks`, an array on the paragraph style of every paragraph that is inside a table cell. DTCoreText mirrors this with ``CoreTextParagraphStyle/textBlocks`` holding ``TextBlock`` objects; table support requires extending that model to match the full `NSTextBlock` API (tracked in [issue #1317](https://github.com/Cocoanetics/DTCoreText/issues/1317)).
+
+Everything below was determined by running representative HTML snippets through the system importer and dumping the result. The tool lives at `Tools/TableInvestigation/main.swift` (run with `swift Tools/TableInvestigation/main.swift`); a captured dump is checked in next to it as `sample-output.txt`. Findings were captured on macOS 26.6 (25G5028f).
+
+## Characters and Paragraphs
+
+A table contributes **no characters of its own** to the string — no tabs, no delimiters, no attachment characters. Each cell becomes one or more ordinary paragraphs terminated by `\n`:
+
+```
+<table><tr><td>A1</td><td>B1</td></tr>
+       <tr><td>A2</td><td>B2</td></tr></table>
+```
+
+produces exactly `"A1\nB1\nA2\nB2\n"`. The table structure exists *only* in the `textBlocks` of the paragraph styles.
+
+- An **empty cell** is a bare `"\n"` paragraph (still carrying its `NSTextTableBlock`).
+- A **cell with multiple paragraphs** (e.g. two `<p>` elements) produces multiple paragraphs that all reference the *same* `NSTextTableBlock` instance.
+- A `<caption>` is emitted as a plain, center-aligned paragraph *before* the cell paragraphs, with **no text block at all** — it is not structurally part of the table.
+
+## The textBlocks Array
+
+- The array contains only `NSTextTableBlock` instances. The `NSTextTable` itself never appears in the array; it is reachable through each cell block's `table` property.
+- For **nested tables**, the order is outermost first, innermost last. With a table inside a cell of an outer table, the inner cell's paragraphs carry `[outerCellBlock, innerCellBlock]`, while outer-cell text before/after the inner table carries just `[outerCellBlock]`.
+- **Object identity is the grouping mechanism.** All paragraphs of one cell share one `NSTextTableBlock` instance; all cells of one table point at one shared `NSTextTable` instance. Two cells with identical properties are still distinct instances. Any consumer (layout, HTML writer) must group by identity, not equality.
+
+## Grid Geometry
+
+- `startingRow` / `startingColumn` are 0-based grid coordinates; `numberOfColumns` on the table counts grid columns including spans.
+- `colspan="2"` → `columnSpan = 2`; the next cell in the row starts at the skipped index (e.g. `startingColumn = 2`).
+- `rowspan="2"` → `rowSpan = 2`; the covered grid positions in following rows simply have **no block** — there is no placeholder. Grid occupancy must be reconstructed from the spans.
+- There is no object representing a row (`<tr>`); rows exist only through the `startingRow` indices. Row-level HTML attributes are pushed down onto the row's cells (see colors below).
+
+## Dimensions
+
+The importer **resolves every width to an absolute point value** — percentage value types never occur in imported strings, even when the HTML uses percentages:
+
+- `<table width="80%">` resolved to `width = 627.19 pt` *absolute* — 80% of WebKit's default layout width of ~784 pt (800 pt minus 2 × 8 pt body margin).
+- Cells always get a `width` dimension with the resolved content width, even when the HTML specifies no width at all (the importer measures the laid-out content, e.g. `width = 14.67 pt` for "A1").
+- The stored width is the resolved **content width**: `<td style="width: 120px">` → `width = 120`; a `<col width="120">` constraint → cell `width = 118` (120 minus 2 × 1 pt default padding). Pixel values import 1:1 as points.
+- `min-width` / `max-width` → `minimumWidth` / `maximumWidth` dimensions, set *in addition to* the resolved `width`.
+- **Heights are never imported.** Legacy `height` attributes and CSS `height` on rows or cells are dropped; all height dimensions stay 0 and row heights come purely from content at layout time.
+- Quirk: only the legacy `width` *attribute* on `<table>` produces a width dimension on the `NSTextTable` block. CSS `width` on the table influences the resolved cell widths but is not stored on the table block itself.
+- `<col>`/`<colgroup>` have no dedicated representation; their widths only influence the resolved cell widths.
+
+The percentage value type (`NSTextBlockPercentageValueType`) is therefore only relevant for programmatically built tables — a DT implementation may choose to *keep* percentages from HTML (richer, resizable layout) or resolve them like the system importer does.
+
+## Box Layers and Edges
+
+Each block has three layers — padding, border, margin — with a width per `NSRectEdge`. In the flipped text coordinate system the edges mean:
+
+| NSRectEdge | Side   |
+|------------|--------|
+| `minX` (0) | left   |
+| `minY` (1) | top    |
+| `maxX` (2) | right  |
+| `maxY` (3) | bottom |
+
+(Verified with distinct per-edge CSS border widths and colors: `border-left: 4px #FF00FF` showed up as `border minX=4`, `borderColor minX=#FF00FF`, etc.)
+
+Observed mappings:
+
+- Default plain `<td>`: padding 1 pt on all edges, margin 0.5 pt on all edges, border 0.
+- `cellpadding="5"` → padding 5 pt on every cell edge.
+- `cellspacing="3"` → margin 1.5 pt on every cell edge — the spacing is split in half between adjacent cells.
+- `border="2"` on the table → border 2 pt on all edges of the `NSTextTable` block itself, plus a 1 pt border on every cell (the HTML separated-borders look).
+- CSS `padding`/`border-*` per edge on a cell → the corresponding layer/edge values; `border-*-color` → `borderColor(for:)` per edge.
+- CSS `margin` on the table → margin layer on the `NSTextTable` block (e.g. `margin-left: 20px` → `margin minX=20`).
+- `border-collapse: collapse` → `collapsesBorders = true` on the table, and the cells lose their default margins (no spacing).
+- Border colors default to opaque black on **all four edges of every block** (table and cells), even when the border width is 0.
+
+## Colors
+
+- `bgcolor`/`background-color` on `<table>` → `backgroundColor` of the `NSTextTable` block.
+- On `<td>`/`<th>` → `backgroundColor` of that cell's block.
+- On `<tr>` → copied to each cell block of that row that has no own background (there is no row object to carry it).
+- Cell and table backgrounds are **not** run-level `NSBackgroundColorAttributeName` attributes — they live exclusively on the blocks. (Contrast: a `<div>` background *does* become a run attribute, see below.)
+
+## Vertical Alignment
+
+- The importer's default for table cells is `.middleAlignment` — note that a freshly initialized `NSTextBlock` defaults to `.topAlignment` instead.
+- `valign` attribute and CSS `vertical-align` map directly: `top` → `.topAlignment`, `middle` → `.middleAlignment`, `bottom` → `.bottomAlignment`, `baseline` → `.baselineAlignment`.
+
+## Paragraph-Level Effects
+
+Some table styling lands on the paragraph style or font rather than the blocks:
+
+- `<th>` → bold font (Times-Bold with default settings) and paragraph alignment `.center`. No block-level difference to `<td>`.
+- `align`/`text-align` on cells → paragraph `alignment`.
+- `dir="rtl"` on the table → `baseWritingDirection = .rightToLeft` on the cell paragraphs. The grid indices remain in source order; visual mirroring is the layout engine's job.
+- The importer always sets an explicit `baseWritingDirection` (`.leftToRight` by default) — never `.natural`.
+- `<p>` inside a cell keeps its usual `paragraphSpacing` (12 pt); bare cell text has none.
+
+## Layout Algorithm and Empty Cells
+
+- `table-layout: fixed` → `layoutAlgorithm = .fixedLayoutAlgorithm`; everything else is `.automaticLayoutAlgorithm`. Since the importer bakes resolved absolute widths anyway, the distinction matters mainly for relayout after edits.
+- `empty-cells: hide` → `hidesEmptyCells = true` on the table.
+
+## What the System Importer Does *Not* Use Blocks For
+
+Only table cells produce text blocks. A `<div>` with padding, border, and background gets **no** `NSTextBlock`: the background color becomes a run-level background attribute and the padding/border are dropped entirely. A `<blockquote>` becomes head/tail indents (±40 pt). DTCoreText's existing use of ``TextBlock`` for padded/background block elements is *richer* than what the system importer does — that behavior must be preserved when extending the class.
+
+## Enum Raw Values and Defaults
+
+For a binary/archival-compatible DT layer the raw values must match exactly. Verified on macOS 26.6:
+
+| Enum | Values |
+|------|--------|
+| `NSTextBlock.Dimension` | width = 0, minimumWidth = 1, maximumWidth = 2, height = 4, minimumHeight = 5, maximumHeight = 6 — **note the gap at 3** |
+| `NSTextBlock.ValueType` | absoluteValueType = 0, percentageValueType = 1 |
+| `NSTextBlock.Layer` | **padding = −1**, border = 0, margin = 1 |
+| `NSTextBlock.VerticalAlignment` | top = 0, middle = 1, bottom = 2, baseline = 3 |
+| `NSTextTable.LayoutAlgorithm` | automatic = 0, fixed = 1 |
+| `NSRectEdge` | minX = 0, minY = 1, maxX = 2, maxY = 3 |
+
+Defaults of freshly initialized instances:
+
+- `NSTextBlock()` — all six dimensions 0 (absolute), all layer widths 0 (absolute), no border colors, no background color, `verticalAlignment = .topAlignment`.
+- `NSTextTable()` — `numberOfColumns = 0`, `layoutAlgorithm = .automaticLayoutAlgorithm`, `collapsesBorders = false`, `hidesEmptyCells = false`.
+
+## The DT Compatibility Layer
+
+The full stack — model, parsing, layout and writing — is implemented:
+
+1. ``TextBlock`` (`DTTextBlock`) carries the full `NSTextBlock` API: dimensions with value types, per-layer/per-edge widths with value types, per-edge border colors, and vertical alignment. The pre-existing `padding`/`backgroundColor` convenience API remains intact — `padding` maps onto the `.padding` layer. Edges are identified by `CGRectEdge`, whose raw values match `NSRectEdge` (which does not exist on iOS).
+2. ``TextTable`` (`DTTextTable`) and ``TextTableBlock`` (`DTTextTableBlock`) mirror their NS counterparts with identical enum raw values. ``TextBlockConverter`` converts in both directions on macOS, preserving instance identity through per-converter caches; it is the swap point for the native classes on iOS 27.
+3. ``TextTable`` and ``TextTableBlock`` compare **by identity**, exactly like their NS counterparts — and this turned out to be load-bearing, not stylistic: Foundation uniques value-equal attribute dictionaries *globally*, across attributed strings. With value-based equality, two equal-styled tables — even from two different documents parsed concurrently — get their runs mapped onto one canonical attribute dictionary, bleeding block instances between documents and destroying the identity grouping. (Plain ``TextBlock`` keeps its historical value-based equality.)
+4. ``HTMLAttributedStringBuilder`` parses `table`/`tr`/`td`/`th`/`thead`/`tbody`/`tfoot`/`caption`/`col` into this model, matching the documented importer behavior: defaults of padding 1 pt / margin 0.5 pt / middle alignment, `cellspacing` split onto cell margins, `border` attribute giving cells 1 pt borders, `tr` colors pushed down to cells, bold+centered `th`, caption as a centered paragraph outside the table, no placeholder blocks for `rowspan`-covered positions. One deliberate difference: percentage widths are **kept** as percentage value types instead of being resolved to absolute points, so layout can resolve them against the actual frame width.
+5. `CoreTextLayoutFrame` lays tables out as grids: a simplified automatic algorithm (explicit widths win and make content wrap, otherwise single-line content measurement with natural widths propagating recursively out of nested tables; leftover width from an explicit table width goes to the flexible columns), the fixed algorithm from the first row, row heights grown by `rowspan` cells, vertical alignment within row slots — including true first-baseline alignment across a row, per the `NSTextBlock.VerticalAlignment.baselineAlignment` documentation — plus justified cell text and recursive layout of nested tables. Cell and table border-box frames feed background and per-edge border drawing. With `collapsesBorders`, each boundary draws only the winning (wider) border — interior boundaries between cells and, per perimeter side, the wider of the table border and the outer cell borders — producing a single-line grid like CSS `border-collapse: collapse`. Current limitations: no full min/max-content width negotiation, no RTL column mirroring, and table content bypasses `numberOfLines` truncation.
+6. ``TextBlock`` additionally models a per-edge **border style** (solid, dashed, dotted, double) — a DTCoreText extension, since `NSTextBlock` only stores width and color per edge (the system importer drops `border-style` entirely). The parser understands the full CSS border grammar: `border`/`border-{edge}` shorthands in any component order, `border-width`/`border-style`/`border-color` with 1–4 value lists in top/right/bottom/left order, per-edge longhands, the `thin`/`medium`/`thick` width keywords, the CSS rule that a style without a width implies a medium (3 px) border, and `none`/`hidden` removing an edge. The 3D styles (groove/ridge/inset/outset) render as solid. Converting to the NS classes drops the style information.
+7. `HTMLWriter` writes the model back out as `<table>`/`<tr>`/`<td>` markup with `colspan`/`rowspan` attributes and inline CSS for widths, backgrounds, borders, padding and vertical alignment — round-tripping structure and styling through the parser.
+
+The demo app contains three table snippets (`Tables.html`, `TableAlignment.html`, `TableWidths.html`) exercising these scenarios, and `TableRenderPreviewTests` renders them (plus eleven focused samples) to PNGs on macOS and iOS for visual inspection.
+
+The parity test suite (`TextBlockAppKitParityTests`) pins the model against AppKit: enum raw values, freshly-initialized defaults, identity-equality semantics, lossless round-trip conversion, and live system-importer fixtures for the structural findings above. `TableParsingTests` additionally compares DTCoreText's parser output structurally against the system importer for identical HTML.

--- a/Sources/DTCoreText/DTHTMLElementDisplayStyle.swift
+++ b/Sources/DTCoreText/DTHTMLElementDisplayStyle.swift
@@ -11,4 +11,10 @@ public enum DTHTMLElementDisplayStyle: UInt, Sendable {
   case listItem
   /// The element is a table
   case table
+  /// The element is a table cell (td, th)
+  case tableCell
+  /// The element is a table row (tr)
+  case tableRow
+  /// The element is a group of table rows (thead, tbody, tfoot)
+  case tableRowGroup
 }

--- a/Sources/DTCoreText/HTMLElement.swift
+++ b/Sources/DTCoreText/HTMLElement.swift
@@ -359,8 +359,8 @@ open class HTMLElement: HTMLParserNode {
       for oneChild in children {
         if oneChild.displayStyle == .none { continue }
 
-        // if previous node was inline and this child is block, need a newline
-        if let prev = previousChild, prev.displayStyle == .inline, oneChild.displayStyle == .block {
+        // if previous node was inline and this child is block-ish, need a newline
+        if let prev = previousChild, prev.displayStyle == .inline, oneChild.displayStyle != .inline {
           // trim off whitespace suffix
           while tmpString.dt_hasSuffixCharacter(
             from: NSCharacterSet.dt_ignorableWhitespaceCharacterSet)
@@ -796,6 +796,10 @@ open class HTMLElement: HTMLParserNode {
       case "inline": _displayStyle = .inline
       case "list-item": _displayStyle = .listItem
       case "table": _displayStyle = .table
+      case "table-cell": _displayStyle = .tableCell
+      case "table-row": _displayStyle = .tableRow
+      case "table-row-group", "table-header-group", "table-footer-group":
+        _displayStyle = .tableRowGroup
       default: break
       }
     }
@@ -925,7 +929,13 @@ open class HTMLElement: HTMLParserNode {
   open class var attributesToIgnoreForCustomAttributesAttribute: Set<String> {
     return [
       "style", "dir", "align", "src", "href", "color", "face", "size", "name", "height", "width",
+      "colspan", "rowspan", "valign", "bgcolor", "cellpadding", "cellspacing", "border",
     ]
+  }
+
+  /// The merged CSS styles that were applied to the receiver via ``applyStyles(_:)``.
+  internal var currentStyles: [String: Any]? {
+    return _styles
   }
 
   /// CSS class names that should not be serialized as custom HTML attributes.

--- a/Sources/DTCoreText/HTMLWriter.swift
+++ b/Sources/DTCoreText/HTMLWriter.swift
@@ -131,6 +131,154 @@ public class HTMLWriter: NSObject {
     }
   }
 
+  // MARK: - Table Tags
+
+  /// CSS pixel string for a point value, without trailing fraction noise.
+  private func _pixelString(_ value: CGFloat) -> String {
+    if value == value.rounded() {
+      return "\(Int(value))px"
+    }
+    return String(format: "%gpx", Double(value))
+  }
+
+  /// The border CSS for a block: a single shorthand when uniform, per-edge otherwise.
+  private func _borderStyles(for block: TextBlock) -> String {
+    let edges: [(CGRectEdge, String)] = [
+      (.minYEdge, "top"), (.maxXEdge, "right"), (.maxYEdge, "bottom"), (.minXEdge, "left"),
+    ]
+
+    let widths = edges.map { block.width(for: .border, edge: $0.0) }
+    guard widths.contains(where: { $0 > 0 }) else { return "" }
+
+    func styleKeyword(for edge: CGRectEdge) -> String {
+      switch block.borderStyle(for: edge) {
+      case .dashed: return "dashed"
+      case .dotted: return "dotted"
+      case .double: return "double"
+      case .solid: return "solid"
+      }
+    }
+
+    func borderValue(width: CGFloat, edge: CGRectEdge) -> String {
+      let hex = block.borderColor(for: edge).flatMap { DTHexStringFromDTColor($0) } ?? "000000"
+      return "\(_pixelString(width)) \(styleKeyword(for: edge)) #\(hex)"
+    }
+
+    let colors = edges.map { block.borderColor(for: $0.0) }
+    let styles2 = edges.map { block.borderStyle(for: $0.0) }
+    let isUniform =
+      widths.allSatisfy { $0 == widths[0] }
+      && styles2.allSatisfy { $0 == styles2[0] }
+      && colors.allSatisfy { color in
+        color === colors[0] || (color != nil && colors[0] != nil && color! == colors[0]!)
+      }
+
+    if isUniform {
+      return "border:\(borderValue(width: widths[0], edge: .minYEdge));"
+    }
+
+    var styles = ""
+    for (index, (edge, name)) in edges.enumerated() where widths[index] > 0 {
+      styles += "border-\(name):\(borderValue(width: widths[index], edge: edge));"
+    }
+    return styles
+  }
+
+  /// The dimension CSS for a block's width-related dimensions.
+  private func _widthStyles(for block: TextBlock) -> String {
+    var styles = ""
+
+    let dimensions: [(TextBlock.Dimension, String)] = [
+      (.width, "width"), (.minimumWidth, "min-width"), (.maximumWidth, "max-width"),
+    ]
+
+    for (dimension, name) in dimensions {
+      let value = block.value(for: dimension)
+      guard value > 0 else { continue }
+
+      switch block.valueType(for: dimension) {
+      case .percentageValueType:
+        styles += "\(name):\(String(format: "%g", Double(value)))%;"
+      case .absoluteValueType:
+        styles += "\(name):\(_pixelString(value));"
+      }
+    }
+
+    return styles
+  }
+
+  /// The opening tag for a table.
+  private func _openingTableTag(for table: TextTable) -> String {
+    var styles = _widthStyles(for: table)
+
+    if let backgroundColor = table.backgroundColor, let hex = DTHexStringFromDTColor(backgroundColor) {
+      styles += "background-color:#\(hex);"
+    }
+
+    if table.collapsesBorders {
+      styles += "border-collapse:collapse;"
+    }
+    if table.hidesEmptyCells {
+      styles += "empty-cells:hide;"
+    }
+    if table.layoutAlgorithm == .fixedLayoutAlgorithm {
+      styles += "table-layout:fixed;"
+    }
+
+    styles += _borderStyles(for: table)
+
+    if styles.isEmpty {
+      return "<table>"
+    }
+    return "<table style=\"\(styles)\">"
+  }
+
+  /// The opening tag for a table cell.
+  private func _openingCellTag(for cell: TextTableBlock) -> String {
+    var tag = "<td"
+
+    if cell.columnSpan > 1 {
+      tag += " colspan=\"\(cell.columnSpan)\""
+    }
+    if cell.rowSpan > 1 {
+      tag += " rowspan=\"\(cell.rowSpan)\""
+    }
+
+    var styles = _widthStyles(for: cell)
+
+    if let backgroundColor = cell.backgroundColor, let hex = DTHexStringFromDTColor(backgroundColor) {
+      styles += "background-color:#\(hex);"
+    }
+
+    switch cell.verticalAlignment {
+    case .topAlignment: styles += "vertical-align:top;"
+    case .bottomAlignment: styles += "vertical-align:bottom;"
+    case .baselineAlignment: styles += "vertical-align:baseline;"
+    case .middleAlignment: break  // parser default
+    }
+
+    // padding: only when it differs from the 1pt importer default
+    let paddingEdges: [CGRectEdge] = [.minYEdge, .maxXEdge, .maxYEdge, .minXEdge]
+    let paddings = paddingEdges.map { cell.width(for: .padding, edge: $0) }
+
+    if paddings.contains(where: { $0 != 1 }) {
+      if paddings.allSatisfy({ $0 == paddings[0] }) {
+        styles += "padding:\(_pixelString(paddings[0]));"
+      } else {
+        styles +=
+          "padding:\(_pixelString(paddings[0])) \(_pixelString(paddings[1])) \(_pixelString(paddings[2])) \(_pixelString(paddings[3]));"
+      }
+    }
+
+    styles += _borderStyles(for: cell)
+
+    if !styles.isEmpty {
+      tag += " style=\"\(styles)\""
+    }
+
+    return tag + ">"
+  }
+
   private func _buildOutput() {
     _buildOutput(asHTMLFragment: false)
   }
@@ -150,6 +298,11 @@ public class HTMLWriter: NSObject {
     var location = 0
 
     var previousListStyles: [DTTextList]? = nil
+
+    // stack of table cells the output is currently inside (outermost first), and the
+    // number of <table> elements currently open in the output
+    var openTableBlocks = [TextTableBlock]()
+    var openEmittedTables = 0
 
     for i in 0..<paragraphs.count {
       let oneParagraph = paragraphs[i]
@@ -196,6 +349,67 @@ public class HTMLWriter: NSObject {
 
       // list styles live on the paragraph style's textLists array
       let currentListStyles = paragraphStyle?.textLists as? [DTTextList]
+
+      // table cells ride on the DTTextBlocks attribute (outermost first)
+      let currentTableBlocks =
+        (paraAttributesDict.object(forKey: DTTextBlocksAttribute) as? [TextBlock])?
+        .compactMap { $0 as? TextTableBlock } ?? []
+
+      // common prefix of cells the paragraph stays inside, by instance identity
+      var commonTableDepth = 0
+      while commonTableDepth < min(openTableBlocks.count, currentTableBlocks.count),
+        openTableBlocks[commonTableDepth] === currentTableBlocks[commonTableDepth]
+      {
+        commonTableDepth += 1
+      }
+
+      if openTableBlocks.count > commonTableDepth || currentTableBlocks.count > commonTableDepth {
+        // lists never straddle a cell boundary — close any open lists first
+        if let prevStyles = previousListStyles, !prevStyles.isEmpty {
+          for closingStyle in prevStyles.reversed() {
+            retString += _tagRepresentation(
+              forListStyle: closingStyle, closingTag: true, listPadding: 0, inlineStyles: fragment)
+            retString += "\n"
+          }
+          previousListStyles = nil
+        }
+      }
+
+      // close cells that ended, innermost first
+      while openTableBlocks.count > commonTableDepth {
+        let closingCell = openTableBlocks.removeLast()
+        retString += "</td>"
+
+        let depth = openTableBlocks.count
+        if currentTableBlocks.count > depth,
+          currentTableBlocks[depth].table === closingCell.table
+        {
+          // the same table continues with another cell; its <table> stays open
+          if currentTableBlocks[depth].startingRow != closingCell.startingRow {
+            retString += "</tr>\n<tr>"
+          }
+        } else {
+          retString += "</tr>\n</table>\n"
+          openEmittedTables -= 1
+        }
+      }
+
+      // open new tables and cells down to the current paragraph's cell
+      while openTableBlocks.count < currentTableBlocks.count {
+        let depth = openTableBlocks.count
+        let openingCell = currentTableBlocks[depth]
+
+        if openEmittedTables <= depth {
+          // entering a new table
+          retString += _openingTableTag(for: openingCell.table)
+          retString += "\n<tr>"
+          openEmittedTables = depth + 1
+        }
+
+        retString += _openingCellTag(for: openingCell)
+        retString += "\n"
+        openTableBlocks.append(openingCell)
+      }
 
       let effectiveListStyle = currentListStyles?.last
       var paraStyleString: String? = nil
@@ -734,6 +948,13 @@ public class HTMLWriter: NSObject {
 
         closingStyles.removeLast()
       } while closingStyles.count > 0
+    }
+
+    // close tables that are still open at the end of the string, innermost first
+    while !openTableBlocks.isEmpty {
+      openTableBlocks.removeLast()
+      retString += "</td></tr>\n</table>\n"
+      openEmittedTables -= 1
     }
 
     var output = ""

--- a/Sources/DTCoreText/TextBlock.swift
+++ b/Sources/DTCoreText/TextBlock.swift
@@ -6,40 +6,330 @@
 //  Copyright (c) 2012 Drobnik.com. All rights reserved.
 //
 
+import CoreGraphics
 import Foundation
 
 /// Class that represents a block of text with attributes like padding or a background color.
+///
+/// The API mirrors AppKit's `NSTextBlock` (which iOS gains natively with iOS 27) so that
+/// instances can be converted 1:1 to the system class where it is available. All enum raw
+/// values are identical to their AppKit counterparts; see the article
+/// <doc:HTMLTablesOnMacOS> for the empirical basis.
+///
+/// Edges are identified by `CGRectEdge`, which has the same raw values as the `NSRectEdge`
+/// used by `NSTextBlock` (`minXEdge` = leading/left, `minYEdge` = top, `maxXEdge` =
+/// trailing/right, `maxYEdge` = bottom in the flipped text coordinate system).
 @objc(DTTextBlock)
 public class TextBlock: NSObject, NSCoding {
 
-  /// The space to be applied between the layouted text and the edges of the receiver
-  @objc public var padding: DTEdgeInsets
+  // MARK: - Constants
+
+  /// The dimensions of a text block. Mirrors `NSTextBlock.Dimension`.
+  @objc(DTTextBlockDimension)
+  public enum Dimension: UInt, Sendable {
+    case width = 0
+    case minimumWidth = 1
+    case maximumWidth = 2
+    // note: raw value 3 is unused, matching AppKit
+    case height = 4
+    case minimumHeight = 5
+    case maximumHeight = 6
+  }
+
+  /// The value type of a dimension or layer width. Mirrors `NSTextBlock.ValueType`.
+  @objc(DTTextBlockValueType)
+  public enum ValueType: UInt, Sendable {
+    /// The value is an absolute length in points.
+    case absoluteValueType = 0
+    /// The value is a percentage of the enclosing block's dimension.
+    case percentageValueType = 1
+  }
+
+  /// The layers of the block box model. Mirrors `NSTextBlock.Layer`.
+  @objc(DTTextBlockLayer)
+  public enum Layer: Int, Sendable {
+    case padding = -1
+    case border = 0
+    case margin = 1
+  }
+
+  /// The vertical alignment of text within a block. Mirrors `NSTextBlock.VerticalAlignment`.
+  @objc(DTTextBlockVerticalAlignment)
+  public enum VerticalAlignment: UInt, Sendable {
+    case topAlignment = 0
+    case middleAlignment = 1
+    case bottomAlignment = 2
+    case baselineAlignment = 3
+  }
+
+  /// The drawing style of a border edge.
+  ///
+  /// This is a DTCoreText extension: `NSTextBlock` only models border width and color,
+  /// so this information is dropped when converting to the AppKit/UIKit classes.
+  /// A `none` border is modeled as a width of 0 instead of a style.
+  @objc(DTTextBlockBorderStyle)
+  public enum BorderStyle: UInt, Sendable {
+    case solid = 0
+    case dashed = 1
+    case dotted = 2
+    case double = 3
+  }
+
+  // MARK: - Storage
+
+  // dimension storage is indexed by Dimension raw value; index 3 is unused like in AppKit
+  private var dimensionValues = [CGFloat](repeating: 0, count: 7)
+  private var dimensionValueTypes = [ValueType](repeating: .absoluteValueType, count: 7)
+
+  // layer storage is indexed by [Layer raw value + 1][edge raw value]
+  private var layerWidths = [[CGFloat]](repeating: [CGFloat](repeating: 0, count: 4), count: 3)
+  private var layerWidthTypes = [[ValueType]](
+    repeating: [ValueType](repeating: .absoluteValueType, count: 4), count: 3)
+
+  // border colors and styles indexed by edge raw value
+  private var borderColors = [DTColor?](repeating: nil, count: 4)
+  private var borderStyles = [BorderStyle](repeating: .solid, count: 4)
+
+  // MARK: - Properties
 
   /// The background color to paint behind the text in the receiver
   @objc public var backgroundColor: DTColor?
 
+  /// The vertical alignment of text within the receiver.
+  @objc public var verticalAlignment: VerticalAlignment = .topAlignment
+
+  /// The space to be applied between the layouted text and the edges of the receiver.
+  ///
+  /// This is a convenience over the `.padding` layer with absolute values: `top` maps to
+  /// the `minYEdge`, `left` to `minXEdge`, `bottom` to `maxYEdge` and `right` to `maxXEdge`.
+  @objc public var padding: DTEdgeInsets {
+    get {
+      return DTEdgeInsets(
+        top: width(for: .padding, edge: .minYEdge),
+        left: width(for: .padding, edge: .minXEdge),
+        bottom: width(for: .padding, edge: .maxYEdge),
+        right: width(for: .padding, edge: .maxXEdge))
+    }
+    set {
+      setWidth(newValue.top, type: .absoluteValueType, for: .padding, edge: .minYEdge)
+      setWidth(newValue.left, type: .absoluteValueType, for: .padding, edge: .minXEdge)
+      setWidth(newValue.bottom, type: .absoluteValueType, for: .padding, edge: .maxYEdge)
+      setWidth(newValue.right, type: .absoluteValueType, for: .padding, edge: .maxXEdge)
+    }
+  }
+
+  // MARK: - Initialization
+
   @objc public override init() {
-    self.padding = DTEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    self.backgroundColor = nil
     super.init()
+  }
+
+  // MARK: - Dimensions
+
+  /// Sets a dimension of the block to the given value of the given value type.
+  @objc(setValue:type:forDimension:)
+  public func setValue(_ val: CGFloat, type: ValueType, for dimension: Dimension) {
+    dimensionValues[Int(dimension.rawValue)] = val
+    dimensionValueTypes[Int(dimension.rawValue)] = type
+  }
+
+  /// The value of the given dimension of the block.
+  @objc(valueForDimension:)
+  public func value(for dimension: Dimension) -> CGFloat {
+    return dimensionValues[Int(dimension.rawValue)]
+  }
+
+  /// The value type of the given dimension of the block.
+  @objc(valueTypeForDimension:)
+  public func valueType(for dimension: Dimension) -> ValueType {
+    return dimensionValueTypes[Int(dimension.rawValue)]
+  }
+
+  /// Convenience for setting the `.width` dimension.
+  @objc(setContentWidth:type:)
+  public func setContentWidth(_ val: CGFloat, type: ValueType) {
+    setValue(val, type: type, for: .width)
+  }
+
+  /// The value of the `.width` dimension.
+  @objc public var contentWidth: CGFloat {
+    return value(for: .width)
+  }
+
+  /// The value type of the `.width` dimension.
+  @objc public var contentWidthValueType: ValueType {
+    return valueType(for: .width)
+  }
+
+  // MARK: - Layer Widths
+
+  /// Sets the width of the given layer at the given edge.
+  @objc(setWidth:type:forLayer:edge:)
+  public func setWidth(_ val: CGFloat, type: ValueType, for layer: Layer, edge: CGRectEdge) {
+    layerWidths[layer.rawValue + 1][Int(edge.rawValue)] = val
+    layerWidthTypes[layer.rawValue + 1][Int(edge.rawValue)] = type
+  }
+
+  /// Sets the width of the given layer at all four edges.
+  @objc(setWidth:type:forLayer:)
+  public func setWidth(_ val: CGFloat, type: ValueType, for layer: Layer) {
+    for edge: CGRectEdge in [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge] {
+      setWidth(val, type: type, for: layer, edge: edge)
+    }
+  }
+
+  /// The width of the given layer at the given edge.
+  @objc(widthForLayer:edge:)
+  public func width(for layer: Layer, edge: CGRectEdge) -> CGFloat {
+    return layerWidths[layer.rawValue + 1][Int(edge.rawValue)]
+  }
+
+  /// The value type of the given layer width at the given edge.
+  @objc(widthValueTypeForLayer:edge:)
+  public func widthValueType(for layer: Layer, edge: CGRectEdge) -> ValueType {
+    return layerWidthTypes[layer.rawValue + 1][Int(edge.rawValue)]
+  }
+
+  // MARK: - Border Colors
+
+  /// Sets the border color at the given edge.
+  @objc(setBorderColor:forEdge:)
+  public func setBorderColor(_ color: DTColor?, for edge: CGRectEdge) {
+    borderColors[Int(edge.rawValue)] = color
+  }
+
+  /// Sets the border color at all four edges.
+  @objc(setBorderColor:)
+  public func setBorderColor(_ color: DTColor?) {
+    for edge: CGRectEdge in [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge] {
+      setBorderColor(color, for: edge)
+    }
+  }
+
+  /// The border color at the given edge.
+  @objc(borderColorForEdge:)
+  public func borderColor(for edge: CGRectEdge) -> DTColor? {
+    return borderColors[Int(edge.rawValue)]
+  }
+
+  // MARK: - Border Styles (DTCoreText extension)
+
+  /// Sets the border style at the given edge.
+  @objc(setBorderStyle:forEdge:)
+  public func setBorderStyle(_ style: BorderStyle, for edge: CGRectEdge) {
+    borderStyles[Int(edge.rawValue)] = style
+  }
+
+  /// Sets the border style at all four edges.
+  @objc(setBorderStyle:)
+  public func setBorderStyle(_ style: BorderStyle) {
+    for edge: CGRectEdge in [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge] {
+      setBorderStyle(style, for: edge)
+    }
+  }
+
+  /// The border style at the given edge.
+  @objc(borderStyleForEdge:)
+  public func borderStyle(for edge: CGRectEdge) -> BorderStyle {
+    return borderStyles[Int(edge.rawValue)]
   }
 
   // MARK: - NSCoding
 
+  // Archive format version. Version 2 added the full NSTextBlock-style properties;
+  // archives without the version key only carry "padding" and "backgroundColor".
+  private static let archiveFormatVersion = 2
+
   @objc public required init?(coder aDecoder: NSCoder) {
-    self.padding = aDecoder.decodeDTEdgeInsets(forKey: "padding")
-    self.backgroundColor = aDecoder.decodeObject(forKey: "backgroundColor") as? DTColor
+    backgroundColor = aDecoder.decodeObject(forKey: "backgroundColor") as? DTColor
+
     super.init()
+
+    if aDecoder.decodeInteger(forKey: "blockFormat") >= 2 {
+      for index in 0..<dimensionValues.count {
+        dimensionValues[index] = CGFloat(aDecoder.decodeDouble(forKey: "dimension.\(index).value"))
+        dimensionValueTypes[index] =
+          ValueType(rawValue: UInt(aDecoder.decodeInteger(forKey: "dimension.\(index).type")))
+          ?? .absoluteValueType
+      }
+
+      for layerIndex in 0..<layerWidths.count {
+        for edgeIndex in 0..<4 {
+          let keyBase = "layer.\(layerIndex - 1).\(edgeIndex)"
+          layerWidths[layerIndex][edgeIndex] = CGFloat(
+            aDecoder.decodeDouble(forKey: "\(keyBase).width"))
+          layerWidthTypes[layerIndex][edgeIndex] =
+            ValueType(rawValue: UInt(aDecoder.decodeInteger(forKey: "\(keyBase).type")))
+            ?? .absoluteValueType
+        }
+      }
+
+      for edgeIndex in 0..<4 {
+        borderColors[edgeIndex] = aDecoder.decodeObject(forKey: "borderColor.\(edgeIndex)")
+          as? DTColor
+        borderStyles[edgeIndex] =
+          BorderStyle(rawValue: UInt(aDecoder.decodeInteger(forKey: "borderStyle.\(edgeIndex)")))
+          ?? .solid
+      }
+
+      verticalAlignment =
+        VerticalAlignment(rawValue: UInt(aDecoder.decodeInteger(forKey: "verticalAlignment")))
+        ?? .topAlignment
+    } else {
+      // legacy archive that only contains padding and background color
+      padding = aDecoder.decodeDTEdgeInsets(forKey: "padding")
+    }
   }
 
   @objc public func encode(with aCoder: NSCoder) {
+    // legacy keys, so that archives stay readable by older versions of DTCoreText
     aCoder.encodeDTEdgeInsets(padding, forKey: "padding")
     aCoder.encode(backgroundColor, forKey: "backgroundColor")
+
+    aCoder.encode(Self.archiveFormatVersion, forKey: "blockFormat")
+
+    for index in 0..<dimensionValues.count {
+      if dimensionValues[index] != 0 {
+        aCoder.encode(Double(dimensionValues[index]), forKey: "dimension.\(index).value")
+      }
+      if dimensionValueTypes[index] != .absoluteValueType {
+        aCoder.encode(Int(dimensionValueTypes[index].rawValue), forKey: "dimension.\(index).type")
+      }
+    }
+
+    for layerIndex in 0..<layerWidths.count {
+      for edgeIndex in 0..<4 {
+        let keyBase = "layer.\(layerIndex - 1).\(edgeIndex)"
+        if layerWidths[layerIndex][edgeIndex] != 0 {
+          aCoder.encode(Double(layerWidths[layerIndex][edgeIndex]), forKey: "\(keyBase).width")
+        }
+        if layerWidthTypes[layerIndex][edgeIndex] != .absoluteValueType {
+          aCoder.encode(
+            Int(layerWidthTypes[layerIndex][edgeIndex].rawValue), forKey: "\(keyBase).type")
+        }
+      }
+    }
+
+    for edgeIndex in 0..<4 {
+      if let color = borderColors[edgeIndex] {
+        aCoder.encode(color, forKey: "borderColor.\(edgeIndex)")
+      }
+      if borderStyles[edgeIndex] != .solid {
+        aCoder.encode(Int(borderStyles[edgeIndex].rawValue), forKey: "borderStyle.\(edgeIndex)")
+      }
+    }
+
+    if verticalAlignment != .topAlignment {
+      aCoder.encode(Int(verticalAlignment.rawValue), forKey: "verticalAlignment")
+    }
   }
 
   // MARK: - Equality & Hashing
 
   public override var hash: Int {
+    // intentionally only based on padding and background color; equal objects hash
+    // equally and unequal objects may collide, which keeps legacy hashes stable
+    let padding = self.padding
     var calcHash = 7
     calcHash = calcHash &* 31 &+ (backgroundColor?.hash ?? 0)
     calcHash = calcHash &* 31 &+ Int(padding.left)
@@ -50,7 +340,7 @@ public class TextBlock: NSObject, NSCoding {
   }
 
   public override func isEqual(_ object: Any?) -> Bool {
-    guard let object = object as? TextBlock else {
+    guard let object = object as? TextBlock, type(of: object) == type(of: self) else {
       return false
     }
 
@@ -58,9 +348,30 @@ public class TextBlock: NSObject, NSCoding {
       return true
     }
 
-    if padding.left != object.padding.left || padding.top != object.padding.top
-      || padding.right != object.padding.right || padding.bottom != object.padding.bottom
+    if dimensionValues != object.dimensionValues
+      || dimensionValueTypes != object.dimensionValueTypes
     {
+      return false
+    }
+
+    if layerWidths != object.layerWidths || layerWidthTypes != object.layerWidthTypes {
+      return false
+    }
+
+    for edgeIndex in 0..<4 {
+      let myColor = borderColors[edgeIndex]
+      let otherColor = object.borderColors[edgeIndex]
+
+      if myColor !== otherColor && !(myColor?.isEqual(otherColor) ?? (otherColor == nil)) {
+        return false
+      }
+    }
+
+    if verticalAlignment != object.verticalAlignment {
+      return false
+    }
+
+    if borderStyles != object.borderStyles {
       return false
     }
 
@@ -71,3 +382,9 @@ public class TextBlock: NSObject, NSCoding {
     return object.backgroundColor == backgroundColor
   }
 }
+
+// Text blocks are built once during parsing and treated as immutable afterwards —
+// the same contract NSAttributedString requires of all attribute values. This makes
+// them safe to carry across concurrency domains, e.g. as typed values inside Swift's
+// `AttributedString`.
+extension TextBlock: @unchecked Sendable {}

--- a/Sources/DTCoreText/TextBlock.swift
+++ b/Sources/DTCoreText/TextBlock.swift
@@ -19,8 +19,13 @@ import Foundation
 /// Edges are identified by `CGRectEdge`, which has the same raw values as the `NSRectEdge`
 /// used by `NSTextBlock` (`minXEdge` = leading/left, `minYEdge` = top, `maxXEdge` =
 /// trailing/right, `maxYEdge` = bottom in the flipped text coordinate system).
+///
+/// Text blocks are built once during parsing and treated as immutable afterwards — the
+/// same contract `NSAttributedString` requires of all attribute values. This makes them
+/// safe to carry across concurrency domains, e.g. as typed values inside Swift's
+/// `AttributedString`, hence the `@unchecked Sendable` conformance.
 @objc(DTTextBlock)
-public class TextBlock: NSObject, NSCoding {
+public class TextBlock: NSObject, NSCoding, @unchecked Sendable {
 
   // MARK: - Constants
 
@@ -382,9 +387,3 @@ public class TextBlock: NSObject, NSCoding {
     return object.backgroundColor == backgroundColor
   }
 }
-
-// Text blocks are built once during parsing and treated as immutable afterwards —
-// the same contract NSAttributedString requires of all attribute values. This makes
-// them safe to carry across concurrency domains, e.g. as typed values inside Swift's
-// `AttributedString`.
-extension TextBlock: @unchecked Sendable {}

--- a/Sources/DTCoreText/TextBlockConverter.swift
+++ b/Sources/DTCoreText/TextBlockConverter.swift
@@ -1,0 +1,219 @@
+//
+//  TextBlockConverter.swift
+//  DTCoreText
+//
+//  Created by Oliver Drobnik on 11.06.26.
+//  Copyright (c) 2026 Drobnik.com. All rights reserved.
+//
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+
+  import AppKit
+
+  /// Converts between the DT text block model classes and their AppKit counterparts.
+  ///
+  /// The system expresses table membership through shared instances: all paragraphs of one
+  /// cell share one `NSTextTableBlock` and all cells of one table share one `NSTextTable`.
+  /// A converter instance therefore caches every object it has converted and returns the
+  /// same output instance for the same input instance. Use one converter per attributed
+  /// string (or per document) so that this identity mapping is preserved across paragraphs.
+  ///
+  /// On iOS 27 and later the same conversions will be provided for the then-native UIKit
+  /// counterparts of these classes.
+  @objc(DTTextBlockConverter)
+  public final class TextBlockConverter: NSObject {
+
+    private static let allDimensions: [TextBlock.Dimension] = [
+      .width, .minimumWidth, .maximumWidth, .height, .minimumHeight, .maximumHeight,
+    ]
+
+    private static let allLayers: [TextBlock.Layer] = [.padding, .border, .margin]
+
+    private static let allEdges: [CGRectEdge] = [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge]
+
+    // identity maps for both directions
+    private var nsTablesByTable = [ObjectIdentifier: NSTextTable]()
+    private var tablesByNSTable = [ObjectIdentifier: TextTable]()
+    private var nsBlocksByBlock = [ObjectIdentifier: NSTextBlock]()
+    private var blocksByNSBlock = [ObjectIdentifier: TextBlock]()
+
+    // MARK: - Converting to AppKit
+
+    /// Converts a ``TextBlock``, ``TextTable`` or ``TextTableBlock`` to its AppKit counterpart.
+    ///
+    /// Repeated calls with the same instance return the same output instance.
+    @objc public func nsTextBlock(from block: TextBlock) -> NSTextBlock {
+      if let existing = nsBlocksByBlock[ObjectIdentifier(block)] {
+        return existing
+      }
+
+      let result: NSTextBlock
+
+      if let tableBlock = block as? TextTableBlock {
+        result = NSTextTableBlock(
+          table: nsTextTable(from: tableBlock.table),
+          startingRow: tableBlock.startingRow,
+          rowSpan: tableBlock.rowSpan,
+          startingColumn: tableBlock.startingColumn,
+          columnSpan: tableBlock.columnSpan)
+      } else if let table = block as? TextTable {
+        return nsTextTable(from: table)
+      } else {
+        result = NSTextBlock()
+      }
+
+      Self.copyProperties(from: block, to: result)
+      nsBlocksByBlock[ObjectIdentifier(block)] = result
+
+      return result
+    }
+
+    /// Converts a ``TextTable`` to an `NSTextTable`.
+    ///
+    /// Repeated calls with the same instance return the same output instance.
+    @objc public func nsTextTable(from table: TextTable) -> NSTextTable {
+      if let existing = nsTablesByTable[ObjectIdentifier(table)] {
+        return existing
+      }
+
+      let result = NSTextTable()
+      result.numberOfColumns = table.numberOfColumns
+      result.layoutAlgorithm =
+        NSTextTable.LayoutAlgorithm(rawValue: table.layoutAlgorithm.rawValue)
+        ?? .automaticLayoutAlgorithm
+      result.collapsesBorders = table.collapsesBorders
+      result.hidesEmptyCells = table.hidesEmptyCells
+
+      Self.copyProperties(from: table, to: result)
+      nsTablesByTable[ObjectIdentifier(table)] = result
+
+      return result
+    }
+
+    /// Converts an array of blocks, e.g. the `textBlocks` of one paragraph style.
+    @objc public func nsTextBlocks(from blocks: [TextBlock]) -> [NSTextBlock] {
+      return blocks.map { nsTextBlock(from: $0) }
+    }
+
+    // MARK: - Converting from AppKit
+
+    /// Converts an `NSTextBlock`, `NSTextTable` or `NSTextTableBlock` to its DT counterpart.
+    ///
+    /// Repeated calls with the same instance return the same output instance.
+    @objc public func textBlock(from nsBlock: NSTextBlock) -> TextBlock {
+      if let existing = blocksByNSBlock[ObjectIdentifier(nsBlock)] {
+        return existing
+      }
+
+      let result: TextBlock
+
+      if let nsTableBlock = nsBlock as? NSTextTableBlock {
+        result = TextTableBlock(
+          table: textTable(from: nsTableBlock.table),
+          startingRow: nsTableBlock.startingRow,
+          rowSpan: nsTableBlock.rowSpan,
+          startingColumn: nsTableBlock.startingColumn,
+          columnSpan: nsTableBlock.columnSpan)
+      } else if let nsTable = nsBlock as? NSTextTable {
+        return textTable(from: nsTable)
+      } else {
+        result = TextBlock()
+      }
+
+      Self.copyProperties(from: nsBlock, to: result)
+      blocksByNSBlock[ObjectIdentifier(nsBlock)] = result
+
+      return result
+    }
+
+    /// Converts an `NSTextTable` to a ``TextTable``.
+    ///
+    /// Repeated calls with the same instance return the same output instance.
+    @objc public func textTable(from nsTable: NSTextTable) -> TextTable {
+      if let existing = tablesByNSTable[ObjectIdentifier(nsTable)] {
+        return existing
+      }
+
+      let result = TextTable()
+      result.numberOfColumns = nsTable.numberOfColumns
+      result.layoutAlgorithm =
+        TextTable.LayoutAlgorithm(rawValue: nsTable.layoutAlgorithm.rawValue)
+        ?? .automaticLayoutAlgorithm
+      result.collapsesBorders = nsTable.collapsesBorders
+      result.hidesEmptyCells = nsTable.hidesEmptyCells
+
+      Self.copyProperties(from: nsTable, to: result)
+      tablesByNSTable[ObjectIdentifier(nsTable)] = result
+
+      return result
+    }
+
+    /// Converts an array of blocks, e.g. the `textBlocks` of one `NSParagraphStyle`.
+    @objc public func textBlocks(from nsBlocks: [NSTextBlock]) -> [TextBlock] {
+      return nsBlocks.map { textBlock(from: $0) }
+    }
+
+    // MARK: - Property Copying
+
+    private static func nsEdge(for edge: CGRectEdge) -> NSRectEdge {
+      return NSRectEdge(rawValue: UInt(edge.rawValue))!
+    }
+
+    private static func copyProperties(from block: TextBlock, to nsBlock: NSTextBlock) {
+      for dimension in allDimensions {
+        let nsDimension = NSTextBlock.Dimension(rawValue: dimension.rawValue)!
+        let nsType = NSTextBlock.ValueType(rawValue: block.valueType(for: dimension).rawValue)!
+        nsBlock.setValue(block.value(for: dimension), type: nsType, for: nsDimension)
+      }
+
+      for layer in allLayers {
+        let nsLayer = NSTextBlock.Layer(rawValue: layer.rawValue)!
+
+        for edge in allEdges {
+          let nsType = NSTextBlock.ValueType(
+            rawValue: block.widthValueType(for: layer, edge: edge).rawValue)!
+          nsBlock.setWidth(
+            block.width(for: layer, edge: edge), type: nsType, for: nsLayer, edge: nsEdge(for: edge)
+          )
+        }
+      }
+
+      for edge in allEdges {
+        nsBlock.setBorderColor(block.borderColor(for: edge), for: nsEdge(for: edge))
+      }
+
+      nsBlock.backgroundColor = block.backgroundColor
+      nsBlock.verticalAlignment =
+        NSTextBlock.VerticalAlignment(rawValue: block.verticalAlignment.rawValue) ?? .topAlignment
+    }
+
+    private static func copyProperties(from nsBlock: NSTextBlock, to block: TextBlock) {
+      for dimension in allDimensions {
+        let nsDimension = NSTextBlock.Dimension(rawValue: dimension.rawValue)!
+        let type = TextBlock.ValueType(rawValue: nsBlock.valueType(for: nsDimension).rawValue)!
+        block.setValue(nsBlock.value(for: nsDimension), type: type, for: dimension)
+      }
+
+      for layer in allLayers {
+        let nsLayer = NSTextBlock.Layer(rawValue: layer.rawValue)!
+
+        for edge in allEdges {
+          let type = TextBlock.ValueType(
+            rawValue: nsBlock.widthValueType(for: nsLayer, edge: nsEdge(for: edge)).rawValue)!
+          block.setWidth(
+            nsBlock.width(for: nsLayer, edge: nsEdge(for: edge)), type: type, for: layer, edge: edge
+          )
+        }
+      }
+
+      for edge in allEdges {
+        block.setBorderColor(nsBlock.borderColor(for: nsEdge(for: edge)), for: edge)
+      }
+
+      block.backgroundColor = nsBlock.backgroundColor
+      block.verticalAlignment =
+        TextBlock.VerticalAlignment(rawValue: nsBlock.verticalAlignment.rawValue) ?? .topAlignment
+    }
+  }
+
+#endif

--- a/Sources/DTCoreText/TextTable.swift
+++ b/Sources/DTCoreText/TextTable.swift
@@ -14,7 +14,7 @@ import Foundation
 /// instance is shared by all cells (``TextTableBlock``) of the same table; the shared
 /// instance is what groups cells into a table, so it must not be copied or deduplicated.
 @objc(DTTextTable)
-public class TextTable: TextBlock {
+public class TextTable: TextBlock, @unchecked Sendable {
 
   /// The table layout algorithm. Mirrors `NSTextTable.LayoutAlgorithm`.
   @objc(DTTextTableLayoutAlgorithm)

--- a/Sources/DTCoreText/TextTable.swift
+++ b/Sources/DTCoreText/TextTable.swift
@@ -1,0 +1,81 @@
+//
+//  TextTable.swift
+//  DTCoreText
+//
+//  Created by Oliver Drobnik on 11.06.26.
+//  Copyright (c) 2026 Drobnik.com. All rights reserved.
+//
+
+import Foundation
+
+/// Class that represents a table of text blocks.
+///
+/// The API mirrors AppKit's `NSTextTable` (which iOS gains natively with iOS 27). One
+/// instance is shared by all cells (``TextTableBlock``) of the same table; the shared
+/// instance is what groups cells into a table, so it must not be copied or deduplicated.
+@objc(DTTextTable)
+public class TextTable: TextBlock {
+
+  /// The table layout algorithm. Mirrors `NSTextTable.LayoutAlgorithm`.
+  @objc(DTTextTableLayoutAlgorithm)
+  public enum LayoutAlgorithm: UInt, Sendable {
+    /// Column widths are determined by the content of the cells.
+    case automaticLayoutAlgorithm = 0
+    /// Column widths are fixed, based on the first row of the table.
+    case fixedLayoutAlgorithm = 1
+  }
+
+  /// The number of columns in the table, including columns covered by spans.
+  @objc public var numberOfColumns: Int = 0
+
+  /// The algorithm to use when distributing column widths.
+  @objc public var layoutAlgorithm: LayoutAlgorithm = .automaticLayoutAlgorithm
+
+  /// Whether the borders of adjacent cells collapse into a single border.
+  @objc public var collapsesBorders: Bool = false
+
+  /// Whether cells without content are rendered.
+  @objc public var hidesEmptyCells: Bool = false
+
+  // MARK: - Initialization
+
+  @objc public override init() {
+    super.init()
+  }
+
+  // MARK: - NSCoding
+
+  @objc public required init?(coder aDecoder: NSCoder) {
+    numberOfColumns = aDecoder.decodeInteger(forKey: "numberOfColumns")
+    layoutAlgorithm =
+      LayoutAlgorithm(rawValue: UInt(aDecoder.decodeInteger(forKey: "layoutAlgorithm")))
+      ?? .automaticLayoutAlgorithm
+    collapsesBorders = aDecoder.decodeBool(forKey: "collapsesBorders")
+    hidesEmptyCells = aDecoder.decodeBool(forKey: "hidesEmptyCells")
+
+    super.init(coder: aDecoder)
+  }
+
+  @objc public override func encode(with aCoder: NSCoder) {
+    super.encode(with: aCoder)
+
+    aCoder.encode(numberOfColumns, forKey: "numberOfColumns")
+    aCoder.encode(Int(layoutAlgorithm.rawValue), forKey: "layoutAlgorithm")
+    aCoder.encode(collapsesBorders, forKey: "collapsesBorders")
+    aCoder.encode(hidesEmptyCells, forKey: "hidesEmptyCells")
+  }
+
+  // MARK: - Equality
+
+  // Identity equality, matching NSTextTable. This is load-bearing: Foundation uniques
+  // value-equal attribute dictionaries globally across attributed strings, so two
+  // equal-by-value tables would get merged into one shared instance, destroying the
+  // identity grouping that defines which cells belong to which table.
+  public override func isEqual(_ object: Any?) -> Bool {
+    return (object as AnyObject?) === self
+  }
+
+  public override var hash: Int {
+    return ObjectIdentifier(self).hashValue
+  }
+}

--- a/Sources/DTCoreText/TextTableBlock.swift
+++ b/Sources/DTCoreText/TextTableBlock.swift
@@ -1,0 +1,88 @@
+//
+//  TextTableBlock.swift
+//  DTCoreText
+//
+//  Created by Oliver Drobnik on 11.06.26.
+//  Copyright (c) 2026 Drobnik.com. All rights reserved.
+//
+
+import Foundation
+
+/// Class that represents one cell of a ``TextTable``.
+///
+/// The API mirrors AppKit's `NSTextTableBlock` (which iOS gains natively with iOS 27).
+/// All paragraphs belonging to the same cell share one instance; the cells of one table
+/// all reference the same shared ``TextTable`` instance.
+@objc(DTTextTableBlock)
+public class TextTableBlock: TextBlock {
+
+  /// The table that the cell belongs to.
+  @objc public private(set) var table: TextTable
+
+  /// The first row of the table grid that the cell covers (0-based).
+  @objc public private(set) var startingRow: Int
+
+  /// The number of rows that the cell covers.
+  @objc public private(set) var rowSpan: Int
+
+  /// The first column of the table grid that the cell covers (0-based).
+  @objc public private(set) var startingColumn: Int
+
+  /// The number of columns that the cell covers.
+  @objc public private(set) var columnSpan: Int
+
+  // MARK: - Initialization
+
+  /// Creates a cell block covering the given grid area of the given table.
+  @objc(initWithTable:startingRow:rowSpan:startingColumn:columnSpan:)
+  public init(table: TextTable, startingRow: Int, rowSpan: Int, startingColumn: Int, columnSpan: Int) {
+    self.table = table
+    self.startingRow = startingRow
+    self.rowSpan = rowSpan
+    self.startingColumn = startingColumn
+    self.columnSpan = columnSpan
+
+    super.init()
+  }
+
+  // MARK: - NSCoding
+
+  @objc public required init?(coder aDecoder: NSCoder) {
+    guard let table = aDecoder.decodeObject(forKey: "table") as? TextTable else {
+      return nil
+    }
+
+    self.table = table
+    startingRow = aDecoder.decodeInteger(forKey: "startingRow")
+    rowSpan = aDecoder.decodeInteger(forKey: "rowSpan")
+    startingColumn = aDecoder.decodeInteger(forKey: "startingColumn")
+    columnSpan = aDecoder.decodeInteger(forKey: "columnSpan")
+
+    super.init(coder: aDecoder)
+  }
+
+  @objc public override func encode(with aCoder: NSCoder) {
+    super.encode(with: aCoder)
+
+    aCoder.encode(table, forKey: "table")
+    aCoder.encode(startingRow, forKey: "startingRow")
+    aCoder.encode(rowSpan, forKey: "rowSpan")
+    aCoder.encode(startingColumn, forKey: "startingColumn")
+    aCoder.encode(columnSpan, forKey: "columnSpan")
+  }
+
+  // MARK: - Equality
+
+  // Identity equality, matching NSTextTableBlock. This is load-bearing: Foundation
+  // uniques value-equal attribute dictionaries globally across attributed strings, so
+  // two equal-by-value cell blocks (even from different documents!) would get merged
+  // into one shared instance, destroying the identity grouping that defines which
+  // paragraphs belong to which cell.
+  public override func isEqual(_ object: Any?) -> Bool {
+    return (object as AnyObject?) === self
+  }
+
+  public override var hash: Int {
+    return ObjectIdentifier(self).hashValue
+  }
+}

--- a/Sources/DTCoreText/TextTableBlock.swift
+++ b/Sources/DTCoreText/TextTableBlock.swift
@@ -14,7 +14,7 @@ import Foundation
 /// All paragraphs belonging to the same cell share one instance; the cells of one table
 /// all reference the same shared ``TextTable`` instance.
 @objc(DTTextTableBlock)
-public class TextTableBlock: TextBlock {
+public class TextTableBlock: TextBlock, @unchecked Sendable {
 
   /// The table that the cell belongs to.
   @objc public private(set) var table: TextTable

--- a/Sources/DTCoreText/default.css
+++ b/Sources/DTCoreText/default.css
@@ -263,5 +263,30 @@ table {
    display: table;
    border-collapse: separate;
    border-spacing: 2px;
-   border-color: gray;
+}
+
+caption {
+   display: block;
+   text-align: center;
+}
+
+thead, tbody, tfoot {
+   display: table-row-group;
+}
+
+tr {
+   display: table-row;
+}
+
+td, th {
+   display: table-cell;
+}
+
+th {
+   font-weight: bold;
+   text-align: center;
+}
+
+col, colgroup {
+   display: none;
 }

--- a/Tests/DTCoreTextTests/AttributedStringSwiftUITests.swift
+++ b/Tests/DTCoreTextTests/AttributedStringSwiftUITests.swift
@@ -187,11 +187,10 @@ struct AttributedStringSwiftUITests {
 
     let run = attrStr.runs.first
     #expect(run?[DTHeaderLevelKey.self] == 3)
-    // Font should be present via UIKit scope
-    #if canImport(UIKit)
-      #expect(run?[AttributeScopes.UIKitAttributes.FontAttribute.self] != nil)
-    #elseif canImport(AppKit)
-      #expect(run?[AttributeScopes.AppKitAttributes.FontAttribute.self] != nil)
-    #endif
+    // the font survives via the platform scope; checked through the NS conversion
+    // because the typed font subscript trips the unavailable Sendable conformance
+    // of UIFont/NSFont
+    let nsAttributedString = try NSAttributedString(attrStr, including: \.dtCoreText)
+    #expect(nsAttributedString.attribute(.font, at: 0, effectiveRange: nil) != nil)
   }
 }

--- a/Tests/DTCoreTextTests/AttributedStringSwiftUITests.swift
+++ b/Tests/DTCoreTextTests/AttributedStringSwiftUITests.swift
@@ -61,7 +61,7 @@ struct AttributedStringSwiftUITests {
     let html = "<div style=\"padding: 10px; background-color: red;\">Block text</div>"
     let attrStr = try AttributedString(htmlData: Data(html.utf8))
 
-    var foundBlocks: NSArray?
+    var foundBlocks: [TextBlock]?
     for run in attrStr.runs {
       if let blocks = run[DTTextBlocksKey.self] {
         foundBlocks = blocks
@@ -70,7 +70,80 @@ struct AttributedStringSwiftUITests {
     }
     #expect(foundBlocks != nil)
     #expect((foundBlocks?.count ?? 0) > 0)
-    #expect(foundBlocks?.firstObject is TextBlock)
+  }
+
+  @Test("Tables survive conversion to AttributedString with identity intact")
+  func tableToAttributedString() throws {
+    let html =
+      "<table><tr><td><p>One</p><p>Two</p></td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>"
+    let attrStr = try AttributedString(htmlData: Data(html.utf8))
+
+    // collect distinct cells in run order via the typed key
+    var cells = [TextTableBlock]()
+    for run in attrStr.runs {
+      guard let blocks = run[DTTextBlocksKey.self] else { continue }
+      for case let cell as TextTableBlock in blocks
+      where !cells.contains(where: { $0 === cell }) {
+        cells.append(cell)
+      }
+    }
+
+    try #require(cells.count == 4)
+
+    // the shared table instance survives the conversion — this is what groups
+    // the cells into one grid
+    let table = cells[0].table
+    #expect(cells.allSatisfy { $0.table === table })
+    #expect(table.numberOfColumns == 2)
+    #expect(cells.map { $0.startingRow } == [0, 0, 1, 1])
+    #expect(cells.map { $0.startingColumn } == [0, 1, 0, 1])
+
+    // the multi-paragraph cell appears as one instance across its runs
+    let firstCellRuns = attrStr.runs.filter { run in
+      run[DTTextBlocksKey.self]?.contains(where: { $0 === cells[0] }) ?? false
+    }
+    #expect(firstCellRuns.count >= 1)
+  }
+
+  @Test("Tables survive the round trip back to NSAttributedString and lay out")
+  func tableRoundTripBackAndLayout() throws {
+    let html = "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>"
+    let attrStr = try AttributedString(htmlData: Data(html.utf8))
+    let roundTripped = try NSAttributedString(attrStr, including: \.dtCoreText)
+
+    #expect(roundTripped.string == "A1\nB1\nA2\nB2\n")
+
+    // structure and identity intact after the round trip
+    var cells = [TextTableBlock]()
+    roundTripped.enumerateAttribute(
+      NSAttributedString.Key(rawValue: DTTextBlocksAttribute),
+      in: NSRange(location: 0, length: roundTripped.length)
+    ) { value, _, _ in
+      guard let blocks = value as? [TextBlock] else { return }
+      for case let cell as TextTableBlock in blocks
+      where !cells.contains(where: { $0 === cell }) {
+        cells.append(cell)
+      }
+    }
+
+    try #require(cells.count == 4)
+    #expect(cells.allSatisfy { $0.table === cells[0].table })
+
+    // the round-tripped string still lays out as a grid
+    let layouter = try #require(CoreTextLayouter(attributedString: roundTripped))
+    let maxRect = CGRect(x: 0, y: 0, width: 400, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+    let frame = try #require(
+      layouter.layoutFrame(
+        with: maxRect, range: NSRange(location: 0, length: roundTripped.length)))
+
+    let nsString = roundTripped.string as NSString
+    let lineA1 = try #require(
+      frame.lineContaining(index: UInt(nsString.range(of: "A1").location)))
+    let lineB1 = try #require(
+      frame.lineContaining(index: UInt(nsString.range(of: "B1").location)))
+
+    #expect(abs(lineA1.baselineOrigin.y - lineB1.baselineOrigin.y) < 1)
+    #expect(lineB1.frame.minX > lineA1.frame.maxX - 1)
   }
 
   @Test("Field attribute round-trips through AttributedString")

--- a/Tests/DTCoreTextTests/CSSStylesheetTests.swift
+++ b/Tests/DTCoreTextTests/CSSStylesheetTests.swift
@@ -134,7 +134,9 @@ struct CSSStylesheetTests {
 		]
 
 		for cssStr in testCases {
-			let stylesheet = CSSStylesheet.defaultStyleSheet()
+			// must operate on a copy: mutating the shared default stylesheet races
+			// against concurrent test suites copying it for HTML parsing
+			let stylesheet = CSSStylesheet.defaultStyleSheet().copy() as! CSSStylesheet
 			stylesheet.parseStyleBlock(cssStr)
 			let s1Styles = stylesForSelector("s1", in: stylesheet)
 			let s2Styles = stylesForSelector("s2", in: stylesheet)

--- a/Tests/DTCoreTextTests/TableIdentityStressTests.swift
+++ b/Tests/DTCoreTextTests/TableIdentityStressTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import DTCoreText
+
+/// Foundation uniques value-equal attribute dictionaries globally, across attributed
+/// strings. If table blocks compared by value, concurrent parses would bleed table
+/// instances into each other's output (and equal-styled tables within one document
+/// would merge). Identity-based equality on TextTable/TextTableBlock prevents this;
+/// this test locks that behavior in.
+@Suite("Table Identity Under Concurrency") struct TableIdentityStressTests {
+  @Test("Concurrent parses keep distinct table identities")
+  func stressParallelTableParsing() async throws {
+    let html =
+      "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>"
+
+    let failures = await withTaskGroup(of: String?.self, returning: [String].self) { group in
+      for index in 0..<64 {
+        group.addTask {
+          guard let attributedString = TestHelpers.attributedString(fromHTML: html) else {
+            return "run \(index): no result"
+          }
+
+          let nsString = attributedString.string as NSString
+          var tables = [TextTable]()
+          var cellCount = 0
+          var location = 0
+
+          while location < nsString.length {
+            let paragraphRange = nsString.paragraphRange(
+              for: NSRange(location: location, length: 0))
+            if let blocks = attributedString.attribute(
+              NSAttributedString.Key(rawValue: DTTextBlocksAttribute),
+              at: paragraphRange.location, effectiveRange: nil) as? [TextBlock],
+              let cell = blocks.first as? TextTableBlock
+            {
+              cellCount += 1
+              if !tables.contains(where: { $0 === cell.table }) {
+                tables.append(cell.table)
+              }
+            }
+            location = NSMaxRange(paragraphRange)
+          }
+
+          if tables.count != 1 || cellCount != 4 {
+            let coords = (0..<nsString.length).compactMap { _ in "" }
+            _ = coords
+            return
+              "run \(index): string=\(attributedString.string.replacingOccurrences(of: "\n", with: "|")) tables=\(tables.count) cells=\(cellCount) columns=\(tables.map { $0.numberOfColumns })"
+          }
+          return nil
+        }
+      }
+
+      var collected = [String]()
+      for await failure in group {
+        if let failure { collected.append(failure) }
+      }
+      return collected
+    }
+
+    for failure in failures {
+      print("STRESS FAILURE: \(failure)")
+    }
+    #expect(failures.isEmpty, "\(failures.count) of 64 parses produced wrong structure")
+  }
+}

--- a/Tests/DTCoreTextTests/TableLayoutTests.swift
+++ b/Tests/DTCoreTextTests/TableLayoutTests.swift
@@ -276,6 +276,93 @@ struct TableLayoutTests {
     #expect(separated >= 5)
   }
 
+  // MARK: - Pagination
+
+  @Test("Tall tables paginate row by row across finite-height frames")
+  func tablePagination() throws {
+    let rows = (1...6).map { "<tr><td>A\($0)</td><td>B\($0)</td></tr>" }.joined()
+    let attributedString = try #require(
+      TestHelpers.attributedString(fromHTML: "<table border=\"1\">\(rows)</table>"))
+    let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+    let fullRange = NSRange(location: 0, length: attributedString.length)
+
+    // a frame that fits roughly three rows
+    let firstFrame = try #require(
+      layouter.layoutFrame(with: CGRect(x: 0, y: 0, width: 300, height: 60), range: fullRange))
+
+    let firstVisible = firstFrame.visibleStringRange()
+    #expect(firstVisible.length > 0)
+    #expect(firstVisible.length < attributedString.length)
+
+    // every consumed line stays within the frame
+    let firstLines = try #require(firstFrame.lines as? [CoreTextLayoutLine])
+    for line in firstLines {
+      #expect(line.frame.maxY <= 60 + 1)
+    }
+
+    // the continuation frame consumes the remaining rows and still forms a grid
+    let continuationStart = NSMaxRange(firstVisible)
+    let secondFrame = try #require(
+      layouter.layoutFrame(
+        with: CGRect(x: 0, y: 0, width: 300, height: 400),
+        range: NSRange(
+          location: continuationStart, length: attributedString.length - continuationStart)))
+
+    let secondVisible = secondFrame.visibleStringRange()
+    #expect(NSMaxRange(secondVisible) == attributedString.length)
+
+    let nsString = attributedString.string as NSString
+    let rangeA6 = nsString.range(of: "A6")
+    let rangeB6 = nsString.range(of: "B6")
+    try #require(rangeA6.location >= continuationStart, "A6 must be on the second page")
+
+    let lineA6 = try #require(secondFrame.lineContaining(index: UInt(rangeA6.location)))
+    let lineB6 = try #require(secondFrame.lineContaining(index: UInt(rangeB6.location)))
+
+    // the continued rows still lay out side by side
+    #expect(abs(lineA6.baselineOrigin.y - lineB6.baselineOrigin.y) < 1)
+    #expect(lineB6.frame.minX > lineA6.frame.maxX - 1)
+  }
+
+  @Test("A table that does not fit at all moves entirely to the next frame")
+  func tableMovesToNextFrame() throws {
+    let attributedString = try #require(
+      TestHelpers.attributedString(
+        fromHTML: "<p>Intro text</p><table border=\"1\"><tr><td>A1</td><td>B1</td></tr>"
+          + "<tr><td>A2</td><td>B2</td></tr></table>"))
+    let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+    let fullRange = NSRange(location: 0, length: attributedString.length)
+
+    // fits the intro line but not a single table row
+    let firstFrame = try #require(
+      layouter.layoutFrame(with: CGRect(x: 0, y: 0, width: 300, height: 24), range: fullRange))
+
+    let firstVisible = firstFrame.visibleStringRange()
+    let tableStart = (attributedString.string as NSString).range(of: "A1").location
+    #expect(NSMaxRange(firstVisible) <= tableStart)
+    #expect(firstVisible.length > 0)
+  }
+
+  @Test("A frame consumes at least the first table row to guarantee progress")
+  func tableForcedFirstRow() throws {
+    let attributedString = try #require(
+      TestHelpers.attributedString(
+        fromHTML: "<table border=\"1\"><tr><td>A1<br>two<br>three</td></tr>"
+          + "<tr><td>A2</td></tr></table>"))
+    let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+    let fullRange = NSRange(location: 0, length: attributedString.length)
+
+    // far too small for even the first row — it must be consumed anyway
+    let frame = try #require(
+      layouter.layoutFrame(with: CGRect(x: 0, y: 0, width: 300, height: 10), range: fullRange))
+
+    let visible = frame.visibleStringRange()
+    #expect(visible.length > 0)
+
+    let secondRowStart = (attributedString.string as NSString).range(of: "A2").location
+    #expect(NSMaxRange(visible) <= secondRowStart)
+  }
+
   // MARK: - Drawing
 
   @Test("Drawing a table with backgrounds and borders does not crash and paints")

--- a/Tests/DTCoreTextTests/TableLayoutTests.swift
+++ b/Tests/DTCoreTextTests/TableLayoutTests.swift
@@ -1,0 +1,318 @@
+import CoreText
+import Foundation
+import Testing
+
+@testable import DTCoreText
+
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
+/// Tests for grid layout of tables in `CoreTextLayoutFrame`.
+@Suite("Table Layout", .serialized)
+struct TableLayoutTests {
+
+  // MARK: - Helpers
+
+  private func layoutFrame(
+    html: String, width: CGFloat = 400
+  ) throws -> (frame: CoreTextLayoutFrame, string: NSAttributedString) {
+    let attributedString = try #require(TestHelpers.attributedString(fromHTML: html))
+    let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+
+    let maxRect = CGRect(x: 0, y: 0, width: width, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+    let entireString = NSRange(location: 0, length: attributedString.length)
+    let frame = try #require(layouter.layoutFrame(with: maxRect, range: entireString))
+
+    return (frame, attributedString)
+  }
+
+  private func line(
+    containing text: String, in layoutFrame: CoreTextLayoutFrame,
+    of attributedString: NSAttributedString
+  ) throws -> CoreTextLayoutLine {
+    let nsString = attributedString.string as NSString
+    let range = nsString.range(of: text)
+    try #require(range.location != NSNotFound, "text \(text) not found")
+    return try #require(layoutFrame.lineContaining(index: UInt(range.location)))
+  }
+
+  // MARK: - Grid Geometry
+
+  @Test("Cells of one row sit side by side, rows stack vertically")
+  func basicGrid() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>")
+
+    let lineA1 = try line(containing: "A1", in: frame, of: string)
+    let lineB1 = try line(containing: "B1", in: frame, of: string)
+    let lineA2 = try line(containing: "A2", in: frame, of: string)
+    let lineB2 = try line(containing: "B2", in: frame, of: string)
+
+    // same row: identical baseline, second column to the right
+    #expect(abs(lineA1.baselineOrigin.y - lineB1.baselineOrigin.y) < 1)
+    #expect(lineB1.frame.minX > lineA1.frame.maxX - 1)
+
+    // second row strictly below the first
+    #expect(lineA2.frame.minY >= lineA1.frame.maxY - 1)
+    #expect(abs(lineA2.baselineOrigin.y - lineB2.baselineOrigin.y) < 1)
+
+    // columns align across rows
+    #expect(abs(lineA1.frame.minX - lineA2.frame.minX) < 1)
+    #expect(abs(lineB1.frame.minX - lineB2.frame.minX) < 1)
+
+    // the auto-sized frame includes both rows
+    #expect(frame.frame.size.height > lineA2.frame.maxY - frame.frame.origin.y - 1)
+  }
+
+  @Test("Fixed layout splits the explicit table width equally")
+  func fixedLayoutWidths() throws {
+    let (frame, string) = try layoutFrame(
+      html:
+        "<table style=\"table-layout: fixed; width: 300px\"><tr><td>A</td><td>B</td></tr></table>")
+
+    let lineA = try line(containing: "A", in: frame, of: string)
+    let lineB = try line(containing: "B", in: frame, of: string)
+
+    // each column is 150pt wide; the second cell's content starts one
+    // cell margin + padding after the column boundary
+    #expect(abs((lineB.frame.minX - lineA.frame.minX) - 150) < 2)
+  }
+
+  @Test("Explicit cell widths are honored")
+  func explicitCellWidths() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<table><tr><td width=\"120\">A</td><td>B</td></tr></table>")
+
+    let lineA = try line(containing: "A", in: frame, of: string)
+    let lineB = try line(containing: "B", in: frame, of: string)
+
+    // first column is 120pt content + 3pt box extras
+    #expect(abs((lineB.frame.minX - lineA.frame.minX) - 123) < 2)
+  }
+
+  @Test("Vertical alignment moves cell content within the row")
+  func verticalAlignment() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<table><tr><td>first line<br>second line</td>"
+        + "<td valign=\"top\">topcell</td><td valign=\"bottom\">bottomcell</td></tr></table>")
+
+    let lineFirst = try line(containing: "first line", in: frame, of: string)
+    let lineSecond = try line(containing: "second line", in: frame, of: string)
+    let lineTop = try line(containing: "topcell", in: frame, of: string)
+    let lineBottom = try line(containing: "bottomcell", in: frame, of: string)
+
+    // the tall cell defines the row height
+    #expect(lineSecond.frame.minY > lineFirst.frame.minY)
+
+    // top-aligned cell aligns with the first line, bottom-aligned with the last
+    #expect(abs(lineTop.baselineOrigin.y - lineFirst.baselineOrigin.y) < 2)
+    #expect(lineBottom.baselineOrigin.y > lineTop.baselineOrigin.y)
+    #expect(abs(lineBottom.frame.maxY - lineSecond.frame.maxY) < 3)
+  }
+
+  @Test("Baseline-aligned cells share the first baseline across the row")
+  func baselineAlignment() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<table><tr>"
+        + "<td style=\"vertical-align: baseline; font-size: 36px\">BIG</td>"
+        + "<td style=\"vertical-align: baseline\">small</td>"
+        + "<td valign=\"baseline\">attr</td></tr></table>")
+
+    let lineBig = try line(containing: "BIG", in: frame, of: string)
+    let lineSmall = try line(containing: "small", in: frame, of: string)
+    let lineAttr = try line(containing: "attr", in: frame, of: string)
+
+    // per NSTextBlock documentation, adjacent baseline-aligned blocks align at the
+    // baseline of their first line of text
+    #expect(abs(lineBig.baselineOrigin.y - lineSmall.baselineOrigin.y) < 1)
+    #expect(abs(lineBig.baselineOrigin.y - lineAttr.baselineOrigin.y) < 1)
+
+    // the small cells are pushed down, not the big one up
+    #expect(lineSmall.frame.minY > lineBig.frame.minY)
+  }
+
+  @Test("Justified text inside cells stretches to the cell width")
+  func justifiedCellText() throws {
+    let words = Array(repeating: "word", count: 30).joined(separator: " ")
+    let (frame, string) = try layoutFrame(
+      html: "<table><tr><td width=\"200\" style=\"text-align: justify\">\(words)</td></tr></table>")
+
+    let firstLine = try line(containing: "word", in: frame, of: string)
+
+    // a justified line fills the available cell content width (200pt)
+    #expect(firstLine.frame.width > 195)
+    #expect(firstLine.frame.width <= 201)
+  }
+
+  @Test("Rowspan cells span multiple rows")
+  func rowspan() throws {
+    let (frame, string) = try layoutFrame(
+      html:
+        "<table><tr><td rowspan=\"2\">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>")
+
+    let lineTall = try line(containing: "Tall", in: frame, of: string)
+    let lineB1 = try line(containing: "B1", in: frame, of: string)
+    let lineB2 = try line(containing: "B2", in: frame, of: string)
+
+    // B1 and B2 are in different rows, both to the right of the spanning cell
+    #expect(lineB2.frame.minY >= lineB1.frame.maxY - 1)
+    #expect(lineB1.frame.minX > lineTall.frame.maxX - 1)
+    #expect(abs(lineB1.frame.minX - lineB2.frame.minX) < 1)
+
+    // the spanning cell is middle-aligned across both rows, so it sits lower
+    // than the first row's cell
+    #expect(lineTall.baselineOrigin.y > lineB1.baselineOrigin.y - 1)
+  }
+
+  @Test("Nested tables lay out inside their cell")
+  func nestedTable() throws {
+    let (frame, string) = try layoutFrame(
+      html:
+        "<table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>"
+    )
+
+    let lineOuterA = try line(containing: "Outer A", in: frame, of: string)
+    let lineInner1 = try line(containing: "Inner 1", in: frame, of: string)
+    let lineInner2 = try line(containing: "Inner 2", in: frame, of: string)
+    let lineAfter = try line(containing: "after inner", in: frame, of: string)
+    let lineOuterB = try line(containing: "Outer B", in: frame, of: string)
+
+    // the inner table is below the cell text that precedes it
+    #expect(lineInner1.frame.minY >= lineOuterA.frame.maxY - 1)
+
+    // inner cells sit side by side within the outer cell
+    #expect(abs(lineInner1.baselineOrigin.y - lineInner2.baselineOrigin.y) < 1)
+    #expect(lineInner2.frame.minX > lineInner1.frame.maxX - 1)
+    #expect(lineInner1.frame.minX >= lineOuterA.frame.minX - 1)
+
+    // content after the inner table continues below it
+    #expect(lineAfter.frame.minY >= lineInner1.frame.maxY - 1)
+
+    // the second outer column is to the right of the inner table content
+    #expect(lineOuterB.frame.minX > lineInner2.frame.maxX - 1)
+  }
+
+  @Test("Flow continues below the table")
+  func flowAfterTable() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<p>Before</p><table><tr><td>A1</td><td>B1</td></tr></table><p>After</p>")
+
+    let lineBefore = try line(containing: "Before", in: frame, of: string)
+    let lineA1 = try line(containing: "A1", in: frame, of: string)
+    let lineAfter = try line(containing: "After", in: frame, of: string)
+
+    #expect(lineA1.frame.minY > lineBefore.frame.maxY - 1)
+    #expect(lineAfter.frame.minY >= lineA1.frame.maxY - 1)
+
+    // the paragraph after the table starts at the leading margin again
+    #expect(abs(lineAfter.frame.minX - lineBefore.frame.minX) < 1)
+  }
+
+  @Test("Percentage table widths resolve against the frame width")
+  func percentageWidth() throws {
+    let (frame, string) = try layoutFrame(
+      html: "<table width=\"50%\"><tr><td width=\"50%\">A</td><td width=\"50%\">B</td></tr></table>",
+      width: 400)
+
+    let lineA = try line(containing: "A", in: frame, of: string)
+    let lineB = try line(containing: "B", in: frame, of: string)
+
+    // table is 200pt, each column 100pt
+    #expect(abs((lineB.frame.minX - lineA.frame.minX) - 100) < 2)
+  }
+
+  @Test("Collapsed borders draw a single-line grid")
+  func collapsedBorderGrid() throws {
+    // counts distinct dark horizontal lines crossing a vertical scan column
+    func darkLineRuns(html: String) throws -> Int {
+      let (frame, string) = try layoutFrame(html: html, width: 200)
+
+      let lineA1 = try line(containing: "A1", in: frame, of: string)
+      let scale = 2
+      let width = 200 * scale
+      let height = (Int(ceil(frame.frame.maxY)) + 4) * scale
+
+      let context = try #require(
+        CGContext(
+          data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+          space: CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+      context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+      context.fill(CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+      context.translateBy(x: 0, y: CGFloat(height))
+      context.scaleBy(x: CGFloat(scale), y: -CGFloat(scale))
+      frame.draw(in: context, options: 0)
+
+      // scan inside the wide cell, to the right of the short text, so only
+      // horizontal border lines cross the column
+      let scanX = Int((lineA1.frame.minX + 60) * CGFloat(scale))
+      let data = try #require(context.data)
+      let buffer = data.bindMemory(to: UInt8.self, capacity: context.bytesPerRow * height)
+
+      var runs = 0
+      var inRun = false
+      for row in 0..<height {
+        let offset = row * context.bytesPerRow + scanX * 4
+        let isDark =
+          buffer[offset] < 128 && buffer[offset + 1] < 128 && buffer[offset + 2] < 128
+        if isDark && !inRun { runs += 1 }
+        inRun = isDark
+      }
+      return runs
+    }
+
+    // a collapsed two-row grid has exactly three horizontal lines: top, middle, bottom
+    let collapsed = try darkLineRuns(
+      html: "<table border=\"1\" style=\"border-collapse: collapse\">"
+        + "<tr><td width=\"100\">A1</td></tr><tr><td>A2</td></tr></table>")
+    #expect(collapsed == 3)
+
+    // separated borders show the table border plus each cell's own border
+    let separated = try darkLineRuns(
+      html: "<table border=\"1\"><tr><td width=\"100\">A1</td></tr><tr><td>A2</td></tr></table>")
+    #expect(separated >= 5)
+  }
+
+  // MARK: - Drawing
+
+  @Test("Drawing a table with backgrounds and borders does not crash and paints")
+  func drawingSmokeTest() throws {
+    let (frame, _) = try layoutFrame(
+      html: "<table border=\"1\" bgcolor=\"#FF0000\"><tr><td bgcolor=\"#00FF00\">A</td>"
+        + "<td style=\"border: 2px solid blue\">B</td></tr></table>")
+
+    let width = 400
+    let height = max(Int(ceil(frame.frame.size.height)) + 10, 50)
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context = try #require(
+      CGContext(
+        data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+        space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+
+    // white background
+    context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+
+    frame.draw(in: context, options: 0)
+
+    // at least some pixels must have been painted non-white
+    let data = try #require(context.data)
+    let buffer = data.bindMemory(to: UInt8.self, capacity: context.bytesPerRow * height)
+
+    var nonWhitePixels = 0
+    for row in 0..<height {
+      for column in 0..<width {
+        let offset = row * context.bytesPerRow + column * 4
+        if buffer[offset] != 255 || buffer[offset + 1] != 255 || buffer[offset + 2] != 255 {
+          nonWhitePixels += 1
+        }
+      }
+    }
+
+    #expect(nonWhitePixels > 50)
+  }
+}

--- a/Tests/DTCoreTextTests/TableParsingTests.swift
+++ b/Tests/DTCoreTextTests/TableParsingTests.swift
@@ -1,0 +1,495 @@
+import Foundation
+import Testing
+
+@testable import DTCoreText
+
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
+/// Tests for parsing HTML tables into the DT text block model, following the structure
+/// the macOS system importer produces (documented in <doc:HTMLTablesOnMacOS>).
+@Suite("Table Parsing", .serialized)
+struct TableParsingTests {
+
+  private let allEdges: [CGRectEdge] = [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge]
+
+  // MARK: - Helpers
+
+  private func parse(_ html: String) throws -> NSAttributedString {
+    return try #require(TestHelpers.attributedString(fromHTML: html))
+  }
+
+  /// The text block arrays governing each paragraph, via the DTTextBlocks attribute.
+  private func paragraphBlocks(of attributedString: NSAttributedString) -> [[TextBlock]] {
+    let nsString = attributedString.string as NSString
+    var result = [[TextBlock]]()
+    var location = 0
+
+    while location < nsString.length {
+      let paragraphRange = nsString.paragraphRange(for: NSRange(location: location, length: 0))
+      let blocks =
+        attributedString.attribute(
+          NSAttributedString.Key(rawValue: DTTextBlocksAttribute), at: paragraphRange.location,
+          effectiveRange: nil) as? [TextBlock]
+      result.append(blocks ?? [])
+      location = NSMaxRange(paragraphRange)
+    }
+
+    return result
+  }
+
+  private func tableCells(of attributedString: NSAttributedString) -> [TextTableBlock] {
+    var cells = [TextTableBlock]()
+
+    for blocks in paragraphBlocks(of: attributedString) {
+      for case let cell as TextTableBlock in blocks where !cells.contains(where: { $0 === cell }) {
+        cells.append(cell)
+      }
+    }
+
+    return cells
+  }
+
+  // MARK: - Structure
+
+  @Test("Simple 2x2 table produces one paragraph per cell and a shared table")
+  func simpleTable() throws {
+    let attributedString = try parse(
+      "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>")
+
+    #expect(attributedString.string == "A1\nB1\nA2\nB2\n")
+
+    let blocks = paragraphBlocks(of: attributedString)
+    #expect(blocks.map { $0.count } == [1, 1, 1, 1])
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 4)
+
+    // one shared table instance
+    let table = cells[0].table
+    #expect(cells.allSatisfy { $0.table === table })
+    #expect(table.numberOfColumns == 2)
+
+    // grid coordinates in reading order
+    #expect(cells.map { $0.startingRow } == [0, 0, 1, 1])
+    #expect(cells.map { $0.startingColumn } == [0, 1, 0, 1])
+
+    // importer-compatible defaults
+    for cell in cells {
+      for edge in allEdges {
+        #expect(cell.width(for: .padding, edge: edge) == 1)
+        #expect(cell.width(for: .margin, edge: edge) == 0.5)
+        #expect(cell.width(for: .border, edge: edge) == 0)
+        #expect(cell.borderColor(for: edge) == DTColor.black)
+      }
+      #expect(cell.verticalAlignment == .middleAlignment)
+    }
+  }
+
+  @Test("Cell paragraphs share one block instance, multiple paragraphs included")
+  func multiParagraphCell() throws {
+    let attributedString = try parse(
+      "<table><tr><td><p>One</p><p>Two</p></td><td>B</td></tr></table>")
+
+    #expect(attributedString.string == "One\nTwo\nB\n")
+
+    let blocks = paragraphBlocks(of: attributedString)
+    try #require(blocks.map { $0.count } == [1, 1, 1])
+
+    #expect(blocks[0][0] === blocks[1][0])
+    #expect(blocks[0][0] !== blocks[2][0])
+  }
+
+  @Test("Empty cells produce a bare newline paragraph carrying the block")
+  func emptyCell() throws {
+    let attributedString = try parse("<table><tr><td></td><td>B</td></tr></table>")
+
+    #expect(attributedString.string == "\nB\n")
+
+    let blocks = paragraphBlocks(of: attributedString)
+    try #require(blocks.map { $0.count } == [1, 1])
+
+    let emptyCell = try #require(blocks[0][0] as? TextTableBlock)
+    #expect(emptyCell.startingColumn == 0)
+  }
+
+  @Test("Caption becomes a centered paragraph outside the table structure")
+  func caption() throws {
+    let attributedString = try parse(
+      "<table><caption>The Caption</caption><tr><td>A</td><td>B</td></tr></table>")
+
+    #expect(attributedString.string == "The Caption\nA\nB\n")
+
+    let blocks = paragraphBlocks(of: attributedString)
+    #expect(blocks.map { $0.count } == [0, 1, 1])
+
+    let style = try #require(
+      attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle)
+    #expect(style.alignment == .center)
+  }
+
+  @Test("Nested tables nest outermost-first with shared instances")
+  func nestedTable() throws {
+    let attributedString = try parse(
+      "<table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>"
+    )
+
+    #expect(attributedString.string == "Outer A\nInner 1\nInner 2\nafter inner\nOuter B\n")
+
+    let blocks = paragraphBlocks(of: attributedString)
+    #expect(blocks.map { $0.count } == [1, 2, 2, 1, 1])
+
+    // the outer cell block is the same instance wherever it appears
+    let outerCell = try #require(blocks[0].first as? TextTableBlock)
+    #expect(blocks[1][0] === outerCell)
+    #expect(blocks[2][0] === outerCell)
+    #expect(blocks[3][0] === outerCell)
+    #expect(blocks[4][0] !== outerCell)
+
+    // inner cells share a table that is different from the outer one
+    let inner1 = try #require(blocks[1][1] as? TextTableBlock)
+    let inner2 = try #require(blocks[2][1] as? TextTableBlock)
+    #expect(inner1.table === inner2.table)
+    #expect(inner1.table !== outerCell.table)
+    #expect(inner1.table.numberOfColumns == 2)
+    #expect(outerCell.table.numberOfColumns == 2)
+  }
+
+  // MARK: - Grid Geometry
+
+  @Test("Column spans skip grid positions")
+  func colspan() throws {
+    let attributedString = try parse(
+      "<table><tr><td colspan=\"2\">Wide</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></table>"
+    )
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 5)
+
+    #expect(cells[0].columnSpan == 2)
+    #expect(cells[0].startingColumn == 0)
+    #expect(cells[1].startingColumn == 2)
+    #expect(cells[0].table.numberOfColumns == 3)
+
+    #expect(cells[2].startingRow == 1)
+    #expect(cells.map { $0.startingColumn } == [0, 2, 0, 1, 2])
+  }
+
+  @Test("Row spans cover grid positions in later rows")
+  func rowspan() throws {
+    let attributedString = try parse(
+      "<table><tr><td rowspan=\"2\">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>")
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 3)
+
+    #expect(cells[0].rowSpan == 2)
+    #expect(cells[0].startingColumn == 0)
+    #expect(cells[1].startingColumn == 1)
+
+    // the cell in the second row skips the position covered by the rowspan
+    #expect(cells[2].startingRow == 1)
+    #expect(cells[2].startingColumn == 1)
+
+    #expect(cells[0].table.numberOfColumns == 2)
+  }
+
+  // MARK: - Header Cells
+
+  @Test("Header cells get bold centered text")
+  func headerCells() throws {
+    let attributedString = try parse(
+      "<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Pi</td></tr></tbody></table>")
+
+    #expect(attributedString.string == "Name\nPi\n")
+
+    let style = try #require(
+      attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle)
+    #expect(style.alignment == .center)
+
+    let font = try #require(attributedString.attribute(.font, at: 0, effectiveRange: nil))
+    let traits = CTFontGetSymbolicTraits(font as! CTFont)
+    #expect(traits.contains(.traitBold))
+
+    let cells = tableCells(of: attributedString)
+    #expect(cells.count == 2)
+    #expect(cells[0].startingRow == 0)
+    #expect(cells[1].startingRow == 1)
+  }
+
+  // MARK: - Legacy Attributes
+
+  @Test("Legacy table attributes map like the system importer")
+  func legacyAttributes() throws {
+    let attributedString = try parse(
+      "<table border=\"2\" cellpadding=\"5\" cellspacing=\"3\" bgcolor=\"#FFEEDD\">"
+        + "<tr bgcolor=\"#DDEEFF\"><td bgcolor=\"#EEFFDD\">X</td><td>Y</td></tr></table>")
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 2)
+
+    let table = cells[0].table
+
+    // border attribute: 2pt table border, 1pt cell borders
+    for edge in allEdges {
+      #expect(table.width(for: .border, edge: edge) == 2)
+      #expect(cells[0].width(for: .border, edge: edge) == 1)
+      #expect(cells[0].width(for: .padding, edge: edge) == 5)
+      #expect(cells[0].width(for: .margin, edge: edge) == 1.5)
+    }
+
+    // backgrounds: table bgcolor on the table, cell bgcolor on the cell,
+    // row bgcolor on cells without their own
+    #expect(table.backgroundColor == DTColorCreateWithHTMLName("#FFEEDD"))
+    #expect(cells[0].backgroundColor == DTColorCreateWithHTMLName("#EEFFDD"))
+    #expect(cells[1].backgroundColor == DTColorCreateWithHTMLName("#DDEEFF"))
+
+    // block backgrounds must not be run-level background attributes
+    var runBackgrounds = 0
+    attributedString.enumerateAttribute(
+      .backgroundColor, in: NSRange(location: 0, length: attributedString.length)
+    ) { value, _, _ in
+      if value != nil { runBackgrounds += 1 }
+    }
+    #expect(runBackgrounds == 0)
+  }
+
+  @Test("Legacy valign attributes map to vertical alignment")
+  func legacyValign() throws {
+    let attributedString = try parse(
+      "<table><tr valign=\"bottom\"><td valign=\"top\">a</td><td>b</td><td valign=\"baseline\">c</td></tr></table>"
+    )
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 3)
+
+    #expect(cells[0].verticalAlignment == .topAlignment)
+    #expect(cells[1].verticalAlignment == .bottomAlignment)
+    #expect(cells[2].verticalAlignment == .baselineAlignment)
+  }
+
+  // MARK: - CSS
+
+  @Test("CSS box properties map onto layers, edges and colors")
+  func cssBox() throws {
+    let attributedString = try parse(
+      "<table style=\"border-collapse: collapse;\"><tr>"
+        + "<td style=\"padding: 1px 2px 3px 4px; border-top: 1px solid #FF0000; border-right: 2px solid #00FF00; border-bottom: 3px solid #0000FF; border-left: 4px solid #FF00FF; background-color: #ABCDEF; width: 120px; vertical-align: baseline;\">styled</td>"
+        + "<td>plain</td></tr></table>")
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 2)
+
+    let cell = cells[0]
+    let table = cell.table
+
+    #expect(table.collapsesBorders == true)
+
+    // collapsed tables have no cell margins
+    for edge in allEdges {
+      #expect(cell.width(for: .margin, edge: edge) == 0)
+    }
+
+    // CSS padding order is top right bottom left
+    #expect(cell.width(for: .padding, edge: .minYEdge) == 1)
+    #expect(cell.width(for: .padding, edge: .maxXEdge) == 2)
+    #expect(cell.width(for: .padding, edge: .maxYEdge) == 3)
+    #expect(cell.width(for: .padding, edge: .minXEdge) == 4)
+
+    // per-edge border widths and colors
+    #expect(cell.width(for: .border, edge: .minYEdge) == 1)
+    #expect(cell.width(for: .border, edge: .maxXEdge) == 2)
+    #expect(cell.width(for: .border, edge: .maxYEdge) == 3)
+    #expect(cell.width(for: .border, edge: .minXEdge) == 4)
+    #expect(cell.borderColor(for: .minYEdge) == DTColorCreateWithHTMLName("#FF0000"))
+    #expect(cell.borderColor(for: .maxXEdge) == DTColorCreateWithHTMLName("#00FF00"))
+    #expect(cell.borderColor(for: .maxYEdge) == DTColorCreateWithHTMLName("#0000FF"))
+    #expect(cell.borderColor(for: .minXEdge) == DTColorCreateWithHTMLName("#FF00FF"))
+
+    #expect(cell.backgroundColor == DTColorCreateWithHTMLName("#ABCDEF"))
+
+    #expect(cell.contentWidth == 120)
+    #expect(cell.contentWidthValueType == .absoluteValueType)
+    #expect(cell.verticalAlignment == .baselineAlignment)
+
+    // the plain neighbor keeps the defaults
+    #expect(cells[1].width(for: .padding, edge: .minXEdge) == 1)
+    #expect(cells[1].verticalAlignment == .middleAlignment)
+  }
+
+  @Test("Border styles, multi-value lists and width keywords parse")
+  func borderStylesAndLists() throws {
+    let attributedString = try parse(
+      "<table><tr>"
+        + "<td style=\"border: 2px dashed #FF0000\">dashed</td>"
+        + "<td style=\"border-style: dotted\">dotted default width</td>"
+        + "<td style=\"border-width: 1px 2px 3px 4px; border-style: solid\">multi width</td>"
+        + "<td style=\"border: thick solid #0000FF; border-left-style: double\">keywords</td>"
+        + "<td style=\"border-color: #FF0000 #00FF00; border-style: solid; border-width: medium\">color list</td>"
+        + "</tr></table>")
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 5)
+
+    // border: 2px dashed red
+    for edge in allEdges {
+      #expect(cells[0].width(for: .border, edge: edge) == 2)
+      #expect(cells[0].borderStyle(for: edge) == .dashed)
+      #expect(cells[0].borderColor(for: edge) == DTColorCreateWithHTMLName("#FF0000"))
+    }
+
+    // border-style alone implies the medium (3px) width
+    for edge in allEdges {
+      #expect(cells[1].borderStyle(for: edge) == .dotted)
+      #expect(cells[1].width(for: .border, edge: edge) == 3)
+    }
+
+    // border-width list is top right bottom left
+    #expect(cells[2].width(for: .border, edge: .minYEdge) == 1)
+    #expect(cells[2].width(for: .border, edge: .maxXEdge) == 2)
+    #expect(cells[2].width(for: .border, edge: .maxYEdge) == 3)
+    #expect(cells[2].width(for: .border, edge: .minXEdge) == 4)
+
+    // thick keyword = 5px; per-edge style override
+    #expect(cells[3].width(for: .border, edge: .minYEdge) == 5)
+    #expect(cells[3].borderStyle(for: .minYEdge) == .solid)
+    #expect(cells[3].borderStyle(for: .minXEdge) == .double)
+
+    // two-value color list: top/bottom first, right/left second; medium = 3px
+    #expect(cells[4].borderColor(for: .minYEdge) == DTColorCreateWithHTMLName("#FF0000"))
+    #expect(cells[4].borderColor(for: .maxYEdge) == DTColorCreateWithHTMLName("#FF0000"))
+    #expect(cells[4].borderColor(for: .maxXEdge) == DTColorCreateWithHTMLName("#00FF00"))
+    #expect(cells[4].borderColor(for: .minXEdge) == DTColorCreateWithHTMLName("#00FF00"))
+    #expect(cells[4].width(for: .border, edge: .minYEdge) == 3)
+  }
+
+  @Test("Percentage widths are preserved as percentage value types")
+  func percentageWidths() throws {
+    let attributedString = try parse(
+      "<table width=\"80%\"><tr><td width=\"100\">fixed</td><td width=\"50%\">half</td></tr></table>"
+    )
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 2)
+
+    let table = cells[0].table
+    #expect(table.contentWidth == 80)
+    #expect(table.contentWidthValueType == .percentageValueType)
+
+    #expect(cells[0].contentWidth == 100)
+    #expect(cells[0].contentWidthValueType == .absoluteValueType)
+
+    #expect(cells[1].contentWidth == 50)
+    #expect(cells[1].contentWidthValueType == .percentageValueType)
+  }
+
+  @Test("Column element widths apply to spanned cells")
+  func columnWidths() throws {
+    let attributedString = try parse(
+      "<table><colgroup><col width=\"120\"><col width=\"60\"></colgroup><tr><td>A</td><td>B</td></tr></table>"
+    )
+
+    #expect(attributedString.string == "A\nB\n")
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 2)
+
+    #expect(cells[0].contentWidth == 120)
+    #expect(cells[1].contentWidth == 60)
+  }
+
+  @Test("Fixed table layout and min/max widths")
+  func fixedLayoutAndMinMax() throws {
+    let attributedString = try parse(
+      "<table style=\"table-layout: fixed; width: 300px\"><tr>"
+        + "<td style=\"min-width: 100px\">min</td><td style=\"max-width: 30px\">maxed</td></tr></table>"
+    )
+
+    let cells = tableCells(of: attributedString)
+    try #require(cells.count == 2)
+
+    let table = cells[0].table
+    #expect(table.layoutAlgorithm == .fixedLayoutAlgorithm)
+    #expect(table.contentWidth == 300)
+
+    #expect(cells[0].value(for: .minimumWidth) == 100)
+    #expect(cells[1].value(for: .maximumWidth) == 30)
+  }
+
+  // MARK: - System Importer Comparison
+
+  #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    @Test("Grid structure matches the system importer for the same HTML")
+    @MainActor
+    func matchesSystemImporter() throws {
+      let fixtures = [
+        "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>",
+        "<table><tr><td colspan=\"2\">Wide</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></table>",
+        "<table><tr><td rowspan=\"2\">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>",
+        "<table><tr><td><p>One</p><p>Two</p></td><td>B</td></tr></table>",
+      ]
+
+      for html in fixtures {
+        let dtString = try parse(html)
+        let dtCells = tableCells(of: dtString)
+
+        let nsData = Data(html.utf8)
+        let nsString = try NSAttributedString(
+          data: nsData,
+          options: [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue,
+          ],
+          documentAttributes: nil)
+
+        // collect distinct system cells in order
+        var nsCells = [NSTextTableBlock]()
+        let nsStringContent = nsString.string as NSString
+        var location = 0
+        while location < nsStringContent.length {
+          let paragraphRange = nsStringContent.paragraphRange(
+            for: NSRange(location: location, length: 0))
+          if let style = nsString.attribute(
+            .paragraphStyle, at: paragraphRange.location, effectiveRange: nil) as? NSParagraphStyle,
+            let cell = style.textBlocks.last as? NSTextTableBlock,
+            !nsCells.contains(where: { $0 === cell })
+          {
+            nsCells.append(cell)
+          }
+          location = NSMaxRange(paragraphRange)
+        }
+
+        // identical plain text
+        #expect(dtString.string == nsString.string, "string for \(html)")
+
+        // identical grid structure
+        try #require(dtCells.count == nsCells.count, "cell count for \(html)")
+
+        for (dtCell, nsCell) in zip(dtCells, nsCells) {
+          #expect(dtCell.startingRow == nsCell.startingRow, "row for \(html)")
+          #expect(dtCell.startingColumn == nsCell.startingColumn, "column for \(html)")
+          #expect(dtCell.rowSpan == nsCell.rowSpan, "rowSpan for \(html)")
+          #expect(dtCell.columnSpan == nsCell.columnSpan, "columnSpan for \(html)")
+          #expect(
+            dtCell.table.numberOfColumns == nsCell.table.numberOfColumns, "columns for \(html)")
+          #expect(
+            dtCell.verticalAlignment.rawValue == nsCell.verticalAlignment.rawValue,
+            "valign for \(html)")
+
+          for edge in allEdges {
+            let nsEdge = NSRectEdge(rawValue: UInt(edge.rawValue))!
+            #expect(
+              dtCell.width(for: .padding, edge: edge)
+                == nsCell.width(for: .padding, edge: nsEdge), "padding for \(html)")
+            #expect(
+              dtCell.width(for: .margin, edge: edge) == nsCell.width(for: .margin, edge: nsEdge),
+              "margin for \(html)")
+          }
+        }
+      }
+    }
+  #endif
+}

--- a/Tests/DTCoreTextTests/TableRenderPreviewTests.swift
+++ b/Tests/DTCoreTextTests/TableRenderPreviewTests.swift
@@ -1,0 +1,208 @@
+import CoreText
+import Foundation
+import ImageIO
+import Testing
+
+@testable import DTCoreText
+
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
+/// Renders representative tables into PNGs (under /tmp/table-renders on macOS, the
+  /// process temporary directory elsewhere) for visual inspection. Also acts as a smoke
+  /// test that none of the samples crash and all of them render.
+  @Suite("Table Render Preview", .serialized)
+  struct TableRenderPreviewTests {
+
+    private static let samples: [(name: String, width: CGFloat, html: String)] = [
+      (
+        "01-simple", 420,
+        "<table><tr><td>Alpha</td><td>Beta</td></tr><tr><td>Gamma</td><td>Delta</td></tr></table>"
+      ),
+      (
+        "02-headers", 420,
+        "<table border=\"1\" cellpadding=\"4\"><thead><tr><th>Name</th><th>Value</th></tr></thead>"
+          + "<tbody><tr><td>Pi</td><td>3.14159</td></tr><tr><td>Euler</td><td>2.71828</td></tr></tbody></table>"
+      ),
+      (
+        "03-spans", 420,
+        "<table border=\"1\" cellpadding=\"4\"><tr><td colspan=\"2\" bgcolor=\"#FFD8A8\">Wide header</td><td bgcolor=\"#A8D8FF\" rowspan=\"2\">Tall<br>cell</td></tr>"
+          + "<tr><td>A2</td><td>B2</td></tr><tr><td>A3</td><td>B3</td><td>C3</td></tr></table>"
+      ),
+      (
+        "04-styled", 420,
+        "<table bgcolor=\"#F4F4F4\" cellspacing=\"6\" cellpadding=\"6\"><tr>"
+          + "<td style=\"border: 2px solid #CC0000; background-color: #FFEEEE\">red border</td>"
+          + "<td style=\"border-left: 6px solid #0066CC; background-color: #EEF4FF\">left accent</td></tr>"
+          + "<tr><td bgcolor=\"#EEFFEE\">plain</td><td>default</td></tr></table>"
+      ),
+      (
+        "05-collapse", 420,
+        "<table style=\"border-collapse: collapse\" border=\"1\"><tr><th>Q</th><th>Revenue</th></tr>"
+          + "<tr><td>Q1</td><td>1.000</td></tr><tr><td>Q2</td><td>1.250</td></tr></table>"
+      ),
+      (
+        "06-valign", 420,
+        "<table border=\"1\" cellpadding=\"3\"><tr><td>first line<br>second line<br>third line</td>"
+          + "<td valign=\"top\">top</td><td>middle</td><td valign=\"bottom\">bottom</td></tr></table>"
+      ),
+      (
+        "07-nested", 420,
+        "<table border=\"1\" cellpadding=\"4\" bgcolor=\"#F0F0F0\"><tr><td>Outer A"
+          + "<table border=\"1\" bgcolor=\"#FFF4D8\"><tr><td>in 1</td><td>in 2</td></tr></table>"
+          + "after inner</td><td bgcolor=\"#E8F8E8\">Outer B</td></tr></table>"
+      ),
+      (
+        "08-widths", 420,
+        "<table width=\"100%\" border=\"1\"><tr><td width=\"25%\" bgcolor=\"#FFE8E8\">25%</td>"
+          + "<td width=\"50%\" bgcolor=\"#E8FFE8\">50%</td><td bgcolor=\"#E8E8FF\">rest</td></tr></table>"
+      ),
+      (
+        "09-flow", 420,
+        "<p>Text before the table flows normally and wraps when it gets long enough.</p>"
+          + "<table border=\"1\" cellpadding=\"3\"><tr><td>A</td><td>B</td></tr></table>"
+          + "<p>Text after the table continues below it.</p>"
+      ),
+      (
+        "10-baseline", 420,
+        "<table border=\"1\" cellpadding=\"3\"><tr>"
+          + "<td style=\"vertical-align: baseline; font-size: 32px\">Large</td>"
+          + "<td style=\"vertical-align: baseline\">baseline</td>"
+          + "<td style=\"vertical-align: baseline; font-size: 9px\">tiny</td></tr></table>"
+      ),
+      (
+        "12-border-styles", 420,
+        "<table cellspacing=\"6\" cellpadding=\"6\"><tr>"
+          + "<td style=\"border: 2px solid #333333\">solid</td>"
+          + "<td style=\"border: 2px dashed #CC0000\">dashed</td>"
+          + "<td style=\"border: 2px dotted #0066CC\">dotted</td>"
+          + "<td style=\"border: 6px double #008800\">double</td></tr>"
+          + "<tr><td colspan=\"4\" style=\"border-width: 1px 3px 5px 7px; border-style: solid dashed dotted double; border-color: #CC0000 #008800 #0066CC #CC8800\">mixed per edge: solid/dashed/dotted/double</td></tr></table>"
+      ),
+      (
+        "11-alignment", 420,
+        "<table border=\"1\" width=\"100%\" cellpadding=\"3\"><tr>"
+          + "<td style=\"text-align: left\">left</td>"
+          + "<td style=\"text-align: center\">center</td>"
+          + "<td style=\"text-align: right\">right</td></tr>"
+          + "<tr><td colspan=\"3\" style=\"text-align: justify\">Justified text in a table cell "
+          + "stretches every full line to the cell width so both edges are flush with the padding box, "
+          + "just like justified paragraphs outside of tables behave.</td></tr></table>"
+      ),
+    ]
+
+    @Test("Render all samples to PNG", arguments: samples.map { $0.name })
+    func renderSample(name: String) throws {
+      let sample = try #require(Self.samples.first { $0.name == name })
+
+      let attributedString = try #require(TestHelpers.attributedString(fromHTML: sample.html))
+      let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+
+      let maxRect = CGRect(
+        x: 10, y: 10, width: sample.width - 20, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+      let entireString = NSRange(location: 0, length: attributedString.length)
+      let layoutFrame = try #require(layouter.layoutFrame(with: maxRect, range: entireString))
+
+      let contentHeight = ceil(layoutFrame.frame.maxY) + 10
+      let scale: CGFloat = 2
+      let pixelWidth = Int(sample.width * scale)
+      let pixelHeight = Int(contentHeight * scale)
+
+      let colorSpace = CGColorSpaceCreateDeviceRGB()
+      let context = try #require(
+        CGContext(
+          data: nil, width: pixelWidth, height: pixelHeight, bitsPerComponent: 8, bytesPerRow: 0,
+          space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+
+      // white background
+      context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+      context.fill(CGRect(x: 0, y: 0, width: CGFloat(pixelWidth), height: CGFloat(pixelHeight)))
+
+      // flip to the top-down coordinate system the layout frame draws in
+      context.translateBy(x: 0, y: CGFloat(pixelHeight))
+      context.scaleBy(x: scale, y: -scale)
+
+      layoutFrame.draw(in: context, options: 0)
+
+      // verify that something was painted
+      let image = try #require(context.makeImage())
+
+      // simulator test processes run on the host, so /tmp is the Mac's /tmp either way
+      #if os(macOS)
+        let outputDirectory = URL(fileURLWithPath: "/tmp/table-renders", isDirectory: true)
+      #else
+        let outputDirectory = URL(fileURLWithPath: "/tmp/table-renders-ios", isDirectory: true)
+      #endif
+      try FileManager.default.createDirectory(
+        at: outputDirectory, withIntermediateDirectories: true)
+
+      let outputURL = outputDirectory.appendingPathComponent("\(name).png")
+      let destination = try #require(
+        CGImageDestinationCreateWithURL(outputURL as CFURL, "public.png" as CFString, 1, nil))
+      CGImageDestinationAddImage(destination, image, nil)
+      #expect(CGImageDestinationFinalize(destination))
+      print("RENDERED: \(outputURL.path)")
+    }
+
+    /// Renders the table demo files of the demo app at iPhone width, so the demo
+    /// content is verified through the same pipeline the demo app uses.
+    @Test(
+      "Render demo app table files",
+      arguments: ["Tables", "TableAlignment", "TableWidths", "TableBorders"])
+    func renderDemoFile(name: String) throws {
+      let demoResources = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // DTCoreTextTests
+        .deletingLastPathComponent()  // Tests
+        .deletingLastPathComponent()  // package root
+        .appendingPathComponent("Demo/Resources")
+
+      let fileURL = demoResources.appendingPathComponent("\(name).html")
+      let html = try String(contentsOf: fileURL, encoding: .utf8)
+
+      let attributedString = try #require(TestHelpers.attributedString(fromHTML: html))
+      let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+
+      let width: CGFloat = 390  // iPhone point width, like the demo app
+      let maxRect = CGRect(
+        x: 10, y: 10, width: width - 20, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+      let entireString = NSRange(location: 0, length: attributedString.length)
+      let layoutFrame = try #require(layouter.layoutFrame(with: maxRect, range: entireString))
+
+      let contentHeight = ceil(layoutFrame.frame.maxY) + 10
+      let scale: CGFloat = 2
+      let pixelWidth = Int(width * scale)
+      let pixelHeight = Int(contentHeight * scale)
+
+      let colorSpace = CGColorSpaceCreateDeviceRGB()
+      let context = try #require(
+        CGContext(
+          data: nil, width: pixelWidth, height: pixelHeight, bitsPerComponent: 8, bytesPerRow: 0,
+          space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+
+      context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+      context.fill(CGRect(x: 0, y: 0, width: CGFloat(pixelWidth), height: CGFloat(pixelHeight)))
+      context.translateBy(x: 0, y: CGFloat(pixelHeight))
+      context.scaleBy(x: scale, y: -scale)
+
+      layoutFrame.draw(in: context, options: 0)
+
+      let image = try #require(context.makeImage())
+
+      #if os(macOS)
+        let outputDirectory = URL(fileURLWithPath: "/tmp/table-renders", isDirectory: true)
+      #else
+        let outputDirectory = URL(fileURLWithPath: "/tmp/table-renders-ios", isDirectory: true)
+      #endif
+      try FileManager.default.createDirectory(
+        at: outputDirectory, withIntermediateDirectories: true)
+
+      let outputURL = outputDirectory.appendingPathComponent("demo-\(name).png")
+      let destination = try #require(
+        CGImageDestinationCreateWithURL(outputURL as CFURL, "public.png" as CFString, 1, nil))
+      CGImageDestinationAddImage(destination, image, nil)
+      #expect(CGImageDestinationFinalize(destination))
+    }
+  }

--- a/Tests/DTCoreTextTests/TableWritingTests.swift
+++ b/Tests/DTCoreTextTests/TableWritingTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+
+@testable import DTCoreText
+
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
+/// Tests for writing tables back to HTML and round-tripping them through the parser.
+@Suite("Table Writing", .serialized)
+struct TableWritingTests {
+
+  // MARK: - Helpers
+
+  private func parse(_ html: String) throws -> NSAttributedString {
+    return try #require(TestHelpers.attributedString(fromHTML: html))
+  }
+
+  private func writeFragment(_ attributedString: NSAttributedString) -> String {
+    let writer = HTMLWriter(attributedString: attributedString)
+    return writer.htmlFragment()
+  }
+
+  private func roundTrip(_ html: String) throws -> (
+    original: NSAttributedString, fragment: String, reparsed: NSAttributedString
+  ) {
+    let original = try parse(html)
+    let fragment = writeFragment(original)
+    let reparsed = try parse(fragment)
+    return (original, fragment, reparsed)
+  }
+
+  private func tableCells(of attributedString: NSAttributedString) -> [TextTableBlock] {
+    let nsString = attributedString.string as NSString
+    var cells = [TextTableBlock]()
+    var location = 0
+
+    while location < nsString.length {
+      let paragraphRange = nsString.paragraphRange(for: NSRange(location: location, length: 0))
+      if let blocks = attributedString.attribute(
+        NSAttributedString.Key(rawValue: DTTextBlocksAttribute), at: paragraphRange.location,
+        effectiveRange: nil) as? [TextBlock]
+      {
+        for case let cell as TextTableBlock in blocks
+        where !cells.contains(where: { $0 === cell }) {
+          cells.append(cell)
+        }
+      }
+      location = NSMaxRange(paragraphRange)
+    }
+
+    return cells
+  }
+
+  // MARK: - Tests
+
+  @Test("Simple table writes table, tr and td tags")
+  func writesBasicMarkup() throws {
+    let (_, fragment, reparsed) = try roundTrip(
+      "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>")
+
+    #expect(fragment.contains("<table"))
+    #expect(fragment.components(separatedBy: "<td").count == 5)
+    #expect(fragment.components(separatedBy: "<tr").count == 3)
+    #expect(fragment.contains("</table>"))
+
+    // structure survives the round-trip
+    #expect(reparsed.string == "A1\nB1\nA2\nB2\n")
+
+    let cells = tableCells(of: reparsed)
+    try #require(cells.count == 4)
+    #expect(cells.map { $0.startingRow } == [0, 0, 1, 1])
+    #expect(cells.map { $0.startingColumn } == [0, 1, 0, 1])
+    #expect(cells[0].table.numberOfColumns == 2)
+    #expect(cells.allSatisfy { $0.table === cells[0].table })
+  }
+
+  @Test("Spans round-trip through colspan and rowspan attributes")
+  func spansRoundTrip() throws {
+    let (original, fragment, reparsed) = try roundTrip(
+      "<table><tr><td colspan=\"2\" rowspan=\"2\">Big</td><td>C1</td></tr><tr><td>C2</td></tr></table>"
+    )
+
+    #expect(fragment.contains("colspan=\"2\""))
+    #expect(fragment.contains("rowspan=\"2\""))
+
+    let originalCells = tableCells(of: original)
+    let reparsedCells = tableCells(of: reparsed)
+    try #require(originalCells.count == reparsedCells.count)
+
+    for (originalCell, reparsedCell) in zip(originalCells, reparsedCells) {
+      #expect(originalCell.startingRow == reparsedCell.startingRow)
+      #expect(originalCell.startingColumn == reparsedCell.startingColumn)
+      #expect(originalCell.rowSpan == reparsedCell.rowSpan)
+      #expect(originalCell.columnSpan == reparsedCell.columnSpan)
+    }
+  }
+
+  @Test("Cell and table styling round-trips")
+  func stylingRoundTrip() throws {
+    let (original, fragment, reparsed) = try roundTrip(
+      "<table bgcolor=\"#FFEEDD\" cellpadding=\"5\"><tr>"
+        + "<td bgcolor=\"#EEFFDD\" valign=\"top\">X</td><td width=\"120\">Y</td></tr></table>")
+
+    #expect(fragment.contains("background-color:#ffeedd"))
+    #expect(fragment.contains("background-color:#eeffdd"))
+    #expect(fragment.contains("vertical-align:top"))
+    #expect(fragment.contains("padding:5px"))
+    #expect(fragment.contains("width:120px"))
+
+    let originalCells = tableCells(of: original)
+    let reparsedCells = tableCells(of: reparsed)
+    try #require(originalCells.count == 2 && reparsedCells.count == 2)
+
+    #expect(reparsedCells[0].table.backgroundColor == originalCells[0].table.backgroundColor)
+    #expect(reparsedCells[0].backgroundColor == originalCells[0].backgroundColor)
+    #expect(reparsedCells[0].verticalAlignment == .topAlignment)
+    #expect(reparsedCells[0].width(for: .padding, edge: .minXEdge) == 5)
+    #expect(reparsedCells[1].contentWidth == 120)
+  }
+
+  @Test("Borders and collapse mode round-trip")
+  func bordersRoundTrip() throws {
+    let (_, fragment, reparsed) = try roundTrip(
+      "<table style=\"border-collapse: collapse\"><tr>"
+        + "<td style=\"border: 2px solid #FF0000\">A</td><td>B</td></tr></table>")
+
+    #expect(fragment.contains("border-collapse:collapse"))
+    #expect(fragment.contains("border:2px solid #ff0000"))
+
+    let cells = tableCells(of: reparsed)
+    try #require(cells.count == 2)
+    #expect(cells[0].table.collapsesBorders == true)
+    #expect(cells[0].width(for: .border, edge: .minYEdge) == 2)
+    #expect(cells[0].borderColor(for: .minYEdge) == DTColorCreateWithHTMLName("#FF0000"))
+  }
+
+  @Test("Border styles round-trip")
+  func borderStylesRoundTrip() throws {
+    let (_, fragment, reparsed) = try roundTrip(
+      "<table><tr><td style=\"border: 2px dashed #FF0000\">dashed</td>"
+        + "<td style=\"border: 3px double #0000FF\">double</td></tr></table>")
+
+    #expect(fragment.contains("dashed"))
+    #expect(fragment.contains("double"))
+
+    let cells = tableCells(of: reparsed)
+    try #require(cells.count == 2)
+    #expect(cells[0].borderStyle(for: .minYEdge) == .dashed)
+    #expect(cells[0].width(for: .border, edge: .minYEdge) == 2)
+    #expect(cells[1].borderStyle(for: .minYEdge) == .double)
+  }
+
+  @Test("Percentage widths round-trip")
+  func percentageWidthRoundTrip() throws {
+    let (_, fragment, reparsed) = try roundTrip(
+      "<table width=\"80%\"><tr><td width=\"50%\">half</td><td>rest</td></tr></table>")
+
+    #expect(fragment.contains("width:80%"))
+    #expect(fragment.contains("width:50%"))
+
+    let cells = tableCells(of: reparsed)
+    try #require(cells.count == 2)
+    #expect(cells[0].table.contentWidth == 80)
+    #expect(cells[0].table.contentWidthValueType == .percentageValueType)
+    #expect(cells[0].contentWidth == 50)
+    #expect(cells[0].contentWidthValueType == .percentageValueType)
+  }
+
+  @Test("Nested tables round-trip")
+  func nestedTableRoundTrip() throws {
+    let (original, fragment, reparsed) = try roundTrip(
+      "<table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>"
+    )
+
+    // two opening table tags
+    #expect(fragment.components(separatedBy: "<table").count == 3)
+
+    #expect(reparsed.string == original.string)
+
+    let reparsedCells = tableCells(of: reparsed)
+    try #require(reparsedCells.count == 4)
+
+    // outer table has 2 columns, inner table has 2 columns, distinct instances
+    let outerTable = reparsedCells[0].table
+    let innerTable = reparsedCells[1].table
+    #expect(innerTable !== outerTable)
+    #expect(outerTable.numberOfColumns == 2)
+    #expect(innerTable.numberOfColumns == 2)
+  }
+
+  @Test("Content before and after a table stays outside of it")
+  func contentAroundTable() throws {
+    let (_, fragment, reparsed) = try roundTrip(
+      "<p>Before</p><table><tr><td>A</td></tr></table><p>After</p>")
+
+    let tableStart = try #require(fragment.range(of: "<table"))
+    let tableEnd = try #require(fragment.range(of: "</table>"))
+    let beforeRange = try #require(fragment.range(of: "Before"))
+    let afterRange = try #require(fragment.range(of: "After"))
+
+    #expect(beforeRange.lowerBound < tableStart.lowerBound)
+    #expect(afterRange.lowerBound > tableEnd.upperBound)
+
+    #expect(reparsed.string == "Before\nA\nAfter\n")
+  }
+}

--- a/Tests/DTCoreTextTests/TextBlockAppKitParityTests.swift
+++ b/Tests/DTCoreTextTests/TextBlockAppKitParityTests.swift
@@ -1,0 +1,470 @@
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+
+  import AppKit
+  import Foundation
+  import Testing
+
+  @testable import DTCoreText
+
+  /// Verifies that the DT text block model classes are exact mirrors of their AppKit
+  /// counterparts: identical enum raw values, identical defaults, lossless conversion in
+  /// both directions, and a faithful representation of what the system HTML importer
+  /// produces. This suite is the executable form of the findings documented in the
+  /// <doc:HTMLTablesOnMacOS> article.
+  @Suite("AppKit Parity", .serialized)
+  struct TextBlockAppKitParityTests {
+
+    private static let allEdges: [CGRectEdge] = [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge]
+
+    // MARK: - Enum raw value parity
+
+    @Test("Dimension raw values match NSTextBlock.Dimension")
+    func dimensionRawValues() {
+      #expect(TextBlock.Dimension.width.rawValue == NSTextBlock.Dimension.width.rawValue)
+      #expect(
+        TextBlock.Dimension.minimumWidth.rawValue == NSTextBlock.Dimension.minimumWidth.rawValue)
+      #expect(
+        TextBlock.Dimension.maximumWidth.rawValue == NSTextBlock.Dimension.maximumWidth.rawValue)
+      #expect(TextBlock.Dimension.height.rawValue == NSTextBlock.Dimension.height.rawValue)
+      #expect(
+        TextBlock.Dimension.minimumHeight.rawValue == NSTextBlock.Dimension.minimumHeight.rawValue)
+      #expect(
+        TextBlock.Dimension.maximumHeight.rawValue == NSTextBlock.Dimension.maximumHeight.rawValue)
+    }
+
+    @Test("ValueType raw values match NSTextBlock.ValueType")
+    func valueTypeRawValues() {
+      #expect(
+        TextBlock.ValueType.absoluteValueType.rawValue
+          == NSTextBlock.ValueType.absoluteValueType.rawValue)
+      #expect(
+        TextBlock.ValueType.percentageValueType.rawValue
+          == NSTextBlock.ValueType.percentageValueType.rawValue)
+    }
+
+    @Test("Layer raw values match NSTextBlock.Layer")
+    func layerRawValues() {
+      #expect(TextBlock.Layer.padding.rawValue == NSTextBlock.Layer.padding.rawValue)
+      #expect(TextBlock.Layer.border.rawValue == NSTextBlock.Layer.border.rawValue)
+      #expect(TextBlock.Layer.margin.rawValue == NSTextBlock.Layer.margin.rawValue)
+    }
+
+    @Test("VerticalAlignment raw values match NSTextBlock.VerticalAlignment")
+    func verticalAlignmentRawValues() {
+      #expect(
+        TextBlock.VerticalAlignment.topAlignment.rawValue
+          == NSTextBlock.VerticalAlignment.topAlignment.rawValue)
+      #expect(
+        TextBlock.VerticalAlignment.middleAlignment.rawValue
+          == NSTextBlock.VerticalAlignment.middleAlignment.rawValue)
+      #expect(
+        TextBlock.VerticalAlignment.bottomAlignment.rawValue
+          == NSTextBlock.VerticalAlignment.bottomAlignment.rawValue)
+      #expect(
+        TextBlock.VerticalAlignment.baselineAlignment.rawValue
+          == NSTextBlock.VerticalAlignment.baselineAlignment.rawValue)
+    }
+
+    @Test("LayoutAlgorithm raw values match NSTextTable.LayoutAlgorithm")
+    func layoutAlgorithmRawValues() {
+      #expect(
+        TextTable.LayoutAlgorithm.automaticLayoutAlgorithm.rawValue
+          == NSTextTable.LayoutAlgorithm.automaticLayoutAlgorithm.rawValue)
+      #expect(
+        TextTable.LayoutAlgorithm.fixedLayoutAlgorithm.rawValue
+          == NSTextTable.LayoutAlgorithm.fixedLayoutAlgorithm.rawValue)
+    }
+
+    @Test("CGRectEdge raw values match NSRectEdge")
+    func edgeRawValues() {
+      #expect(UInt(CGRectEdge.minXEdge.rawValue) == NSRectEdge.minX.rawValue)
+      #expect(UInt(CGRectEdge.minYEdge.rawValue) == NSRectEdge.minY.rawValue)
+      #expect(UInt(CGRectEdge.maxXEdge.rawValue) == NSRectEdge.maxX.rawValue)
+      #expect(UInt(CGRectEdge.maxYEdge.rawValue) == NSRectEdge.maxY.rawValue)
+    }
+
+    // MARK: - Property comparison helper
+
+    /// Asserts that a DT block and an NSTextBlock carry identical block-level properties.
+    private func expectEqualBlockProperties(
+      _ block: TextBlock, _ nsBlock: NSTextBlock,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+      for dimension in [
+        TextBlock.Dimension.width, .minimumWidth, .maximumWidth, .height, .minimumHeight,
+        .maximumHeight,
+      ] {
+        let nsDimension = NSTextBlock.Dimension(rawValue: dimension.rawValue)!
+        #expect(
+          block.value(for: dimension) == nsBlock.value(for: nsDimension),
+          "dimension \(dimension)", sourceLocation: sourceLocation)
+        #expect(
+          block.valueType(for: dimension).rawValue == nsBlock.valueType(for: nsDimension).rawValue,
+          "dimension type \(dimension)", sourceLocation: sourceLocation)
+      }
+
+      for layer in [TextBlock.Layer.padding, .border, .margin] {
+        let nsLayer = NSTextBlock.Layer(rawValue: layer.rawValue)!
+
+        for edge in Self.allEdges {
+          let nsEdge = NSRectEdge(rawValue: UInt(edge.rawValue))!
+          #expect(
+            block.width(for: layer, edge: edge) == nsBlock.width(for: nsLayer, edge: nsEdge),
+            "layer \(layer) edge \(edge)", sourceLocation: sourceLocation)
+          #expect(
+            block.widthValueType(for: layer, edge: edge).rawValue
+              == nsBlock.widthValueType(for: nsLayer, edge: nsEdge).rawValue,
+            "layer type \(layer) edge \(edge)", sourceLocation: sourceLocation)
+        }
+      }
+
+      for edge in Self.allEdges {
+        let nsEdge = NSRectEdge(rawValue: UInt(edge.rawValue))!
+        #expect(
+          block.borderColor(for: edge) == nsBlock.borderColor(for: nsEdge),
+          "border color edge \(edge)", sourceLocation: sourceLocation)
+      }
+
+      #expect(
+        block.backgroundColor == nsBlock.backgroundColor, "background color",
+        sourceLocation: sourceLocation)
+      #expect(
+        block.verticalAlignment.rawValue == nsBlock.verticalAlignment.rawValue,
+        "vertical alignment", sourceLocation: sourceLocation)
+    }
+
+    // MARK: - Defaults and round-trip
+
+    @Test("Freshly initialized blocks have identical defaults")
+    func defaultsParity() {
+      expectEqualBlockProperties(TextBlock(), NSTextBlock())
+
+      let table = TextTable()
+      let nsTable = NSTextTable()
+      expectEqualBlockProperties(table, nsTable)
+      #expect(table.numberOfColumns == nsTable.numberOfColumns)
+      #expect(table.layoutAlgorithm.rawValue == nsTable.layoutAlgorithm.rawValue)
+      #expect(table.collapsesBorders == nsTable.collapsesBorders)
+      #expect(table.hidesEmptyCells == nsTable.hidesEmptyCells)
+    }
+
+    @Test("Conversion to AppKit and back is lossless")
+    func conversionRoundTrip() throws {
+      let table = TextTable()
+      table.numberOfColumns = 3
+      table.layoutAlgorithm = .fixedLayoutAlgorithm
+      table.collapsesBorders = true
+      table.hidesEmptyCells = true
+      table.setValue(80, type: .percentageValueType, for: .width)
+      table.setWidth(2, type: .absoluteValueType, for: .border)
+      table.backgroundColor = NSColor.yellow
+
+      let cell = TextTableBlock(
+        table: table, startingRow: 1, rowSpan: 2, startingColumn: 0, columnSpan: 3)
+      cell.setValue(120, type: .absoluteValueType, for: .width)
+      cell.setValue(100, type: .absoluteValueType, for: .minimumWidth)
+      cell.padding = DTEdgeInsets(top: 1, left: 4, bottom: 3, right: 2)
+      cell.setWidth(0.5, type: .absoluteValueType, for: .margin)
+      cell.setBorderColor(NSColor.red, for: .minYEdge)
+      cell.setBorderColor(NSColor.blue, for: .maxXEdge)
+      cell.verticalAlignment = .middleAlignment
+
+      let toNS = TextBlockConverter()
+      let nsCell = try #require(toNS.nsTextBlock(from: cell) as? NSTextTableBlock)
+
+      // NS side carries identical properties
+      expectEqualBlockProperties(cell, nsCell)
+      expectEqualBlockProperties(table, nsCell.table)
+      #expect(nsCell.startingRow == 1)
+      #expect(nsCell.rowSpan == 2)
+      #expect(nsCell.startingColumn == 0)
+      #expect(nsCell.columnSpan == 3)
+      #expect(nsCell.table.numberOfColumns == 3)
+      #expect(nsCell.table.layoutAlgorithm == .fixedLayoutAlgorithm)
+      #expect(nsCell.table.collapsesBorders == true)
+      #expect(nsCell.table.hidesEmptyCells == true)
+
+      // converting the same instance again returns the same NS instance
+      #expect(toNS.nsTextBlock(from: cell) === nsCell)
+      #expect(toNS.nsTextTable(from: table) === nsCell.table)
+
+      // and back
+      let toDT = TextBlockConverter()
+      let backCell = try #require(toDT.textBlock(from: nsCell) as? TextTableBlock)
+
+      expectEqualBlockProperties(backCell, nsCell)
+      #expect(backCell.startingRow == cell.startingRow)
+      #expect(backCell.rowSpan == cell.rowSpan)
+      #expect(backCell.startingColumn == cell.startingColumn)
+      #expect(backCell.columnSpan == cell.columnSpan)
+      #expect(backCell.table.numberOfColumns == table.numberOfColumns)
+      #expect(backCell.table.layoutAlgorithm == table.layoutAlgorithm)
+      #expect(backCell.table.collapsesBorders == table.collapsesBorders)
+      #expect(backCell.table.hidesEmptyCells == table.hidesEmptyCells)
+      #expect(toDT.textBlock(from: nsCell) === backCell)
+    }
+
+    @Test("Table classes compare by identity like their AppKit counterparts")
+    func identityEqualityParity() {
+      // two value-identical tables are distinct objects on both sides
+      #expect(NSTextTable() != NSTextTable())
+      #expect(TextTable() != TextTable())
+
+      let nsTable = NSTextTable()
+      #expect(
+        NSTextTableBlock(table: nsTable, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+          != NSTextTableBlock(
+            table: nsTable, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1))
+
+      let table = TextTable()
+      #expect(
+        TextTableBlock(table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+          != TextTableBlock(
+            table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1))
+    }
+
+    // MARK: - System HTML importer fixtures
+
+    /// Imports an HTML fragment via the system importer (the same call TextEdit uses).
+    @MainActor
+    private func systemAttributedString(fromHTML html: String) throws -> NSAttributedString {
+      let data = Data(html.utf8)
+      return try NSAttributedString(
+        data: data,
+        options: [
+          .documentType: NSAttributedString.DocumentType.html,
+          .characterEncoding: String.Encoding.utf8.rawValue,
+        ],
+        documentAttributes: nil)
+    }
+
+    /// The `textBlocks` array of the paragraph style governing each paragraph.
+    private func paragraphTextBlocks(of attributedString: NSAttributedString) -> [[NSTextBlock]] {
+      let nsString = attributedString.string as NSString
+      var result = [[NSTextBlock]]()
+      var location = 0
+
+      while location < nsString.length {
+        let paragraphRange = nsString.paragraphRange(for: NSRange(location: location, length: 0))
+        let style =
+          attributedString.attribute(.paragraphStyle, at: paragraphRange.location, effectiveRange: nil)
+          as? NSParagraphStyle
+        result.append(style?.textBlocks ?? [])
+        location = NSMaxRange(paragraphRange)
+      }
+
+      return result
+    }
+
+    @Test("Simple 2x2 table: one shared table, one block per cell")
+    @MainActor
+    func importerSimpleTable() throws {
+      let attributedString = try systemAttributedString(
+        fromHTML:
+          "<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>")
+
+      #expect(attributedString.string == "A1\nB1\nA2\nB2\n")
+
+      let paragraphBlocks = paragraphTextBlocks(of: attributedString)
+      #expect(paragraphBlocks.count == 4)
+
+      let nsCells = paragraphBlocks.compactMap { $0.first as? NSTextTableBlock }
+      try #require(nsCells.count == 4)
+
+      // all cells share one table instance
+      let nsTable = nsCells[0].table
+      #expect(nsCells.allSatisfy { $0.table === nsTable })
+      #expect(nsTable.numberOfColumns == 2)
+
+      // grid coordinates in reading order
+      #expect(nsCells.map { $0.startingRow } == [0, 0, 1, 1])
+      #expect(nsCells.map { $0.startingColumn } == [0, 1, 0, 1])
+
+      // convert to the DT model with one converter for the whole string
+      let converter = TextBlockConverter()
+      let cells = nsCells.compactMap { converter.textBlock(from: $0) as? TextTableBlock }
+      try #require(cells.count == 4)
+
+      // shared table identity survives the conversion
+      let table = cells[0].table
+      #expect(cells.allSatisfy { $0.table === table })
+      #expect(table.numberOfColumns == 2)
+
+      // importer defaults: padding 1pt, margin 0.5pt on every edge, middle alignment
+      for (cell, nsCell) in zip(cells, nsCells) {
+        for edge in Self.allEdges {
+          #expect(cell.width(for: .padding, edge: edge) == 1)
+          #expect(cell.width(for: .margin, edge: edge) == 0.5)
+          #expect(cell.width(for: .border, edge: edge) == 0)
+        }
+        #expect(cell.verticalAlignment == .middleAlignment)
+        #expect(cell.contentWidthValueType == .absoluteValueType)
+        #expect(cell.contentWidth > 0)
+
+        // full property parity with the system-imported original
+        expectEqualBlockProperties(cell, nsCell)
+        #expect(cell.startingRow == nsCell.startingRow)
+        #expect(cell.startingColumn == nsCell.startingColumn)
+      }
+    }
+
+    @Test("Column and row spans map to columnSpan/rowSpan")
+    @MainActor
+    func importerSpans() throws {
+      let colspanString = try systemAttributedString(
+        fromHTML:
+          "<table><tr><td colspan=\"2\">Wide</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></table>"
+      )
+
+      let colspanCells = paragraphTextBlocks(of: colspanString).compactMap {
+        $0.first as? NSTextTableBlock
+      }
+      #expect(colspanCells.count == 5)
+      #expect(colspanCells[0].columnSpan == 2)
+      #expect(colspanCells[0].table.numberOfColumns == 3)
+
+      // the cell after the span starts at the skipped grid index
+      #expect(colspanCells[1].startingColumn == 2)
+
+      let converter = TextBlockConverter()
+      let wide = try #require(converter.textBlock(from: colspanCells[0]) as? TextTableBlock)
+      #expect(wide.columnSpan == 2)
+      #expect(wide.startingColumn == 0)
+
+      let rowspanString = try systemAttributedString(
+        fromHTML:
+          "<table><tr><td rowspan=\"2\">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>")
+
+      let rowspanCells = paragraphTextBlocks(of: rowspanString).compactMap {
+        $0.first as? NSTextTableBlock
+      }
+
+      // no placeholder block exists for the covered grid position
+      #expect(rowspanCells.count == 3)
+      #expect(rowspanCells[0].rowSpan == 2)
+      #expect(rowspanCells[2].startingRow == 1)
+      #expect(rowspanCells[2].startingColumn == 1)
+    }
+
+    @Test("Nested tables produce outermost-first block arrays with shared instances")
+    @MainActor
+    func importerNestedTables() throws {
+      let attributedString = try systemAttributedString(
+        fromHTML:
+          "<table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>"
+      )
+
+      let paragraphBlocks = paragraphTextBlocks(of: attributedString)
+      #expect(paragraphBlocks.map { $0.count } == [1, 2, 2, 1, 1])
+
+      // the outer cell block is the same instance wherever it appears
+      let outerCell = try #require(paragraphBlocks[0].first as? NSTextTableBlock)
+      #expect(paragraphBlocks[1][0] === outerCell)
+      #expect(paragraphBlocks[2][0] === outerCell)
+      #expect(paragraphBlocks[3][0] === outerCell)
+      #expect(paragraphBlocks[4][0] !== outerCell)
+
+      // inner cells belong to a different table than the outer cells
+      let innerCell1 = try #require(paragraphBlocks[1][1] as? NSTextTableBlock)
+      let innerCell2 = try #require(paragraphBlocks[2][1] as? NSTextTableBlock)
+      #expect(innerCell1.table === innerCell2.table)
+      #expect(innerCell1.table !== outerCell.table)
+
+      // identity relationships survive conversion to the DT model
+      let converter = TextBlockConverter()
+      let convertedParagraphs = paragraphBlocks.map { converter.textBlocks(from: $0) }
+
+      #expect(convertedParagraphs[1][0] === convertedParagraphs[0][0])
+      #expect(convertedParagraphs[3][0] === convertedParagraphs[0][0])
+
+      let convertedInner1 = try #require(convertedParagraphs[1][1] as? TextTableBlock)
+      let convertedInner2 = try #require(convertedParagraphs[2][1] as? TextTableBlock)
+      let convertedOuter = try #require(convertedParagraphs[0][0] as? TextTableBlock)
+      #expect(convertedInner1.table === convertedInner2.table)
+      #expect(convertedInner1.table !== convertedOuter.table)
+    }
+
+    @Test("Multi-paragraph cells share one block instance")
+    @MainActor
+    func importerMultiParagraphCell() throws {
+      let attributedString = try systemAttributedString(
+        fromHTML: "<table><tr><td><p>One</p><p>Two</p></td><td>B</td></tr></table>")
+
+      let paragraphBlocks = paragraphTextBlocks(of: attributedString)
+      #expect(paragraphBlocks.count == 3)
+      #expect(paragraphBlocks[0].first === paragraphBlocks[1].first)
+      #expect(paragraphBlocks[0].first !== paragraphBlocks[2].first)
+
+      let converter = TextBlockConverter()
+      let first = converter.textBlock(from: paragraphBlocks[0][0])
+      let second = converter.textBlock(from: paragraphBlocks[1][0])
+      #expect(first === second)
+    }
+
+    @Test("CSS box properties map onto layers, edges and colors")
+    @MainActor
+    func importerCSSBox() throws {
+      let attributedString = try systemAttributedString(
+        fromHTML: "<table style=\"border-collapse: collapse;\"><tr>"
+          + "<td style=\"padding: 1px 2px 3px 4px; border-top: 1px solid #FF0000; border-right: 2px solid #00FF00; border-bottom: 3px solid #0000FF; border-left: 4px solid #FF00FF; background-color: #ABCDEF; width: 120px; vertical-align: baseline;\">styled</td>"
+          + "<td>plain</td></tr></table>")
+
+      let nsCell = try #require(
+        paragraphTextBlocks(of: attributedString).first?.first as? NSTextTableBlock)
+
+      let converter = TextBlockConverter()
+      let cell = try #require(converter.textBlock(from: nsCell) as? TextTableBlock)
+
+      // border-collapse lands on the table
+      #expect(cell.table.collapsesBorders == true)
+
+      // CSS padding order is top right bottom left; minX=left minY=top maxX=right maxY=bottom
+      #expect(cell.width(for: .padding, edge: .minYEdge) == 1)
+      #expect(cell.width(for: .padding, edge: .maxXEdge) == 2)
+      #expect(cell.width(for: .padding, edge: .maxYEdge) == 3)
+      #expect(cell.width(for: .padding, edge: .minXEdge) == 4)
+      #expect(cell.padding.top == 1)
+      #expect(cell.padding.right == 2)
+      #expect(cell.padding.bottom == 3)
+      #expect(cell.padding.left == 4)
+
+      // per-edge border widths
+      #expect(cell.width(for: .border, edge: .minYEdge) == 1)
+      #expect(cell.width(for: .border, edge: .maxXEdge) == 2)
+      #expect(cell.width(for: .border, edge: .maxYEdge) == 3)
+      #expect(cell.width(for: .border, edge: .minXEdge) == 4)
+
+      // per-edge border colors
+      expectColor(cell.borderColor(for: .minYEdge), red: 1, green: 0, blue: 0)
+      expectColor(cell.borderColor(for: .maxXEdge), red: 0, green: 1, blue: 0)
+      expectColor(cell.borderColor(for: .maxYEdge), red: 0, green: 0, blue: 1)
+      expectColor(cell.borderColor(for: .minXEdge), red: 1, green: 0, blue: 1)
+
+      expectColor(
+        cell.backgroundColor, red: 0xAB / 255.0, green: 0xCD / 255.0, blue: 0xEF / 255.0)
+
+      #expect(cell.contentWidth == 120)
+      #expect(cell.contentWidthValueType == .absoluteValueType)
+      #expect(cell.verticalAlignment == .baselineAlignment)
+
+      // round-trip back to AppKit preserves everything
+      let backConverter = TextBlockConverter()
+      expectEqualBlockProperties(cell, backConverter.nsTextBlock(from: cell))
+    }
+
+    private func expectColor(
+      _ color: NSColor?, red: CGFloat, green: CGFloat, blue: CGFloat,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+      guard let rgb = color?.usingColorSpace(.sRGB) else {
+        Issue.record("color is nil or not convertible", sourceLocation: sourceLocation)
+        return
+      }
+
+      #expect(abs(rgb.redComponent - red) < 0.01, sourceLocation: sourceLocation)
+      #expect(abs(rgb.greenComponent - green) < 0.01, sourceLocation: sourceLocation)
+      #expect(abs(rgb.blueComponent - blue) < 0.01, sourceLocation: sourceLocation)
+    }
+  }
+
+#endif

--- a/Tests/DTCoreTextTests/TextTableTests.swift
+++ b/Tests/DTCoreTextTests/TextTableTests.swift
@@ -1,0 +1,324 @@
+import Foundation
+import Testing
+
+@testable import DTCoreText
+
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
+/// Tests for the extended NSTextBlock-style API of `TextBlock` and the table model
+/// classes `TextTable` and `TextTableBlock`.
+@Suite("Text Table Model", .serialized)
+struct TextTableTests {
+
+  // MARK: - TextBlock extended API
+
+  @Test("Dimensions store value and value type")
+  func dimensions() {
+    let block = TextBlock()
+
+    // defaults
+    #expect(block.value(for: .width) == 0)
+    #expect(block.valueType(for: .width) == .absoluteValueType)
+    #expect(block.verticalAlignment == .topAlignment)
+
+    block.setValue(120, type: .absoluteValueType, for: .width)
+    block.setValue(50, type: .percentageValueType, for: .maximumWidth)
+    block.setValue(33, type: .absoluteValueType, for: .minimumHeight)
+
+    #expect(block.value(for: .width) == 120)
+    #expect(block.valueType(for: .width) == .absoluteValueType)
+    #expect(block.value(for: .maximumWidth) == 50)
+    #expect(block.valueType(for: .maximumWidth) == .percentageValueType)
+    #expect(block.value(for: .minimumHeight) == 33)
+
+    // dimensions are independent
+    #expect(block.value(for: .minimumWidth) == 0)
+    #expect(block.value(for: .height) == 0)
+
+    block.setContentWidth(80, type: .percentageValueType)
+    #expect(block.contentWidth == 80)
+    #expect(block.contentWidthValueType == .percentageValueType)
+  }
+
+  @Test("Layer widths are stored per layer and edge")
+  func layerWidths() {
+    let block = TextBlock()
+
+    block.setWidth(1, type: .absoluteValueType, for: .padding, edge: .minYEdge)
+    block.setWidth(2, type: .absoluteValueType, for: .border, edge: .maxXEdge)
+    block.setWidth(3, type: .percentageValueType, for: .margin, edge: .maxYEdge)
+
+    #expect(block.width(for: .padding, edge: .minYEdge) == 1)
+    #expect(block.width(for: .border, edge: .maxXEdge) == 2)
+    #expect(block.width(for: .margin, edge: .maxYEdge) == 3)
+    #expect(block.widthValueType(for: .margin, edge: .maxYEdge) == .percentageValueType)
+
+    // other layer/edge combinations stay untouched
+    #expect(block.width(for: .padding, edge: .maxXEdge) == 0)
+    #expect(block.width(for: .border, edge: .minYEdge) == 0)
+
+    // setting all edges at once
+    block.setWidth(5, type: .absoluteValueType, for: .border)
+    for edge: CGRectEdge in [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge] {
+      #expect(block.width(for: .border, edge: edge) == 5)
+    }
+  }
+
+  @Test("Padding convenience maps onto the padding layer")
+  func paddingConvenience() {
+    let block = TextBlock()
+    block.padding = DTEdgeInsets(top: 1, left: 4, bottom: 3, right: 2)
+
+    #expect(block.width(for: .padding, edge: .minYEdge) == 1)
+    #expect(block.width(for: .padding, edge: .minXEdge) == 4)
+    #expect(block.width(for: .padding, edge: .maxYEdge) == 3)
+    #expect(block.width(for: .padding, edge: .maxXEdge) == 2)
+
+    block.setWidth(10, type: .absoluteValueType, for: .padding, edge: .minYEdge)
+    #expect(block.padding.top == 10)
+    #expect(block.padding.left == 4)
+  }
+
+  @Test("Border colors are stored per edge")
+  func borderColors() {
+    let block = TextBlock()
+    let red = DTColorCreateWithHTMLName("red")
+    let blue = DTColorCreateWithHTMLName("blue")
+
+    #expect(block.borderColor(for: .minXEdge) == nil)
+
+    block.setBorderColor(red, for: .minYEdge)
+    #expect(block.borderColor(for: .minYEdge) == red)
+    #expect(block.borderColor(for: .maxYEdge) == nil)
+
+    block.setBorderColor(blue)
+    for edge: CGRectEdge in [.minXEdge, .minYEdge, .maxXEdge, .maxYEdge] {
+      #expect(block.borderColor(for: edge) == blue)
+    }
+  }
+
+  @Test("Equality covers the extended properties")
+  func extendedEquality() {
+    let block1 = TextBlock()
+    let block2 = TextBlock()
+    #expect(block1 == block2)
+
+    block1.setValue(100, type: .absoluteValueType, for: .width)
+    #expect(block1 != block2)
+
+    block2.setValue(100, type: .absoluteValueType, for: .width)
+    #expect(block1 == block2)
+
+    // same value, different value type
+    block2.setValue(100, type: .percentageValueType, for: .width)
+    #expect(block1 != block2)
+    block2.setValue(100, type: .absoluteValueType, for: .width)
+
+    block1.verticalAlignment = .middleAlignment
+    #expect(block1 != block2)
+    block2.verticalAlignment = .middleAlignment
+    #expect(block1 == block2)
+
+    block1.setBorderColor(DTColorCreateWithHTMLName("red"), for: .minXEdge)
+    #expect(block1 != block2)
+    block2.setBorderColor(DTColorCreateWithHTMLName("red"), for: .minXEdge)
+    #expect(block1 == block2)
+  }
+
+  @Test("Different block classes are never equal")
+  func classMismatchInequality() {
+    let block = TextBlock()
+    let table = TextTable()
+    let cell = TextTableBlock(table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+
+    #expect(block != table)
+    #expect(table != block)
+    #expect(block != cell)
+    #expect(cell != block)
+  }
+
+  // MARK: - TextTable
+
+  @Test("Table properties and identity equality")
+  func tableProperties() {
+    let table = TextTable()
+
+    // defaults
+    #expect(table.numberOfColumns == 0)
+    #expect(table.layoutAlgorithm == .automaticLayoutAlgorithm)
+    #expect(table.collapsesBorders == false)
+    #expect(table.hidesEmptyCells == false)
+
+    table.numberOfColumns = 3
+    table.layoutAlgorithm = .fixedLayoutAlgorithm
+    table.collapsesBorders = true
+    table.hidesEmptyCells = true
+
+    #expect(table.numberOfColumns == 3)
+    #expect(table.layoutAlgorithm == .fixedLayoutAlgorithm)
+
+    // tables compare by identity like NSTextTable: identical properties are still
+    // distinct tables (Foundation uniques value-equal attribute dictionaries, which
+    // would otherwise merge separate tables)
+    let other = TextTable()
+    other.numberOfColumns = 3
+    other.layoutAlgorithm = .fixedLayoutAlgorithm
+    other.collapsesBorders = true
+    other.hidesEmptyCells = true
+    #expect(table != other)
+    #expect(table == table)
+
+    let cellA = TextTableBlock(table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+    let cellB = TextTableBlock(table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+    #expect(cellA != cellB)
+    #expect(cellA == cellA)
+  }
+
+  @Test("Table block carries grid geometry")
+  func tableBlockGeometry() {
+    let table = TextTable()
+    table.numberOfColumns = 3
+
+    let cell = TextTableBlock(table: table, startingRow: 1, rowSpan: 2, startingColumn: 0, columnSpan: 3)
+
+    #expect(cell.table === table)
+    #expect(cell.startingRow == 1)
+    #expect(cell.rowSpan == 2)
+    #expect(cell.startingColumn == 0)
+    #expect(cell.columnSpan == 3)
+  }
+
+  // MARK: - NSCoding
+
+  private func archiveRoundTrip<T: NSObject & NSCoding>(_ object: T) throws -> T {
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: object, requiringSecureCoding: false)
+    let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+    unarchiver.requiresSecureCoding = false
+    let result = unarchiver.decodeObject(forKey: NSKeyedArchiveRootObjectKey) as! T
+    return result
+  }
+
+  @Test("NSCoding round-trip preserves extended properties")
+  func codingExtendedProperties() throws {
+    let block = TextBlock()
+    block.setValue(120, type: .absoluteValueType, for: .width)
+    block.setValue(50, type: .percentageValueType, for: .maximumWidth)
+    block.setWidth(1, type: .absoluteValueType, for: .padding, edge: .minYEdge)
+    block.setWidth(2.5, type: .absoluteValueType, for: .margin)
+    block.setWidth(4, type: .percentageValueType, for: .border, edge: .maxXEdge)
+    block.setBorderColor(DTColorCreateWithHTMLName("red"), for: .minYEdge)
+    block.setBorderStyle(.dashed, for: .minYEdge)
+    block.setBorderStyle(.double, for: .maxXEdge)
+    block.backgroundColor = DTColorCreateWithHTMLName("yellow")
+    block.verticalAlignment = .baselineAlignment
+
+    let unarchived = try archiveRoundTrip(block)
+
+    #expect(unarchived == block)
+    #expect(unarchived.borderStyle(for: .minYEdge) == .dashed)
+    #expect(unarchived.borderStyle(for: .maxXEdge) == .double)
+    #expect(unarchived.borderStyle(for: .maxYEdge) == .solid)
+    #expect(unarchived.value(for: .maximumWidth) == 50)
+    #expect(unarchived.valueType(for: .maximumWidth) == .percentageValueType)
+    #expect(unarchived.widthValueType(for: .border, edge: .maxXEdge) == .percentageValueType)
+    #expect(unarchived.verticalAlignment == .baselineAlignment)
+  }
+
+  @Test("Legacy archives with only padding and background color stay readable")
+  func codingLegacyFormat() throws {
+    let payload = LegacyTextBlockPayload(
+      insets: DTEdgeInsets(top: 10, left: 20, bottom: 30, right: 40),
+      color: DTColorCreateWithHTMLName("red"))
+
+    let archiver = NSKeyedArchiver(requiringSecureCoding: false)
+    archiver.setClassName("DTTextBlock", for: LegacyTextBlockPayload.self)
+    archiver.encode(payload, forKey: NSKeyedArchiveRootObjectKey)
+    archiver.finishEncoding()
+
+    let unarchiver = try NSKeyedUnarchiver(forReadingFrom: archiver.encodedData)
+    unarchiver.requiresSecureCoding = false
+    let block = try #require(
+      unarchiver.decodeObject(forKey: NSKeyedArchiveRootObjectKey) as? TextBlock)
+
+    #expect(block.padding.top == 10)
+    #expect(block.padding.left == 20)
+    #expect(block.padding.bottom == 30)
+    #expect(block.padding.right == 40)
+    #expect(block.backgroundColor == DTColorCreateWithHTMLName("red"))
+    #expect(block.verticalAlignment == .topAlignment)
+  }
+
+  @Test("NSCoding round-trip preserves table properties")
+  func codingTable() throws {
+    let table = TextTable()
+    table.numberOfColumns = 4
+    table.layoutAlgorithm = .fixedLayoutAlgorithm
+    table.collapsesBorders = true
+    table.hidesEmptyCells = true
+    table.setWidth(2, type: .absoluteValueType, for: .border)
+    table.backgroundColor = DTColorCreateWithHTMLName("yellow")
+
+    let unarchived = try archiveRoundTrip(table)
+
+    #expect(unarchived.numberOfColumns == 4)
+    #expect(unarchived.layoutAlgorithm == .fixedLayoutAlgorithm)
+    #expect(unarchived.collapsesBorders == true)
+    #expect(unarchived.hidesEmptyCells == true)
+    #expect(unarchived.width(for: .border, edge: .minXEdge) == 2)
+    #expect(unarchived.backgroundColor == DTColorCreateWithHTMLName("yellow"))
+  }
+
+  @Test("NSCoding preserves the shared table instance across cells")
+  func codingSharedTableIdentity() throws {
+    let table = TextTable()
+    table.numberOfColumns = 2
+
+    let cellA = TextTableBlock(
+      table: table, startingRow: 0, rowSpan: 1, startingColumn: 0, columnSpan: 1)
+    let cellB = TextTableBlock(
+      table: table, startingRow: 0, rowSpan: 1, startingColumn: 1, columnSpan: 2)
+
+    let data = try NSKeyedArchiver.archivedData(
+      withRootObject: [cellA, cellB], requiringSecureCoding: false)
+    let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+    unarchiver.requiresSecureCoding = false
+    let cells = try #require(
+      unarchiver.decodeObject(forKey: NSKeyedArchiveRootObjectKey) as? [TextTableBlock])
+
+    #expect(cells.count == 2)
+    #expect(cells[0].table === cells[1].table)
+    #expect(cells[0].table.numberOfColumns == 2)
+    #expect(cells[0].startingColumn == 0)
+    #expect(cells[1].startingColumn == 1)
+    #expect(cells[1].columnSpan == 2)
+    #expect(cells[0].startingRow == cellA.startingRow)
+    #expect(cells[1].rowSpan == cellB.rowSpan)
+  }
+}
+
+/// Encodes only the keys that pre-table versions of DTCoreText wrote for a DTTextBlock,
+/// to simulate decoding a legacy archive.
+@objc(DTTestLegacyTextBlockPayload)
+private final class LegacyTextBlockPayload: NSObject, NSCoding {
+  let insets: DTEdgeInsets
+  let color: DTColor?
+
+  init(insets: DTEdgeInsets, color: DTColor?) {
+    self.insets = insets
+    self.color = color
+  }
+
+  func encode(with coder: NSCoder) {
+    coder.encodeDTEdgeInsets(insets, forKey: "padding")
+    coder.encode(color, forKey: "backgroundColor")
+  }
+
+  required init?(coder: NSCoder) {
+    return nil
+  }
+}

--- a/Tools/TableInvestigation/main.swift
+++ b/Tools/TableInvestigation/main.swift
@@ -1,0 +1,487 @@
+#!/usr/bin/env swift
+//
+//  main.swift
+//  TableInvestigation
+//
+//  Investigates how the macOS system HTML importer (NSAttributedString with
+//  NSHTMLTextDocumentType) represents HTML tables in attributed strings:
+//  NSTextTable, NSTextTableBlock and plain NSTextBlock instances inside
+//  NSParagraphStyle.textBlocks.
+//
+//  This is the empirical basis for the DT* compatibility layer that mirrors
+//  these classes on iOS (pre iOS 27). See GitHub issue #1317.
+//
+//  Run with: swift Tools/TableInvestigation/main.swift
+//
+
+import AppKit
+
+// MARK: - Identity registries (to observe instance sharing)
+
+var tableIDs: [ObjectIdentifier: String] = [:]
+var blockIDs: [ObjectIdentifier: String] = [:]
+var orderedTables: [NSTextTable] = []
+var orderedBlocks: [NSTextBlock] = []
+
+func register(_ block: NSTextBlock) -> String {
+  let oid = ObjectIdentifier(block)
+
+  if let table = block as? NSTextTable {
+    if let existing = tableIDs[oid] { return existing }
+    let name = "T\(orderedTables.count + 1)"
+    tableIDs[oid] = name
+    orderedTables.append(table)
+    return name
+  }
+
+  if let existing = blockIDs[oid] { return existing }
+  let name = "B\(orderedBlocks.count + 1)"
+  blockIDs[oid] = name
+  orderedBlocks.append(block)
+  return name
+}
+
+func resetRegistries() {
+  tableIDs.removeAll()
+  blockIDs.removeAll()
+  orderedTables.removeAll()
+  orderedBlocks.removeAll()
+}
+
+// MARK: - Formatting helpers
+
+func fmt(_ value: CGFloat) -> String {
+  return String(format: "%g", Double(value))
+}
+
+func escaped(_ string: String) -> String {
+  var result = ""
+  for character in string.unicodeScalars {
+    switch character {
+    case "\n": result += "\\n"
+    case "\r": result += "\\r"
+    case "\t": result += "\\t"
+    case "\u{FFFC}": result += "[OBJ]"
+    case "\u{00A0}": result += "[NBSP]"
+    case "\u{2028}": result += "[LSEP]"
+    case "\u{2029}": result += "[PSEP]"
+    default: result.unicodeScalars.append(character)
+    }
+  }
+  return result
+}
+
+func describe(_ color: NSColor?) -> String {
+  guard let color = color else { return "nil" }
+  guard let rgb = color.usingColorSpace(.sRGB) else { return "\(color)" }
+  return String(
+    format: "#%02X%02X%02X a=%.2f",
+    Int(round(rgb.redComponent * 255)),
+    Int(round(rgb.greenComponent * 255)),
+    Int(round(rgb.blueComponent * 255)),
+    Double(rgb.alphaComponent))
+}
+
+func name(of valueType: NSTextBlock.ValueType) -> String {
+  switch valueType {
+  case .absoluteValueType: return "abs"
+  case .percentageValueType: return "%"
+  @unknown default: return "?(\(valueType.rawValue))"
+  }
+}
+
+func name(of alignment: NSTextBlock.VerticalAlignment) -> String {
+  switch alignment {
+  case .topAlignment: return "top"
+  case .middleAlignment: return "middle"
+  case .bottomAlignment: return "bottom"
+  case .baselineAlignment: return "baseline"
+  @unknown default: return "?(\(alignment.rawValue))"
+  }
+}
+
+func name(of algorithm: NSTextTable.LayoutAlgorithm) -> String {
+  switch algorithm {
+  case .automaticLayoutAlgorithm: return "automatic"
+  case .fixedLayoutAlgorithm: return "fixed"
+  @unknown default: return "?(\(algorithm.rawValue))"
+  }
+}
+
+func name(of textAlignment: NSTextAlignment) -> String {
+  switch textAlignment {
+  case .left: return "left"
+  case .right: return "right"
+  case .center: return "center"
+  case .justified: return "justified"
+  case .natural: return "natural"
+  @unknown default: return "?(\(textAlignment.rawValue))"
+  }
+}
+
+let allDimensions: [(NSTextBlock.Dimension, String)] = [
+  (.width, "width"),
+  (.minimumWidth, "minWidth"),
+  (.maximumWidth, "maxWidth"),
+  (.height, "height"),
+  (.minimumHeight, "minHeight"),
+  (.maximumHeight, "maxHeight"),
+]
+
+let allLayers: [(NSTextBlock.Layer, String)] = [
+  (.padding, "padding"),
+  (.border, "border"),
+  (.margin, "margin"),
+]
+
+let allEdges: [(NSRectEdge, String)] = [
+  (.minX, "minX"),
+  (.minY, "minY"),
+  (.maxX, "maxX"),
+  (.maxY, "maxY"),
+]
+
+/// Dumps all NSTextBlock-level properties (dimensions, layer widths, colors,
+/// vertical alignment). When `includingDefaults` is false only values that
+/// differ from 0/nil are printed.
+func describeBlockProperties(_ block: NSTextBlock, indent: String, includingDefaults: Bool = false)
+{
+  var dimensionParts: [String] = []
+  for (dimension, dimensionName) in allDimensions {
+    let value = block.value(for: dimension)
+    let type = block.valueType(for: dimension)
+    if includingDefaults || value != 0 {
+      dimensionParts.append("\(dimensionName)=\(fmt(value))(\(name(of: type)))")
+    }
+  }
+  if !dimensionParts.isEmpty {
+    print("\(indent)dimensions: \(dimensionParts.joined(separator: " "))")
+  }
+
+  for (layer, layerName) in allLayers {
+    var parts: [String] = []
+    var allZero = true
+    for (edge, edgeName) in allEdges {
+      let width = block.width(for: layer, edge: edge)
+      let type = block.widthValueType(for: layer, edge: edge)
+      if width != 0 { allZero = false }
+      parts.append("\(edgeName)=\(fmt(width))(\(name(of: type)))")
+    }
+    if includingDefaults || !allZero {
+      print("\(indent)\(layerName): \(parts.joined(separator: " "))")
+    }
+  }
+
+  var borderColorParts: [String] = []
+  var anyBorderColor = false
+  for (edge, edgeName) in allEdges {
+    let color = block.borderColor(for: edge)
+    if color != nil { anyBorderColor = true }
+    borderColorParts.append("\(edgeName)=\(describe(color))")
+  }
+  if includingDefaults || anyBorderColor {
+    print("\(indent)borderColor: \(borderColorParts.joined(separator: " "))")
+  }
+
+  if includingDefaults || block.backgroundColor != nil {
+    print("\(indent)backgroundColor: \(describe(block.backgroundColor))")
+  }
+
+  if includingDefaults || block.verticalAlignment != .topAlignment {
+    print("\(indent)verticalAlignment: \(name(of: block.verticalAlignment))")
+  }
+}
+
+// MARK: - HTML conversion
+
+func attributedString(fromHTML html: String) -> NSAttributedString? {
+  let data = Data(html.utf8)
+  let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+    .documentType: NSAttributedString.DocumentType.html,
+    .characterEncoding: String.Encoding.utf8.rawValue,
+  ]
+  return try? NSAttributedString(data: data, options: options, documentAttributes: nil)
+}
+
+// MARK: - Dumping
+
+func shortLabel(for block: NSTextBlock) -> String {
+  if let tableBlock = block as? NSTextTableBlock {
+    let blockName = register(tableBlock)
+    let tableName = register(tableBlock.table)
+    var label = "\(blockName)→\(tableName) r\(tableBlock.startingRow)c\(tableBlock.startingColumn)"
+    if tableBlock.rowSpan != 1 { label += " rowSpan=\(tableBlock.rowSpan)" }
+    if tableBlock.columnSpan != 1 { label += " colSpan=\(tableBlock.columnSpan)" }
+    return label
+  }
+  if block is NSTextTable {
+    return register(block)
+  }
+  return "\(register(block)) (plain NSTextBlock)"
+}
+
+func dumpCase(name caseName: String, html: String) {
+  resetRegistries()
+
+  print("================================================================================")
+  print("CASE \(caseName)")
+  print("HTML: \(html)")
+  print("--------------------------------------------------------------------------------")
+
+  guard let attributedString = attributedString(fromHTML: html) else {
+    print("!! conversion FAILED")
+    return
+  }
+
+  print("STRING: \"\(escaped(attributedString.string))\"")
+  print("")
+
+  let nsString = attributedString.string as NSString
+  var location = 0
+  var paragraphIndex = 0
+
+  while location < nsString.length {
+    let paragraphRange = nsString.paragraphRange(for: NSRange(location: location, length: 0))
+    let paragraphText = nsString.substring(with: paragraphRange)
+    let attributes = attributedString.attributes(at: paragraphRange.location, effectiveRange: nil)
+
+    var infoParts: [String] = []
+
+    if let font = attributes[.font] as? NSFont {
+      infoParts.append("font=\(font.fontName)@\(fmt(font.pointSize))")
+    }
+
+    if let backgroundColor = attributes[.backgroundColor] as? NSColor {
+      infoParts.append("runBG=\(describe(backgroundColor))")
+    }
+
+    var blocksLabel = "[]"
+    if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
+      let blocks = paragraphStyle.textBlocks
+      if !blocks.isEmpty {
+        blocksLabel = "[" + blocks.map { shortLabel(for: $0) }.joined(separator: " | ") + "]"
+      }
+      if paragraphStyle.alignment != .natural {
+        infoParts.append("align=\(name(of: paragraphStyle.alignment))")
+      }
+      if paragraphStyle.headIndent != 0 {
+        infoParts.append("headIndent=\(fmt(paragraphStyle.headIndent))")
+      }
+      if paragraphStyle.firstLineHeadIndent != 0 {
+        infoParts.append("firstLineHeadIndent=\(fmt(paragraphStyle.firstLineHeadIndent))")
+      }
+      if paragraphStyle.tailIndent != 0 {
+        infoParts.append("tailIndent=\(fmt(paragraphStyle.tailIndent))")
+      }
+      if paragraphStyle.paragraphSpacing != 0 {
+        infoParts.append("paraSpacing=\(fmt(paragraphStyle.paragraphSpacing))")
+      }
+      if paragraphStyle.paragraphSpacingBefore != 0 {
+        infoParts.append("paraSpacingBefore=\(fmt(paragraphStyle.paragraphSpacingBefore))")
+      }
+      if !paragraphStyle.textLists.isEmpty {
+        infoParts.append("textLists=\(paragraphStyle.textLists.count)")
+      }
+      if paragraphStyle.baseWritingDirection != .natural {
+        infoParts.append(
+          "writingDirection=\(paragraphStyle.baseWritingDirection == .rightToLeft ? "RTL" : "LTR")")
+      }
+    }
+
+    print("P\(paragraphIndex) \"\(escaped(paragraphText))\"")
+    print("   blocks=\(blocksLabel)")
+    if !infoParts.isEmpty {
+      print("   \(infoParts.joined(separator: " "))")
+    }
+
+    location = NSMaxRange(paragraphRange)
+    paragraphIndex += 1
+  }
+
+  if !orderedTables.isEmpty {
+    print("")
+    print("TABLES:")
+    for table in orderedTables {
+      let tableName = tableIDs[ObjectIdentifier(table)] ?? "?"
+      print(
+        "  \(tableName): numberOfColumns=\(table.numberOfColumns) "
+          + "layoutAlgorithm=\(name(of: table.layoutAlgorithm)) "
+          + "collapsesBorders=\(table.collapsesBorders) "
+          + "hidesEmptyCells=\(table.hidesEmptyCells)")
+      describeBlockProperties(table, indent: "     ")
+    }
+  }
+
+  if !orderedBlocks.isEmpty {
+    print("")
+    print("BLOCKS:")
+    for block in orderedBlocks {
+      let blockName = blockIDs[ObjectIdentifier(block)] ?? "?"
+      if let tableBlock = block as? NSTextTableBlock {
+        let tableName = register(tableBlock.table)
+        print(
+          "  \(blockName): NSTextTableBlock table=\(tableName) "
+            + "startingRow=\(tableBlock.startingRow) rowSpan=\(tableBlock.rowSpan) "
+            + "startingColumn=\(tableBlock.startingColumn) columnSpan=\(tableBlock.columnSpan)")
+      } else {
+        print("  \(blockName): \(type(of: block))")
+      }
+      describeBlockProperties(block, indent: "     ")
+    }
+  }
+
+  print("")
+}
+
+// MARK: - Constants dump
+
+func dumpConstants() {
+  print("================================================================================")
+  print("CONSTANTS (raw values of the AppKit enums, for DT* compatibility)")
+  print("--------------------------------------------------------------------------------")
+
+  print("NSTextBlock.Dimension:")
+  for (dimension, dimensionName) in allDimensions {
+    print("   .\(dimensionName) = \(dimension.rawValue)")
+  }
+
+  print("NSTextBlock.ValueType:")
+  print("   .absoluteValueType = \(NSTextBlock.ValueType.absoluteValueType.rawValue)")
+  print("   .percentageValueType = \(NSTextBlock.ValueType.percentageValueType.rawValue)")
+
+  print("NSTextBlock.Layer:")
+  for (layer, layerName) in allLayers {
+    print("   .\(layerName) = \(layer.rawValue)")
+  }
+
+  print("NSTextBlock.VerticalAlignment:")
+  print("   .topAlignment = \(NSTextBlock.VerticalAlignment.topAlignment.rawValue)")
+  print("   .middleAlignment = \(NSTextBlock.VerticalAlignment.middleAlignment.rawValue)")
+  print("   .bottomAlignment = \(NSTextBlock.VerticalAlignment.bottomAlignment.rawValue)")
+  print("   .baselineAlignment = \(NSTextBlock.VerticalAlignment.baselineAlignment.rawValue)")
+
+  print("NSTextTable.LayoutAlgorithm:")
+  print(
+    "   .automaticLayoutAlgorithm = \(NSTextTable.LayoutAlgorithm.automaticLayoutAlgorithm.rawValue)"
+  )
+  print("   .fixedLayoutAlgorithm = \(NSTextTable.LayoutAlgorithm.fixedLayoutAlgorithm.rawValue)")
+
+  print("NSRectEdge:")
+  for (edge, edgeName) in allEdges {
+    print("   .\(edgeName) = \(edge.rawValue)")
+  }
+
+  print("")
+  print("Defaults of freshly created NSTextBlock():")
+  let freshBlock = NSTextBlock()
+  describeBlockProperties(freshBlock, indent: "   ", includingDefaults: true)
+
+  print("")
+  print("Defaults of freshly created NSTextTable():")
+  let freshTable = NSTextTable()
+  print(
+    "   numberOfColumns=\(freshTable.numberOfColumns) "
+      + "layoutAlgorithm=\(name(of: freshTable.layoutAlgorithm)) "
+      + "collapsesBorders=\(freshTable.collapsesBorders) "
+      + "hidesEmptyCells=\(freshTable.hidesEmptyCells)")
+
+  print("")
+}
+
+// MARK: - Test cases
+
+let testCases: [(String, String)] = [
+  (
+    "01-simple",
+    "<p>Before</p><table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table><p>After</p>"
+  ),
+  (
+    "02-th-thead",
+    "<table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>Pi</td><td>3.14</td></tr></tbody></table>"
+  ),
+  (
+    "03-colspan",
+    "<table><tr><td colspan=\"2\">Wide</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></table>"
+  ),
+  (
+    "04-rowspan",
+    "<table><tr><td rowspan=\"2\">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>"
+  ),
+  (
+    "05-widths",
+    "<table width=\"80%\"><tr><td width=\"100\">fixed 100</td><td width=\"50%\">half</td></tr></table>"
+  ),
+  (
+    "06-legacy-attrs",
+    "<table border=\"2\" cellpadding=\"5\" cellspacing=\"3\" bgcolor=\"#FFEEDD\"><tr bgcolor=\"#DDEEFF\"><td bgcolor=\"#EEFFDD\">X</td><td>Y</td></tr></table>"
+  ),
+  (
+    "07-css-box",
+    "<table style=\"border-collapse: collapse;\"><tr>"
+      + "<td style=\"padding: 1px 2px 3px 4px; border-top: 1px solid #FF0000; border-right: 2px solid #00FF00; border-bottom: 3px solid #0000FF; border-left: 4px solid #FF00FF; background-color: #ABCDEF; width: 120px;\">styled</td>"
+      + "<td>plain</td></tr></table>"
+  ),
+  (
+    "08-align-valign",
+    "<table><tr style=\"height: 50px\"><td valign=\"top\">top</td><td valign=\"bottom\">bottom</td>"
+      + "<td style=\"vertical-align: middle; text-align: right;\">mid right</td></tr></table>"
+  ),
+  (
+    "09-nested",
+    "<table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>"
+  ),
+  (
+    "10-empty-caption",
+    "<table><caption>The Caption</caption><tr><td></td><td>B</td></tr></table>"
+  ),
+  (
+    "11-multiparagraph",
+    "<table><tr><td><p>One</p><p>Two</p></td><td>B</td></tr></table>"
+  ),
+  (
+    "12-div-blockquote",
+    "<div style=\"background-color: #FFFF00; padding: 10px; border: 1px solid #000000;\">styled div</div><blockquote>quoted text</blockquote>"
+  ),
+  (
+    "13-fixed-layout",
+    "<table style=\"table-layout: fixed; width: 300px;\"><tr><td>A</td><td>B</td></tr></table>"
+  ),
+  (
+    "14-heights",
+    "<table><tr><td height=\"50\">legacy 50</td><td style=\"height: 40px\">css 40</td></tr></table>"
+  ),
+  (
+    "15-colgroup",
+    "<table><colgroup><col width=\"120\"><col width=\"60\"></colgroup><tr><td>A</td><td>B</td></tr></table>"
+  ),
+  (
+    "16-empty-cells-hide",
+    "<table style=\"empty-cells: hide\"><tr><td>A</td><td></td></tr></table>"
+  ),
+  (
+    "17-rtl",
+    "<table dir=\"rtl\"><tr><td>one</td><td>two</td></tr></table>"
+  ),
+  (
+    "18-table-margin",
+    "<table style=\"margin-left: 20px; width: 200px\"><tr><td>A</td></tr></table>"
+  ),
+  (
+    "19-min-max-width",
+    "<table><tr><td style=\"min-width: 100px\">min</td><td style=\"max-width: 30px\">maxed</td></tr></table>"
+  ),
+  (
+    "20-valign-baseline",
+    "<table><tr><td style=\"vertical-align: baseline\">css bl</td><td valign=\"baseline\">legacy bl</td></tr></table>"
+  ),
+]
+
+// MARK: - Main
+
+dumpConstants()
+
+for (caseName, html) in testCases {
+  dumpCase(name: caseName, html: html)
+}
+
+print("DONE")

--- a/Tools/TableInvestigation/sample-output.txt
+++ b/Tools/TableInvestigation/sample-output.txt
@@ -1,0 +1,759 @@
+================================================================================
+CONSTANTS (raw values of the AppKit enums, for DT* compatibility)
+--------------------------------------------------------------------------------
+NSTextBlock.Dimension:
+   .width = 0
+   .minWidth = 1
+   .maxWidth = 2
+   .height = 4
+   .minHeight = 5
+   .maxHeight = 6
+NSTextBlock.ValueType:
+   .absoluteValueType = 0
+   .percentageValueType = 1
+NSTextBlock.Layer:
+   .padding = -1
+   .border = 0
+   .margin = 1
+NSTextBlock.VerticalAlignment:
+   .topAlignment = 0
+   .middleAlignment = 1
+   .bottomAlignment = 2
+   .baselineAlignment = 3
+NSTextTable.LayoutAlgorithm:
+   .automaticLayoutAlgorithm = 0
+   .fixedLayoutAlgorithm = 1
+NSRectEdge:
+   .minX = 0
+   .minY = 1
+   .maxX = 2
+   .maxY = 3
+
+Defaults of freshly created NSTextBlock():
+   dimensions: width=0(abs) minWidth=0(abs) maxWidth=0(abs) height=0(abs) minHeight=0(abs) maxHeight=0(abs)
+   padding: minX=0(abs) minY=0(abs) maxX=0(abs) maxY=0(abs)
+   border: minX=0(abs) minY=0(abs) maxX=0(abs) maxY=0(abs)
+   margin: minX=0(abs) minY=0(abs) maxX=0(abs) maxY=0(abs)
+   borderColor: minX=nil minY=nil maxX=nil maxY=nil
+   backgroundColor: nil
+   verticalAlignment: top
+
+Defaults of freshly created NSTextTable():
+   numberOfColumns=0 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+
+================================================================================
+CASE 01-simple
+HTML: <p>Before</p><table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table><p>After</p>
+--------------------------------------------------------------------------------
+STRING: "Before\nA1\nB1\nA2\nB2\nAfter\n"
+
+P0 "Before\n"
+   blocks=[]
+   font=Times-Roman@12 paraSpacing=12 writingDirection=LTR
+P1 "A1\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "B1\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+P3 "A2\n"
+   blocks=[B3→T1 r1c0]
+   font=Times-Roman@12 writingDirection=LTR
+P4 "B2\n"
+   blocks=[B4→T1 r1c1]
+   font=Times-Roman@12 writingDirection=LTR
+P5 "After\n"
+   blocks=[]
+   font=Times-Roman@12 paraSpacing=12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=14.6719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B3: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=14.6719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B4: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 02-th-thead
+HTML: <table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>Pi</td><td>3.14</td></tr></tbody></table>
+--------------------------------------------------------------------------------
+STRING: "Name\nValue\nPi\n3.14\n"
+
+P0 "Name\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Bold@12 align=center writingDirection=LTR
+P1 "Value\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Bold@12 align=center writingDirection=LTR
+P2 "Pi\n"
+   blocks=[B3→T1 r1c0]
+   font=Times-Roman@12 writingDirection=LTR
+P3 "3.14\n"
+   blocks=[B4→T1 r1c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=30(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=28.9062(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B3: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=30(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B4: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=28.9062(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 03-colspan
+HTML: <table><tr><td colspan="2">Wide</td><td>C1</td></tr><tr><td>A2</td><td>B2</td><td>C2</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "Wide\nC1\nA2\nB2\nC2\n"
+
+P0 "Wide\n"
+   blocks=[B1→T1 r0c0 colSpan=2]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "C1\n"
+   blocks=[B2→T1 r0c2]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "A2\n"
+   blocks=[B3→T1 r1c0]
+   font=Times-Roman@12 writingDirection=LTR
+P3 "B2\n"
+   blocks=[B4→T1 r1c1]
+   font=Times-Roman@12 writingDirection=LTR
+P4 "C2\n"
+   blocks=[B5→T1 r1c2]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=3 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=2
+     dimensions: width=32.6875(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=2 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B3: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=14.6719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B4: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B5: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=2 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 04-rowspan
+HTML: <table><tr><td rowspan="2">Tall</td><td>B1</td></tr><tr><td>B2</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "Tall\nB1\nB2\n"
+
+P0 "Tall\n"
+   blocks=[B1→T1 r0c0 rowSpan=2]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "B1\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "B2\n"
+   blocks=[B3→T1 r1c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=2 startingColumn=0 columnSpan=1
+     dimensions: width=18.5(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B3: NSTextTableBlock table=T1 startingRow=1 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=14.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 05-widths
+HTML: <table width="80%"><tr><td width="100">fixed 100</td><td width="50%">half</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "fixed 100\nhalf\n"
+
+P0 "fixed 100\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "half\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     dimensions: width=627.188(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=308.594(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=308.594(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 06-legacy-attrs
+HTML: <table border="2" cellpadding="5" cellspacing="3" bgcolor="#FFEEDD"><tr bgcolor="#DDEEFF"><td bgcolor="#EEFFDD">X</td><td>Y</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "X\nY\n"
+
+P0 "X\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "Y\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     border: minX=2(abs) minY=2(abs) maxX=2(abs) maxY=2(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     backgroundColor: #FFEEDD a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=8.67188(abs)
+     padding: minX=5(abs) minY=5(abs) maxX=5(abs) maxY=5(abs)
+     border: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=1.5(abs) minY=1.5(abs) maxX=1.5(abs) maxY=1.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     backgroundColor: #EEFFDD a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=8.67188(abs)
+     padding: minX=5(abs) minY=5(abs) maxX=5(abs) maxY=5(abs)
+     border: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=1.5(abs) minY=1.5(abs) maxX=1.5(abs) maxY=1.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     backgroundColor: #DDEEFF a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 07-css-box
+HTML: <table style="border-collapse: collapse;"><tr><td style="padding: 1px 2px 3px 4px; border-top: 1px solid #FF0000; border-right: 2px solid #00FF00; border-bottom: 3px solid #0000FF; border-left: 4px solid #FF00FF; background-color: #ABCDEF; width: 120px;">styled</td><td>plain</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "styled\nplain\n"
+
+P0 "styled\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "plain\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=true hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=120(abs)
+     padding: minX=4(abs) minY=1(abs) maxX=2(abs) maxY=3(abs)
+     border: minX=4(abs) minY=1(abs) maxX=2(abs) maxY=3(abs)
+     borderColor: minX=#FF00FF a=1.00 minY=#FF0000 a=1.00 maxX=#00FF00 a=1.00 maxY=#0000FF a=1.00
+     backgroundColor: #ABCDEF a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=24(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 08-align-valign
+HTML: <table><tr style="height: 50px"><td valign="top">top</td><td valign="bottom">bottom</td><td style="vertical-align: middle; text-align: right;">mid right</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "top\nbottom\nmid right\n"
+
+P0 "top\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "bottom\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "mid right\n"
+   blocks=[B3→T1 r0c2]
+   font=Times-Roman@12 align=right writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=3 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=15.3438(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=34.0156(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: bottom
+  B3: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=2 columnSpan=1
+     dimensions: width=44.3438(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 09-nested
+HTML: <table><tr><td>Outer A<table><tr><td>Inner 1</td><td>Inner 2</td></tr></table>after inner</td><td>Outer B</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "Outer A\nInner 1\nInner 2\nafter inner\nOuter B\n"
+
+P0 "Outer A\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "Inner 1\n"
+   blocks=[B1→T1 r0c0 | B2→T2 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "Inner 2\n"
+   blocks=[B1→T1 r0c0 | B3→T2 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+P3 "after inner\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P4 "Outer B\n"
+   blocks=[B4→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+  T2: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=78.6719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T2 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=34.3281(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B3: NSTextTableBlock table=T2 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=34.3281(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B4: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=38.3281(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 10-empty-caption
+HTML: <table><caption>The Caption</caption><tr><td></td><td>B</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "The Caption\n\nB\n"
+
+P0 "The Caption\n"
+   blocks=[]
+   font=Times-Roman@12 align=center writingDirection=LTR
+P1 "\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P2 "B\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=3.32812(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=24.6875(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 11-multiparagraph
+HTML: <table><tr><td><p>One</p><p>Two</p></td><td>B</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "One\nTwo\nB\n"
+
+P0 "One\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 paraSpacing=12 writingDirection=LTR
+P1 "Two\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 paraSpacing=12 writingDirection=LTR
+P2 "B\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=21.1719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=8.01562(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 12-div-blockquote
+HTML: <div style="background-color: #FFFF00; padding: 10px; border: 1px solid #000000;">styled div</div><blockquote>quoted text</blockquote>
+--------------------------------------------------------------------------------
+STRING: "styled div\nquoted text\n"
+
+P0 "styled div\n"
+   blocks=[]
+   font=Times-Roman@12 runBG=#FFFF00 a=1.00 writingDirection=LTR
+P1 "quoted text\n"
+   blocks=[]
+   font=Times-Roman@12 headIndent=40 tailIndent=-40 paraSpacing=12 writingDirection=LTR
+
+================================================================================
+CASE 13-fixed-layout
+HTML: <table style="table-layout: fixed; width: 300px;"><tr><td>A</td><td>B</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "A\nB\n"
+
+P0 "A\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "B\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=fixed collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=145(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=145(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 14-heights
+HTML: <table><tr><td height="50">legacy 50</td><td style="height: 40px">css 40</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "legacy 50\ncss 40\n"
+
+P0 "legacy 50\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "css 40\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=46.3125(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=29.6719(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 15-colgroup
+HTML: <table><colgroup><col width="120"><col width="60"></colgroup><tr><td>A</td><td>B</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "A\nB\n"
+
+P0 "A\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "B\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=118(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=58(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 16-empty-cells-hide
+HTML: <table style="empty-cells: hide"><tr><td>A</td><td></td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "A\n\n"
+
+P0 "A\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=true
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=8.67188(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 17-rtl
+HTML: <table dir="rtl"><tr><td>one</td><td>two</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "one\ntwo\n"
+
+P0 "one\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=RTL
+P1 "two\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=RTL
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=17.3281(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=18(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 18-table-margin
+HTML: <table style="margin-left: 20px; width: 200px"><tr><td>A</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "A\n"
+
+P0 "A\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=1 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     margin: minX=20(abs) minY=0(abs) maxX=0(abs) maxY=0(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=194(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 19-min-max-width
+HTML: <table><tr><td style="min-width: 100px">min</td><td style="max-width: 30px">maxed</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "min\nmaxed\n"
+
+P0 "min\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "maxed\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=100(abs) minWidth=100(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=30(abs) maxWidth=30(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: middle
+
+================================================================================
+CASE 20-valign-baseline
+HTML: <table><tr><td style="vertical-align: baseline">css bl</td><td valign="baseline">legacy bl</td></tr></table>
+--------------------------------------------------------------------------------
+STRING: "css bl\nlegacy bl\n"
+
+P0 "css bl\n"
+   blocks=[B1→T1 r0c0]
+   font=Times-Roman@12 writingDirection=LTR
+P1 "legacy bl\n"
+   blocks=[B2→T1 r0c1]
+   font=Times-Roman@12 writingDirection=LTR
+
+TABLES:
+  T1: numberOfColumns=2 layoutAlgorithm=automatic collapsesBorders=false hidesEmptyCells=false
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+
+BLOCKS:
+  B1: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=0 columnSpan=1
+     dimensions: width=27(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: baseline
+  B2: NSTextTableBlock table=T1 startingRow=0 rowSpan=1 startingColumn=1 columnSpan=1
+     dimensions: width=43.6562(abs)
+     padding: minX=1(abs) minY=1(abs) maxX=1(abs) maxY=1(abs)
+     margin: minX=0.5(abs) minY=0.5(abs) maxX=0.5(abs) maxY=0.5(abs)
+     borderColor: minX=#000000 a=1.00 minY=#000000 a=1.00 maxX=#000000 a=1.00 maxY=#000000 a=1.00
+     verticalAlignment: baseline
+
+DONE


### PR DESCRIPTION
Implements HTML table support end to end — model, parsing, grid layout, drawing, HTML round-trip, SwiftUI bridging — designed around the `NSTextBlock`/`NSTextTable`/`NSTextTableBlock` classes so the model can be swapped for the native UIKit classes when iOS 27 ships. Tracks #1317, where each phase is documented in detail with progress comments.

## What changed

**Model (`TextBlock`, `TextTable`, `TextTableBlock`, `TextBlockConverter`)**
- `TextBlock` (`DTTextBlock`) now mirrors the complete `NSTextBlock` API: six dimensions with absolute/percentage value types, per-layer/per-edge widths, per-edge border colors, vertical alignment. The legacy `padding`/`backgroundColor` API is a convenience over the new storage; `NSCoding` is versioned and stays readable by older DTCoreText versions. Edges use `CGRectEdge` (identical raw values to `NSRectEdge`, which does not exist on iOS).
- New `TextTable`/`TextTableBlock` mirror their NS counterparts with identical enum raw values — pinned by a macOS parity suite that compares raw values, defaults, equality semantics and round-trip conversion against real AppKit objects, plus live system-importer fixtures.
- **Identity equality is load-bearing**: Foundation uniques value-equal attribute dictionaries globally across attributed strings, so value-equal table objects bled shared instances between concurrently parsed documents. The table classes compare by identity exactly like the NS classes; a concurrency stress test locks this in.
- `TextBlockConverter` converts DT ↔ NS on macOS preserving instance identity — the designated iOS 27 swap point.
- Per-edge border **styles** (solid/dashed/dotted/double) as a documented DT extension (`NSTextBlock` only models width and color).

**Parsing (`BuilderState+Tables`, display styles, `default.css`)**
- `table`/`tr`/`td`/`th`/`thead`/`tbody`/`tfoot`/`caption`/`col(group)` produce the exact structure the macOS HTML importer produces — verified structurally against the live importer for identical HTML. Cells are plain `\n`-terminated paragraphs; the grid lives in shared block instances on the `DTTextBlocks` attribute, outermost-first for nesting, no placeholder blocks under `rowspan`.
- Full attribute/CSS mapping per the empirical findings: spans, `cellpadding`/`cellspacing` (split onto cell margins), `border` (table + implied 1pt cell borders), `bgcolor` on table/row/cell, `valign`, `<col>` widths, per-edge border longhands and 1–4 value lists, `thin`/`medium`/`thick`, `border-collapse`, `empty-cells`, `table-layout`, `width`/`min-width`/`max-width`. One deliberate difference from the importer: percentage widths are preserved as percentage value types instead of being baked to absolute points.

**Layout (`CoreTextLayoutFrame`)**
- Tables lay out as real grids: automatic column sizing (explicit widths win and wrap content; natural widths propagate recursively out of nested tables; leftover width from an explicit table width goes to flexible columns), fixed layout from the first row, rowspan-aware row heights, vertical alignment including **true first-baseline alignment** per the `NSTextBlock` docs, justified cell text, recursive nested tables, and flow continuing below the table.
- Cell/table border-box frames are cached and drive background + border drawing in correct stacking order; dashed/dotted/double styles render.
- `border-collapse: collapse` resolves every boundary to the wider border — a genuine single-line grid, pixel-verified (3 lines across a collapsed two-row table vs 6 separated).
- Block-run grouping switched from `isEqual` to instance identity (matching system semantics); `CoreTextParagraphStyle.textBlocks` is now `[TextBlock]?`.

**Writing & SwiftUI**
- `HTMLWriter` emits `<table>/<tr>/<td>` with `colspan`/`rowspan` and inline CSS; structure and styling round-trip through the parser, nested tables included.
- `DTTextBlocksKey` is now a typed `[TextBlock]` `AttributedString` key (`ObjectiveCConvertibleAttributedStringKey`); tables keep shared-instance identity through `AttributedString` and back, and the round-tripped string still lays out as a grid. `TextBlock` is `@unchecked Sendable` under the same immutable-after-parse contract `NSAttributedString` imposes on attribute values.

## Reviewer notes

- The DocC article `HTMLTablesOnMacOS` documents the empirically determined macOS representation (reproducible dump tool under `Tools/TableInvestigation/`) and every deliberate deviation. Start there for the design rationale.
- `TableRenderPreviewTests` writes PNG renders of 12 samples plus the 4 new demo pages to `/tmp/table-renders` (macOS) and `/tmp/table-renders-ios` (simulator) for visual inspection.
- Demo app gains four snippets: *Tables*, *Tables — Alignment*, *Tables — Widths*, *Tables — Borders*.
- Includes a fix for a pre-existing cross-suite test race (a test mutated the shared default stylesheet singleton).
- Known limitations (documented): no full min/max-content negotiation, no RTL column mirroring, tables bypass `numberOfLines` truncation, 3D border styles render solid.

## Verification

- macOS: 296 tests in 30 suites, stable across repeated runs (the new table work adds ~110 tests: parity, parsing incl. system-importer comparison, layout incl. pixel tests, writing round-trips, identity stress, SwiftUI).
- iOS: 288 tests in 29 suites pass on an iPhone 17 Pro simulator via `xcodebuild test`; demo app builds and runs with the new pages.
- All renders visually inspected on both platforms.

Remaining for a follow-up once the iOS 27 SDK is available: bridging the DT classes to the native UIKit classes via `TextBlockConverter` and optionally handing layout off to TextKit (tracked in #1317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
