### PR TITLE
Support float:left/right for images and blocks with text wrapping

### DIFF
--- a/Demo/Resources/Floats.html
+++ b/Demo/Resources/Floats.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+<title>Floats</title>
+</head>
+<body>
+<h2>Floated Images</h2>
+
+<p><img src="Oliver.jpg" width="100" height="100" style="float:left">An image with <code>float:left</code> sits at the left content edge and the text of the paragraph wraps around it on the right side. Once the text reaches the bottom edge of the image it returns to the full width of the column, exactly like in a web browser. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
+
+<p><img src="Oliver.jpg" width="100" height="100" style="float:right">With <code>float:right</code> the image moves to the right content edge instead. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.</p>
+
+<h2>Several Floats</h2>
+
+<p><img src="Oliver.jpg" width="80" height="80" style="float:right"><img src="Oliver.jpg" width="60" height="60" style="float:right">Two floats on the same side stack next to each other when there is room, otherwise the later one moves below the earlier one. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
+
+<h2>Floated Blocks</h2>
+
+<div style="float:right; width:140px; background-color:#e8f0fe; padding:6px">A <code>div</code> with <code>float:right</code> and a fixed width becomes a column that the main text flows around.</div>
+
+<p>Block elements can float too: the floated box keeps its own width — either the CSS <code>width</code> or, without one, the natural width of its content — and the surrounding paragraphs wrap along its edge. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est lorem ipsum dolor sit amet.</p>
+
+<h2>Clearing</h2>
+
+<p><img src="Oliver.jpg" width="100" height="100" style="float:left">This paragraph flows beside the floated image.</p>
+
+<p style="clear:left">This paragraph has <code>clear:left</code>, so it starts below the floated image instead of beside it.</p>
+
+</body>
+</html>

--- a/Demo/Resources/Snippets.plist
+++ b/Demo/Resources/Snippets.plist
@@ -60,6 +60,14 @@
 	</dict>
 	<dict>
 		<key>Description</key>
+		<string>Demonstrates float:left and float:right on images and blocks with text wrapping around them, and the clear property.</string>
+		<key>File</key>
+		<string>Floats.html</string>
+		<key>Title</key>
+		<string>Floats</string>
+	</dict>
+	<dict>
+		<key>Description</key>
 		<string>Demonstrates setting of Line Height</string>
 		<key>File</key>
 		<string>LineHeight.html</string>

--- a/Sources/DTCoreText/CoreTextLayoutFrame.swift
+++ b/Sources/DTCoreText/CoreTextLayoutFrame.swift
@@ -53,6 +53,12 @@ open class CoreTextLayoutFrame: NSObject {
   private var _tablesInDrawOrder = [(table: TextTable, rect: CGRect, level: Int)]()
   private var _maxTableBottom: CGFloat = 0
 
+  // float layout results: the lowest bottom edge of floated content (which can
+  // reach below the last text line) and whether any content was floated at all
+  // (floated columns make the line array non-monotonic in y)
+  private var _maxFloatBottom: CGFloat = 0
+  private var _hasFloatedContent = false
+
   // border edges not to draw (bitmask by edge raw value), from collapsed-border
   // resolution: only the winning border of each boundary is drawn
   private var _suppressedBorderEdges = [ObjectIdentifier: UInt]()
@@ -348,11 +354,17 @@ open class CoreTextLayoutFrame: NSObject {
     _tableBlockFrames.removeAll()
     _tablesInDrawOrder.removeAll()
     _maxTableBottom = 0
+    _maxFloatBottom = 0
+    _hasFloatedContent = false
     _suppressedBorderEdges.removeAll()
 
     var typesetLines = [CoreTextLayoutLine]()
     var previousLine: CoreTextLayoutLine? = nil
     var minimumBaselineYAfterTable: CGFloat? = nil
+
+    // floats only make sense within a known width
+    var floatRegions = [_FloatRegion]()
+    let floatsEnabled = _frame.size.width < CGFLOAT_WIDTH_UNKNOWN
 
     var paragraphRanges = (self.paragraphRanges ?? []).map { $0 }
     guard !paragraphRanges.isEmpty else { return }
@@ -365,7 +377,7 @@ open class CoreTextLayoutFrame: NSObject {
     var fittingLength = 0
     var shouldTruncateLine = false
 
-    repeat {
+    lineLoop: repeat {
       while lineRange.location >= currentParagraphRange.location + currentParagraphRange.length {
         paragraphRanges.removeFirst()
         guard !paragraphRanges.isEmpty else { return }
@@ -373,6 +385,35 @@ open class CoreTextLayoutFrame: NSObject {
       }
 
       let isAtBeginOfParagraph = (currentParagraphRange.location == lineRange.location)
+
+      // floated content is taken out of the normal flow: it becomes a box at the
+      // left or right content edge and the following text wraps around it. This
+      // runs before the table check so that a floated table becomes a column.
+      if floatsEnabled, _floatStyleValue(at: lineRange.location) != nil {
+        if let floatResult = _layoutFloat(
+          at: lineRange.location,
+          previousLine: previousLine,
+          regions: floatRegions,
+          maximumY: maxY,
+          canOverflow: typesetLines.isEmpty)
+        {
+          typesetLines.append(contentsOf: floatResult.lines)
+          floatRegions.append(floatResult.region)
+          _maxFloatBottom = max(_maxFloatBottom, floatResult.region.rect.maxY)
+          _hasFloatedContent = true
+
+          if let nested = floatResult.nested {
+            _registerTableLayoutResult(nested)
+          }
+
+          fittingLength += floatResult.range.length
+          lineRange.location = NSMaxRange(floatResult.range)
+          continue lineLoop
+        } else {
+          // no room left in this frame — the float continues in the next one
+          break lineLoop
+        }
+      }
 
       // a table starting at this paragraph is laid out as a grid in one go
       if isAtBeginOfParagraph, let tableStart = _tableStart(at: lineRange.location) {
@@ -450,191 +491,282 @@ open class CoreTextLayoutFrame: NSObject {
         }
       }
 
-      var availableSpace: CGFloat
-      if tailIndent <= 0 {
-        availableSpace =
-          _frame.size.width - headIndent - totalRightPadding + tailIndent - totalLeftPadding
-      } else {
-        availableSpace = tailIndent - headIndent - totalLeftPadding - totalRightPadding
+      // floats narrow the lines they vertically intersect; the intersection can
+      // only be verified once the line's real vertical extent is known, so the
+      // line is re-typeset until the assumed insets match the actual ones
+      var estimatedLineTop = _estimatedTopForNextLine(
+        after: previousLine, atLocation: lineRange.location)
+      var floatPushdownTop: CGFloat? = nil
+
+      if floatsEnabled, isAtBeginOfParagraph,
+        let clearBottom = _clearanceBottom(at: lineRange.location, regions: floatRegions),
+        clearBottom > estimatedLineTop
+      {
+        floatPushdownTop = clearBottom
+        estimatedLineTop = clearBottom
       }
 
-      var offset = totalLeftPadding
-      let lineStartStr = (fragment.string as NSString).substring(
-        with: NSRange(location: lineRange.location, length: 1))
-      if lineStartStr != "\t" {
-        offset += headIndent
-      }
+      var floatInsets =
+        floatsEnabled
+        ? _floatInsets(top: estimatedLineTop, bottom: estimatedLineTop + 1, regions: floatRegions)
+        : (left: 0, right: 0)
+      var floatAttempt = 0
 
-      lineRange.length = CTTypesetterSuggestLineBreak(
-        typesetter, lineRange.location, Double(availableSpace))
+      var acceptedLine: CoreTextLayoutLine? = nil
 
-      if NSMaxRange(lineRange) > maxIndex {
-        lineRange.length = maxIndex - lineRange.location
-      }
+      floatFitLoop: while true {
 
-      shouldTruncateLine =
-        ((numberOfLines > 0 && typesetLines.count + 1 == numberOfLines)
-          || (_numberLinesFitInFrame > 0 && _numberLinesFitInFrame == typesetLines.count + 1))
-
-      var ctLine: CTLine
-      var isHyphenatedString = false
-
-      if !shouldTruncateLine {
-        let lineString = (fragment.attributedSubstring(from: lineRange).string as NSString)
-        let lastChar = lineString.character(at: lineString.length - 1)
-
-        if lastChar == 0x00AD {  // soft hyphen
-          let hyphenatedString =
-            fragment.attributedSubstring(from: lineRange).mutableCopy()
-            as! NSMutableAttributedString
-          hyphenatedString.replaceCharacters(
-            in: NSRange(location: hyphenatedString.length - 1, length: 1), with: "-")
-          ctLine = CTLineCreateWithAttributedString(hyphenatedString as CFAttributedString)
-          isHyphenatedString = true
+        var availableSpace: CGFloat
+        if tailIndent <= 0 {
+          availableSpace =
+            _frame.size.width - headIndent - totalRightPadding + tailIndent - totalLeftPadding
         } else {
-          ctLine = CTTypesetterCreateLine(
-            typesetter, CFRangeMake(lineRange.location, lineRange.length))
+          availableSpace = tailIndent - headIndent - totalLeftPadding - totalRightPadding
         }
-      } else {
-        let oldLineRange = lineRange
-        lineRange.length = maxIndex - lineRange.location
-        let baseLine = CTTypesetterCreateLine(
-          typesetter, CFRangeMake(lineRange.location, lineRange.length))
 
-        let truncationType = DTCTLineTruncationTypeFromNSLineBreakMode(lineBreakMode)
+        var floatLeftExtra: CGFloat = 0
 
-        var attribStr = truncationString
-        if attribStr == nil {
-          var index = oldLineRange.location
-          if truncationType == .end {
-            index += max(oldLineRange.length - 1, 0)
-          } else if truncationType == .middle {
-            index += max(oldLineRange.length / 2 - 1, 0)
+        if floatInsets.left > 0 || floatInsets.right > 0 {
+          floatLeftExtra = max(0, floatInsets.left - totalLeftPadding)
+
+          let rightEdgeWithoutFloats: CGFloat
+          if tailIndent <= 0 {
+            rightEdgeWithoutFloats = _frame.size.width - totalRightPadding + tailIndent
+          } else {
+            rightEdgeWithoutFloats = tailIndent - totalRightPadding
           }
-          var range = NSRange()
-          let attributes = fragment.attributes(at: index, effectiveRange: &range)
-          attribStr = NSAttributedString(string: "\u{2026}", attributes: attributes)
+          let floatRightExtra = max(
+            0, rightEdgeWithoutFloats - (_frame.size.width - floatInsets.right))
+
+          // no usable room beside the floats: this line continues below them
+          if availableSpace - floatLeftExtra - floatRightExtra < 12, floatAttempt < 8,
+            let nextTop = _lowestFloatBottom(below: estimatedLineTop, regions: floatRegions)
+          {
+            estimatedLineTop = nextTop
+            floatPushdownTop = max(floatPushdownTop ?? -.greatestFiniteMagnitude, nextTop)
+            floatInsets = _floatInsets(
+              top: estimatedLineTop, bottom: estimatedLineTop + 1, regions: floatRegions)
+            floatAttempt += 1
+            continue floatFitLoop
+          }
+
+          availableSpace -= (floatLeftExtra + floatRightExtra)
         }
 
-        let ellipsisLine = CTLineCreateWithAttributedString(attribStr! as CFAttributedString)
+        var offset = totalLeftPadding + floatLeftExtra
+        let lineStartStr = (fragment.string as NSString).substring(
+          with: NSRange(location: lineRange.location, length: 1))
+        if lineStartStr != "\t" {
+          offset += headIndent
+        }
 
-        if let truncatedLine = CTLineCreateTruncatedLine(
-          baseLine, Double(availableSpace), truncationType, ellipsisLine)
-        {
-          ctLine = truncatedLine
+        lineRange.length = CTTypesetterSuggestLineBreak(
+          typesetter, lineRange.location, Double(availableSpace))
 
-          // check if truncation occurred
-          let truncationOccurred = !areLinesEqual(baseLine, ctLine)
-          let endOfParagraphIndex = NSMaxRange(currentParagraphRange)
+        if NSMaxRange(lineRange) > maxIndex {
+          lineRange.length = maxIndex - lineRange.location
+        }
 
-          if truncationType == .end {
-            if truncationOccurred {
-              let truncationIndex = getTruncationIndex(ctLine, ellipsisLine)
-              if truncationIndex > endOfParagraphIndex {
-                let subStr = fragment.attributedSubstring(
-                  from: NSRange(
-                    location: lineRange.location,
-                    length: endOfParagraphIndex - lineRange.location - 1))
-                let attrMutStr = subStr.mutableCopy() as! NSMutableAttributedString
-                attrMutStr.append(attribStr!)
-                ctLine = CTLineCreateWithAttributedString(attrMutStr as CFAttributedString)
-              }
-            } else {
-              if maxIndex != endOfParagraphIndex {
-                let subStr = fragment.attributedSubstring(
-                  from: NSRange(
-                    location: lineRange.location,
-                    length: endOfParagraphIndex - lineRange.location - 1))
-                let attrMutStr = subStr.mutableCopy() as! NSMutableAttributedString
-                attrMutStr.append(attribStr!)
-                ctLine = CTLineCreateWithAttributedString(attrMutStr as CFAttributedString)
+        // a line may not run across the start of floated content
+        if floatsEnabled, let floatStart = _firstFloatStart(in: lineRange) {
+          lineRange.length = floatStart - lineRange.location
+        }
+
+        shouldTruncateLine =
+          ((numberOfLines > 0 && typesetLines.count + 1 == numberOfLines)
+            || (_numberLinesFitInFrame > 0 && _numberLinesFitInFrame == typesetLines.count + 1))
+
+        var ctLine: CTLine
+        var isHyphenatedString = false
+
+        if !shouldTruncateLine {
+          let lineString = (fragment.attributedSubstring(from: lineRange).string as NSString)
+          let lastChar = lineString.character(at: lineString.length - 1)
+
+          if lastChar == 0x00AD {  // soft hyphen
+            let hyphenatedString =
+              fragment.attributedSubstring(from: lineRange).mutableCopy()
+              as! NSMutableAttributedString
+            hyphenatedString.replaceCharacters(
+              in: NSRange(location: hyphenatedString.length - 1, length: 1), with: "-")
+            ctLine = CTLineCreateWithAttributedString(hyphenatedString as CFAttributedString)
+            isHyphenatedString = true
+          } else {
+            ctLine = CTTypesetterCreateLine(
+              typesetter, CFRangeMake(lineRange.location, lineRange.length))
+          }
+        } else {
+          let oldLineRange = lineRange
+          lineRange.length = maxIndex - lineRange.location
+          let baseLine = CTTypesetterCreateLine(
+            typesetter, CFRangeMake(lineRange.location, lineRange.length))
+
+          let truncationType = DTCTLineTruncationTypeFromNSLineBreakMode(lineBreakMode)
+
+          var attribStr = truncationString
+          if attribStr == nil {
+            var index = oldLineRange.location
+            if truncationType == .end {
+              index += max(oldLineRange.length - 1, 0)
+            } else if truncationType == .middle {
+              index += max(oldLineRange.length / 2 - 1, 0)
+            }
+            var range = NSRange()
+            let attributes = fragment.attributes(at: index, effectiveRange: &range)
+            attribStr = NSAttributedString(string: "\u{2026}", attributes: attributes)
+          }
+
+          let ellipsisLine = CTLineCreateWithAttributedString(attribStr! as CFAttributedString)
+
+          if let truncatedLine = CTLineCreateTruncatedLine(
+            baseLine, Double(availableSpace), truncationType, ellipsisLine)
+          {
+            ctLine = truncatedLine
+
+            // check if truncation occurred
+            let truncationOccurred = !areLinesEqual(baseLine, ctLine)
+            let endOfParagraphIndex = NSMaxRange(currentParagraphRange)
+
+            if truncationType == .end {
+              if truncationOccurred {
+                let truncationIndex = getTruncationIndex(ctLine, ellipsisLine)
+                if truncationIndex > endOfParagraphIndex {
+                  let subStr = fragment.attributedSubstring(
+                    from: NSRange(
+                      location: lineRange.location,
+                      length: endOfParagraphIndex - lineRange.location - 1))
+                  let attrMutStr = subStr.mutableCopy() as! NSMutableAttributedString
+                  attrMutStr.append(attribStr!)
+                  ctLine = CTLineCreateWithAttributedString(attrMutStr as CFAttributedString)
+                }
+              } else {
+                if maxIndex != endOfParagraphIndex {
+                  let subStr = fragment.attributedSubstring(
+                    from: NSRange(
+                      location: lineRange.location,
+                      length: endOfParagraphIndex - lineRange.location - 1))
+                  let attrMutStr = subStr.mutableCopy() as! NSMutableAttributedString
+                  attrMutStr.append(attribStr!)
+                  ctLine = CTLineCreateWithAttributedString(attrMutStr as CFAttributedString)
+                }
               }
             }
-          }
-        } else {
-          ctLine = baseLine
-        }
-      }
-
-      let currentLineWidth = CGFloat(CTLineGetTypographicBounds(ctLine, nil, nil, nil))
-
-      // adjust lineOrigin based on paragraph text alignment
-      var textAlignment: CTTextAlignment = .natural
-      CTParagraphStyleGetValueForSpecifier(
-        ctStyle, .alignment, MemoryLayout<CTTextAlignment>.size, &textAlignment)
-
-      // determine writing direction
-      var isRTL = false
-      var baseWritingDirection: CTWritingDirection = .natural
-      CTParagraphStyleGetValueForSpecifier(
-        ctStyle, .baseWritingDirection, MemoryLayout<CTWritingDirection>.size, &baseWritingDirection
-      )
-      isRTL = (baseWritingDirection == .rightToLeft)
-
-      var lineOriginX: CGFloat
-
-      switch textAlignment {
-      case .left:
-        lineOriginX = _frame.origin.x + offset
-      case .natural:
-        lineOriginX = _frame.origin.x + offset
-        if baseWritingDirection == .rightToLeft {
-          lineOriginX =
-            _frame.origin.x + offset
-            + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(availableSpace)))
-        }
-      case .right:
-        lineOriginX =
-          _frame.origin.x + offset
-          + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(availableSpace)))
-      case .center:
-        lineOriginX =
-          _frame.origin.x + offset
-          + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 0.5, Double(availableSpace)))
-      case .justified:
-        let isAtEndOfParagraph =
-          (currentParagraphRange.location + currentParagraphRange.length <= lineRange.location
-            + lineRange.length
-            || (fragment.string as NSString).character(
-              at: lineRange.location + lineRange.length - 1) == 0x2028)
-
-        if !isAtEndOfParagraph && currentLineWidth > justifyRatio * _frame.size.width {
-          if let justifiedLine = CTLineCreateJustifiedLine(ctLine, 1.0, Double(availableSpace)) {
-            ctLine = justifiedLine
+          } else {
+            ctLine = baseLine
           }
         }
 
-        if isRTL {
+        let currentLineWidth = CGFloat(CTLineGetTypographicBounds(ctLine, nil, nil, nil))
+
+        // adjust lineOrigin based on paragraph text alignment
+        var textAlignment: CTTextAlignment = .natural
+        CTParagraphStyleGetValueForSpecifier(
+          ctStyle, .alignment, MemoryLayout<CTTextAlignment>.size, &textAlignment)
+
+        // determine writing direction
+        var isRTL = false
+        var baseWritingDirection: CTWritingDirection = .natural
+        CTParagraphStyleGetValueForSpecifier(
+          ctStyle, .baseWritingDirection, MemoryLayout<CTWritingDirection>.size, &baseWritingDirection
+        )
+        isRTL = (baseWritingDirection == .rightToLeft)
+
+        var lineOriginX: CGFloat
+
+        switch textAlignment {
+        case .left:
+          lineOriginX = _frame.origin.x + offset
+        case .natural:
+          lineOriginX = _frame.origin.x + offset
+          if baseWritingDirection == .rightToLeft {
+            lineOriginX =
+              _frame.origin.x + offset
+              + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(availableSpace)))
+          }
+        case .right:
           lineOriginX =
             _frame.origin.x + offset
             + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(availableSpace)))
-        } else {
+        case .center:
+          lineOriginX =
+            _frame.origin.x + offset
+            + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 0.5, Double(availableSpace)))
+        case .justified:
+          let isAtEndOfParagraph =
+            (currentParagraphRange.location + currentParagraphRange.length <= lineRange.location
+              + lineRange.length
+              || (fragment.string as NSString).character(
+                at: lineRange.location + lineRange.length - 1) == 0x2028)
+
+          if !isAtEndOfParagraph && currentLineWidth > justifyRatio * _frame.size.width {
+            if let justifiedLine = CTLineCreateJustifiedLine(ctLine, 1.0, Double(availableSpace)) {
+              ctLine = justifiedLine
+            }
+          }
+
+          if isRTL {
+            lineOriginX =
+              _frame.origin.x + offset
+              + CGFloat(CTLineGetPenOffsetForFlush(ctLine, 1.0, Double(availableSpace)))
+          } else {
+            lineOriginX = _frame.origin.x + offset
+          }
+        @unknown default:
           lineOriginX = _frame.origin.x + offset
         }
-      @unknown default:
-        lineOriginX = _frame.origin.x + offset
+
+        guard
+          let newLine = CoreTextLayoutLine(
+            line: ctLine, stringLocationOffset: isHyphenatedString ? lineRange.location : 0)
+        else {
+          lineRange.location += max(lineRange.length, 1)
+          continue lineLoop
+        }
+        newLine.writingDirectionIsRightToLeft = isRTL
+
+        var newLineBaselineOrigin = _algorithmWebKit_BaselineOrigin(
+          toPositionLine: newLine, afterLine: previousLine)
+
+        // following a table, flow continues below the table's lowest cell
+        if let minimumY = minimumBaselineYAfterTable {
+          newLineBaselineOrigin.y = max(newLineBaselineOrigin.y, ceil(minimumY + newLine.ascent))
+        }
+
+        // a cleared paragraph or a line that found no room beside the floats
+        // starts below them
+        if let pushdownTop = floatPushdownTop {
+          newLineBaselineOrigin.y = max(
+            newLineBaselineOrigin.y, ceil(pushdownTop + newLine.ascent))
+        }
+
+        newLineBaselineOrigin.x = lineOriginX
+        newLine.baselineOrigin = newLineBaselineOrigin
+
+        // verify the float assumption against the line's real vertical extent
+        if floatsEnabled, floatAttempt < 6 {
+          let actualInsets = _floatInsets(
+            top: newLineBaselineOrigin.y - newLine.ascent,
+            bottom: newLineBaselineOrigin.y + newLine.descent,
+            regions: floatRegions)
+
+          if actualInsets.left != floatInsets.left || actualInsets.right != floatInsets.right {
+            floatInsets = actualInsets
+            floatAttempt += 1
+            continue floatFitLoop
+          }
+        }
+
+        acceptedLine = newLine
+        break floatFitLoop
+
+      }  // floatFitLoop
+
+      guard let newLine = acceptedLine else {
+        lineRange.location += max(lineRange.length, 1)
+        continue lineLoop
       }
 
-      guard
-        let newLine = CoreTextLayoutLine(
-          line: ctLine, stringLocationOffset: isHyphenatedString ? lineRange.location : 0)
-      else {
-        lineRange.location += lineRange.length
-        continue
-      }
-      newLine.writingDirectionIsRightToLeft = isRTL
-
-      var newLineBaselineOrigin = _algorithmWebKit_BaselineOrigin(
-        toPositionLine: newLine, afterLine: previousLine)
-
-      // following a table, flow continues below the table's lowest cell
-      if let minimumY = minimumBaselineYAfterTable {
-        newLineBaselineOrigin.y = max(newLineBaselineOrigin.y, ceil(minimumY + newLine.ascent))
-        minimumBaselineYAfterTable = nil
-      }
-
-      newLineBaselineOrigin.x = lineOriginX
-      newLine.baselineOrigin = newLineBaselineOrigin
+      minimumBaselineYAfterTable = nil
 
       var lineBottom = newLine.frame.maxY
       if let textBlocks = newLine.textBlocks as? [TextBlock], let first = textBlocks.first {
@@ -705,7 +837,11 @@ open class CoreTextLayoutFrame: NSObject {
     for oneLine in lines {
       let lineFrame = oneLine.frame
       if lineFrame.maxY < minY { continue }
-      if lineFrame.origin.y > maxY { break }
+      if lineFrame.origin.y > maxY {
+        // text wrapping around floated content is not monotonic in y
+        if _hasFloatedContent { continue }
+        break
+      }
 
       var adjustedFrame = lineFrame
       adjustedFrame.size.width = max(adjustedFrame.size.width, 1)
@@ -732,7 +868,11 @@ open class CoreTextLayoutFrame: NSObject {
     for oneLine in lines {
       let lineFrame = oneLine.frame
       if lineFrame.maxY < minY { continue }
-      if lineFrame.origin.y > maxY { break }
+      if lineFrame.origin.y > maxY {
+        // text wrapping around floated content is not monotonic in y
+        if _hasFloatedContent { continue }
+        break
+      }
       if rect.contains(lineFrame) { tmpArray.append(oneLine) }
     }
     return tmpArray
@@ -2159,6 +2299,402 @@ extension CoreTextLayoutFrame {
     return result
   }
 
+  // MARK: - Float Layout
+
+  /// A box taken out of the normal flow by `float:left` / `float:right`; lines
+  /// vertically intersecting it are narrowed so the text wraps around it.
+  struct _FloatRegion {
+    var rect: CGRect
+    var style: DTHTMLElementFloatStyle
+  }
+
+  private struct _FloatLayoutResult {
+    var lines: [CoreTextLayoutLine]
+    var region: _FloatRegion
+    /// The string range consumed by the float.
+    var range: NSRange
+    /// Nested layout results (block frames, tables) of a floated block.
+    var nested: _TableLayoutResult? = nil
+  }
+
+  /// The float style marked at the given string index, if any.
+  private func _floatStyleValue(at location: Int) -> DTHTMLElementFloatStyle? {
+    guard let fragment = _attributedStringFragment, location < fragment.length,
+      let number = fragment.attribute(
+        NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: location,
+        effectiveRange: nil) as? NSNumber,
+      let style = DTHTMLElementFloatStyle(rawValue: number.uintValue), style != .none
+    else { return nil }
+
+    return style
+  }
+
+  /// The first location after the range's start where floated content begins.
+  private func _firstFloatStart(in range: NSRange) -> Int? {
+    guard let fragment = _attributedStringFragment, range.length > 0 else { return nil }
+
+    let key = NSAttributedString.Key(rawValue: DTFloatStyleAttribute)
+    var index = range.location
+    let end = NSMaxRange(range)
+
+    while index < end {
+      var effectiveRange = NSRange()
+      let value =
+        fragment.attribute(key, at: index, longestEffectiveRange: &effectiveRange, in: range)
+        as? NSNumber
+
+      if let value, value.uintValue != DTHTMLElementFloatStyle.none.rawValue,
+        index > range.location
+      {
+        return index
+      }
+
+      index = NSMaxRange(effectiveRange)
+    }
+
+    return nil
+  }
+
+  /// Where the top of the next line (or float) is expected, before the line exists.
+  private func _estimatedTopForNextLine(
+    after previousLine: CoreTextLayoutLine?, atLocation location: Int
+  ) -> CGFloat {
+    guard let previousLine else { return _frame.origin.y }
+
+    var top = previousLine.frame.maxY
+
+    if isLineLast(inParagraph: previousLine) {
+      top += previousLine.paragraphStyle?.paragraphSpacing ?? 0
+
+      if let fragment = _attributedStringFragment, location < fragment.length,
+        let style = fragment.attribute(.paragraphStyle, at: location, effectiveRange: nil)
+          as? NSParagraphStyle
+      {
+        top += style.paragraphSpacingBefore
+      }
+    }
+
+    return top
+  }
+
+  /// Horizontal insets from the frame's left/right edges caused by float regions
+  /// that vertically intersect the band between top and bottom.
+  private func _floatInsets(top: CGFloat, bottom: CGFloat, regions: [_FloatRegion])
+    -> (left: CGFloat, right: CGFloat)
+  {
+    var left: CGFloat = 0
+    var right: CGFloat = 0
+
+    for region in regions {
+      guard region.rect.minY < bottom, region.rect.maxY > top else { continue }
+
+      switch region.style {
+      case .left:
+        left = max(left, region.rect.maxX - _frame.minX)
+      case .right:
+        right = max(right, _frame.maxX - region.rect.minX)
+      case .none:
+        break
+      }
+    }
+
+    return (left, right)
+  }
+
+  /// The nearest bottom edge below the given top among the float regions — where
+  /// layout continues when content has to move below them.
+  private func _lowestFloatBottom(below top: CGFloat, regions: [_FloatRegion]) -> CGFloat? {
+    var nearest: CGFloat? = nil
+
+    for region in regions where region.rect.maxY > top {
+      nearest = min(nearest ?? .greatestFiniteMagnitude, region.rect.maxY)
+    }
+
+    return nearest
+  }
+
+  /// The bottom edge below which content at the given location must start because
+  /// of a `clear` property, or nil when nothing needs clearing.
+  private func _clearanceBottom(at location: Int, regions: [_FloatRegion]) -> CGFloat? {
+    guard !regions.isEmpty, let fragment = _attributedStringFragment,
+      location < fragment.length,
+      let number = fragment.attribute(
+        NSAttributedString.Key(rawValue: DTClearFloatsAttribute), at: location,
+        effectiveRange: nil) as? NSNumber,
+      let clearStyle = DTHTMLElementClearStyle(rawValue: number.uintValue),
+      clearStyle != .none
+    else { return nil }
+
+    var bottom: CGFloat? = nil
+
+    for region in regions {
+      let matches: Bool
+      switch clearStyle {
+      case .left: matches = (region.style == .left)
+      case .right: matches = (region.style == .right)
+      case .both: matches = true
+      case .none: matches = false
+      }
+
+      if matches {
+        bottom = max(bottom ?? -.greatestFiniteMagnitude, region.rect.maxY)
+      }
+    }
+
+    return bottom
+  }
+
+  /// Whether the block's entire span lies inside the given range. A block reaching
+  /// beyond the range also occurs in the blocks arrays just outside of it.
+  private func _blockIsFullyContained(_ block: TextBlock, in range: NSRange) -> Bool {
+    guard let fragment = _attributedStringFragment else { return false }
+
+    if range.location > 0, let before = _textBlocks(at: range.location - 1),
+      before.contains(where: { $0 === block })
+    {
+      return false
+    }
+
+    let end = NSMaxRange(range)
+    if end < fragment.length, let after = _textBlocks(at: end),
+      after.contains(where: { $0 === block })
+    {
+      return false
+    }
+
+    return true
+  }
+
+  /// The accumulated horizontal padding of the blocks containing the given location,
+  /// ignoring blocks that belong to the floated content itself.
+  private func _containerPadding(at location: Int, excludingBlocksInside floatRange: NSRange?)
+    -> (left: CGFloat, right: CGFloat)
+  {
+    guard let blocks = _textBlocks(at: location) else { return (0, 0) }
+
+    var left: CGFloat = 0
+    var right: CGFloat = 0
+
+    for block in blocks {
+      if let floatRange, _blockIsFullyContained(block, in: floatRange) { continue }
+      left += block.padding.left
+      right += block.padding.right
+    }
+
+    return (left, right)
+  }
+
+  /// Finds the position for a float box: at the requested side's content edge, next
+  /// to earlier floats when there is room, otherwise below them.
+  private func _placeFloat(
+    width: CGFloat, style: DTHTMLElementFloatStyle, startingAt top: CGFloat,
+    containerPadding: (left: CGFloat, right: CGFloat), regions: [_FloatRegion]
+  ) -> (x: CGFloat, top: CGFloat) {
+    // a float's top may not be above the top of any earlier float
+    var floatTop = top
+    if let lowestRegionTop = regions.map({ $0.rect.minY }).max() {
+      floatTop = max(floatTop, lowestRegionTop)
+    }
+
+    var attempts = 0
+
+    while true {
+      // collision testing only needs the top band: earlier floats always start
+      // at or above this float's top, so any overlap also intersects the band
+      let insets = _floatInsets(top: floatTop, bottom: floatTop + 1, regions: regions)
+      let leftEdge = _frame.minX + max(insets.left, containerPadding.left)
+      let rightEdge = _frame.maxX - max(insets.right, containerPadding.right)
+
+      let fits = (width <= rightEdge - leftEdge) || (insets.left == 0 && insets.right == 0)
+
+      if !fits, attempts < 32, let nextTop = _lowestFloatBottom(below: floatTop, regions: regions) {
+        floatTop = nextTop
+        attempts += 1
+        continue
+      }
+
+      let x = (style == .right) ? rightEdge - width : leftEdge
+      return (x, floatTop)
+    }
+  }
+
+  /// Lays out the floated content starting at the given location and returns its
+  /// lines, the region that the following text wraps around, and the consumed
+  /// string range. Returns nil when the float does not fit into the remaining
+  /// vertical space and should move to a continuation frame.
+  private func _layoutFloat(
+    at location: Int, previousLine: CoreTextLayoutLine?, regions: [_FloatRegion],
+    maximumY: CGFloat, canOverflow: Bool
+  ) -> _FloatLayoutResult? {
+    guard let framesetter = _framesetter, let fragment = _attributedStringFragment,
+      let style = _floatStyleValue(at: location)
+    else { return nil }
+
+    let nsString = fragment.string as NSString
+    let maxIndex = NSMaxRange(_requestedStringRange)
+
+    // the full extent of this floated content, never reaching back before the
+    // current location (a continuation frame can start inside a float)
+    var attributeRange = NSRange()
+    _ = fragment.attribute(
+      NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: location,
+      longestEffectiveRange: &attributeRange,
+      in: NSRange(location: 0, length: fragment.length))
+
+    var floatRange = NSRange(
+      location: location, length: max(NSMaxRange(attributeRange) - location, 1))
+    if NSMaxRange(floatRange) > maxIndex {
+      floatRange.length = maxIndex - location
+    }
+
+    // where the float's top edge goes
+    var floatTop = _estimatedTopForNextLine(after: previousLine, atLocation: location)
+    if let clearBottom = _clearanceBottom(at: location, regions: regions) {
+      floatTop = max(floatTop, clearBottom)
+    }
+
+    let attachment =
+      fragment.attribute(.attachment, at: location, effectiveRange: nil) as? NSTextAttachment
+
+    // a floated image is a single object placeholder, possibly followed by other
+    // floated placeholders or the paragraph break; a floated block is anything else
+    var isImageFloat = false
+    if attachment != nil {
+      let next = location + 1
+      if next >= NSMaxRange(floatRange) {
+        isImageFloat = true
+      } else {
+        let nextCharacter = nsString.character(at: next)
+        isImageFloat = (nextCharacter == 0x0A || nextCharacter == 0xFFFC)
+      }
+    }
+
+    if let attachment, isImageFloat {
+      let size = dtAttachmentLayoutSize(attachment)
+      let ascent = dtAttachmentLayoutAscent(attachment)
+      let width = size.width
+      let height = max(size.height, 1)
+
+      // an image that ends its paragraph absorbs the paragraph break so that the
+      // flow does not get an empty line
+      var unitLength = 1
+      let next = location + 1
+      if next < maxIndex, nsString.character(at: next) == 0x0A {
+        unitLength = 2
+      }
+
+      let containerPadding = _containerPadding(at: location, excludingBlocksInside: nil)
+      let placement = _placeFloat(
+        width: width, style: style, startingAt: floatTop,
+        containerPadding: containerPadding, regions: regions)
+
+      if !canOverflow && placement.top + height > maximumY {
+        return nil
+      }
+
+      let typesetter = CTFramesetterGetTypesetter(framesetter)
+      let ctLine = CTTypesetterCreateLine(typesetter, CFRangeMake(location, unitLength))
+
+      guard let line = CoreTextLayoutLine(line: ctLine, stringLocationOffset: 0) else {
+        return nil
+      }
+
+      // the attachment's metrics, not the font's, define the box (the run
+      // delegate is unavailable on AppKit)
+      line.ascent = ascent
+      line.descent = max(height - ascent, 0)
+      let baselineY = ceil(placement.top + ascent)
+      line.baselineOrigin = CGPoint(x: placement.x, y: baselineY)
+
+      let region = _FloatRegion(
+        rect: CGRect(x: placement.x, y: baselineY - ascent, width: width, height: height),
+        style: style)
+
+      return _FloatLayoutResult(
+        lines: [line], region: region,
+        range: NSRange(location: location, length: unitLength))
+    }
+
+    // block float: laid out as a column at the content edge
+    let blocksAtLocation = _textBlocks(at: location) ?? []
+    let ownBlocks = blocksAtLocation.filter { _blockIsFullyContained($0, in: floatRange) }
+
+    var ownPaddingLeft: CGFloat = 0
+    var ownPaddingRight: CGFloat = 0
+    var ownPaddingTop: CGFloat = 0
+    var ownPaddingBottom: CGFloat = 0
+
+    for block in ownBlocks {
+      ownPaddingLeft += block.padding.left
+      ownPaddingRight += block.padding.right
+      ownPaddingTop += block.padding.top
+      ownPaddingBottom += block.padding.bottom
+    }
+
+    let containerPadding = _containerPadding(at: location, excludingBlocksInside: floatRange)
+
+    // nested tables of the column live below the blocks present at its start
+    let tableSearchLevel = blocksAtLocation.prefix { !($0 is TextTableBlock) }.count
+
+    // explicit CSS width wins, otherwise shrink-to-fit the content
+    var borderBoxWidth: CGFloat
+    if let widthNumber = fragment.attribute(
+      NSAttributedString.Key(rawValue: DTFloatWidthAttribute), at: location,
+      effectiveRange: nil) as? NSNumber, widthNumber.doubleValue > 0
+    {
+      borderBoxWidth = CGFloat(widthNumber.doubleValue) + ownPaddingLeft + ownPaddingRight
+    } else {
+      let naturalWidth = _naturalContentWidth(ofParagraphsIn: floatRange, level: tableSearchLevel)
+      borderBoxWidth = ceil(naturalWidth) + ownPaddingLeft + ownPaddingRight
+    }
+
+    let availableWidth = _frame.size.width - containerPadding.left - containerPadding.right
+    borderBoxWidth = max(min(borderBoxWidth, max(availableWidth, 1)), 1)
+
+    let placement = _placeFloat(
+      width: borderBoxWidth, style: style, startingAt: floatTop,
+      containerPadding: containerPadding, regions: regions)
+
+    var flow = _layoutFlow(
+      range: floatRange,
+      level: tableSearchLevel,
+      width: max(borderBoxWidth - ownPaddingLeft - ownPaddingRight, 1),
+      originX: placement.x + ownPaddingLeft,
+      topY: placement.top + ownPaddingTop)
+
+    let bottom = max(flow.bottomY, placement.top + ownPaddingTop) + ownPaddingBottom
+
+    if !canOverflow && bottom > maximumY {
+      return nil
+    }
+
+    // border-box frames of the float's own blocks, for background/border drawing;
+    // outermost first, each inner box inset by the outer block's padding
+    var blockRect = CGRect(
+      x: placement.x, y: placement.top, width: borderBoxWidth,
+      height: max(bottom - placement.top, 1))
+
+    for block in ownBlocks {
+      if let level = blocksAtLocation.firstIndex(where: { $0 === block }) {
+        flow.cellFrames.append((block, blockRect, level))
+      }
+
+      blockRect = CGRect(
+        x: blockRect.minX + block.padding.left,
+        y: blockRect.minY + block.padding.top,
+        width: max(blockRect.width - block.padding.left - block.padding.right, 1),
+        height: max(blockRect.height - block.padding.top - block.padding.bottom, 1))
+    }
+
+    let region = _FloatRegion(
+      rect: CGRect(
+        x: placement.x, y: placement.top, width: borderBoxWidth,
+        height: max(bottom - placement.top, 1)),
+      style: style)
+
+    return _FloatLayoutResult(lines: flow.lines, region: region, range: floatRange, nested: flow)
+  }
+
   /// Lays out a range of text as a vertical flow of lines with the given width — the
   /// content of one table cell. Nested tables are laid out recursively.
   private func _layoutFlow(
@@ -2291,8 +2827,8 @@ extension CoreTextLayoutFrame {
 
     if _frame.size.height == CGFLOAT_HEIGHT_UNKNOWN {
       if let lastLine = lines.last {
-        // a table's lowest cell can reach below the last line of text
-        let contentBottom = max(lastLine.frame.maxY, _maxTableBottom)
+        // a table's lowest cell or a floated box can reach below the last line of text
+        let contentBottom = max(lastLine.frame.maxY, _maxTableBottom, _maxFloatBottom)
         _frame.size.height = ceil(
           contentBottom - _frame.origin.y + 1.5 + _additionalPaddingAtBottom)
       }

--- a/Sources/DTCoreText/CoreTextLayoutFrame.swift
+++ b/Sources/DTCoreText/CoreTextLayoutFrame.swift
@@ -70,6 +70,10 @@ open class CoreTextLayoutFrame: NSObject {
   @objc open var justifyRatio: CGFloat = 0.6
 
   /// Maximum number of lines to display before truncation. Default is 0 (no limit).
+  ///
+  /// Only lines of the normal flow count towards the limit; floated content
+  /// (`float:left` / `float:right`) is out of the flow, so a leading floated
+  /// image plus its wrapped text line count as one line, not two.
   @objc open var numberOfLines: Int = 0 {
     didSet {
       if numberOfLines != oldValue {
@@ -362,6 +366,10 @@ open class CoreTextLayoutFrame: NSObject {
     var previousLine: CoreTextLayoutLine? = nil
     var minimumBaselineYAfterTable: CGFloat? = nil
 
+    // lines of the normal flow — floated content is out of the flow and does
+    // not count towards numberOfLines or the lines-fitting retry
+    var flowLineCount = 0
+
     // floats only make sense within a known width
     var floatRegions = [_FloatRegion]()
     let floatsEnabled = _frame.size.width < CGFLOAT_WIDTH_UNKNOWN
@@ -573,8 +581,8 @@ open class CoreTextLayoutFrame: NSObject {
         }
 
         shouldTruncateLine =
-          ((numberOfLines > 0 && typesetLines.count + 1 == numberOfLines)
-            || (_numberLinesFitInFrame > 0 && _numberLinesFitInFrame == typesetLines.count + 1))
+          ((numberOfLines > 0 && flowLineCount + 1 >= numberOfLines)
+            || (_numberLinesFitInFrame > 0 && _numberLinesFitInFrame <= flowLineCount + 1))
 
         var ctLine: CTLine
         var isHyphenatedString = false
@@ -774,8 +782,8 @@ open class CoreTextLayoutFrame: NSObject {
       }
 
       if lineBottom > maxY {
-        if !typesetLines.isEmpty && lineBreakMode != .byWordWrapping {
-          _numberLinesFitInFrame = typesetLines.count
+        if flowLineCount > 0 && lineBreakMode != .byWordWrapping {
+          _numberLinesFitInFrame = flowLineCount
           _buildLinesWithTypesetter()
           return
         } else {
@@ -784,6 +792,7 @@ open class CoreTextLayoutFrame: NSObject {
       }
 
       typesetLines.append(newLine)
+      flowLineCount += 1
       fittingLength += lineRange.length
       lineRange.location += lineRange.length
       previousLine = newLine

--- a/Sources/DTCoreText/CoreTextLayoutLine.swift
+++ b/Sources/DTCoreText/CoreTextLayoutLine.swift
@@ -328,8 +328,14 @@ open class CoreTextLayoutLine: NSObject {
 
   /// The descent (height below the baseline) of the receiver.
   @objc open var descent: CGFloat {
-    if !_didCalculateMetrics { _calculateMetrics() }
-    return _descent
+    get {
+      if !_didCalculateMetrics { _calculateMetrics() }
+      return _descent
+    }
+    set {
+      if !_didCalculateMetrics { _calculateMetrics() }
+      _descent = newValue
+    }
   }
 
   /// The leading (additional space above the ascent) of the receiver.

--- a/Sources/DTCoreText/DTCoreText.docc/DTCoreText.md
+++ b/Sources/DTCoreText/DTCoreText.docc/DTCoreText.md
@@ -4,7 +4,7 @@ Generate `NSAttributedString` and SwiftUI `AttributedString` from HTML on iOS, m
 
 ## Overview
 
-DTCoreText parses HTML into attributed strings using CoreText, giving you full control over rich text display without a web view. It supports fonts, colors, links, images, lists, tables, text shadows, and custom HTML attributes.
+DTCoreText parses HTML into attributed strings using CoreText, giving you full control over rich text display without a web view. It supports fonts, colors, links, images, lists, tables, floats (`float:left` / `float:right` on images and blocks, with text wrapping around them and `clear` support), text shadows, and custom HTML attributes.
 
 ### Generating Attributed Strings
 

--- a/Sources/DTCoreText/DTCoreTextConstants.swift
+++ b/Sources/DTCoreText/DTCoreTextConstants.swift
@@ -209,6 +209,20 @@ public let DTBackgroundStrokeWidthAttribute: String = "DTBackgroundStrokeWidth"
 public let DTBackgroundCornerRadiusAttribute: String = "DTBackgroundCornerRadius"
 public let DTArchivingAttribute: String = "DTArchivingAttribute"
 
+/// `NSNumber` wrapping a `DTHTMLElementFloatStyle` raw value. Marks content that is
+/// taken out of the normal flow and floated to the left or right content edge during
+/// layout; following text wraps around it. On a floated image the attribute sits on
+/// the object placeholder character, on a floated block it spans the block's output.
+public let DTFloatStyleAttribute: String = "DTFloatStyle"
+
+/// `NSNumber` wrapping the explicit CSS width (in points) of a floated block.
+/// Absent when the float should shrink-to-fit its content.
+public let DTFloatWidthAttribute: String = "DTFloatWidth"
+
+/// `NSNumber` wrapping a `DTHTMLElementClearStyle` raw value. The marked paragraph
+/// starts below previously floated content on the indicated side(s).
+public let DTClearFloatsAttribute: String = "DTClearFloats"
+
 // MARK: - Field Constants
 
 public let DTListPrefixField: String = "{listprefix}"

--- a/Sources/DTCoreText/DTHTMLElementClearStyle.swift
+++ b/Sources/DTCoreText/DTHTMLElementClearStyle.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// The sides on which an element does not allow earlier floated content,
+/// from the CSS `clear` property.
+public enum DTHTMLElementClearStyle: UInt, Sendable {
+  /// The element is not moved below floated content
+  case none = 0
+  /// The element begins below left-floated content
+  case left
+  /// The element begins below right-floated content
+  case right
+  /// The element begins below all floated content
+  case both
+}

--- a/Sources/DTCoreText/HTMLElement.swift
+++ b/Sources/DTCoreText/HTMLElement.swift
@@ -49,6 +49,7 @@ open class HTMLElement: HTMLParserNode {
 
   private var _displayStyle: DTHTMLElementDisplayStyle = .inline
   private var _floatStyle: DTHTMLElementFloatStyle = .none
+  private var _clearStyle: DTHTMLElementClearStyle = .none
 
   internal var _isColorInherited: Bool = false
   internal var _preserveNewlines: Bool = false
@@ -151,6 +152,12 @@ open class HTMLElement: HTMLParserNode {
       // remember original paragraphSpacing
       tmpDict[NSAttributedString.Key(rawValue: DTAttachmentParagraphSpacingAttribute)] = NSNumber(
         value: Double(self.paragraphStyle.paragraphSpacing))
+
+      // a floated attachment is taken out of the flow during layout
+      if _floatStyle != .none {
+        tmpDict[NSAttributedString.Key(rawValue: DTFloatStyleAttribute)] = NSNumber(
+          value: _floatStyle.rawValue)
+      }
     }
 
     if let fontDescriptor = _fontDescriptor {
@@ -251,6 +258,11 @@ open class HTMLElement: HTMLParserNode {
     if _headerLevel != 0 {
       tmpDict[NSAttributedString.Key(rawValue: DTHeaderLevelAttribute)] = NSNumber(
         value: _headerLevel)
+    }
+
+    if _clearStyle != .none {
+      tmpDict[NSAttributedString.Key(rawValue: DTClearFloatsAttribute)] = NSNumber(
+        value: _clearStyle.rawValue)
     }
 
     // List metadata rides on `NSParagraphStyle.textLists` (set by
@@ -468,7 +480,39 @@ open class HTMLElement: HTMLParserNode {
       _addCustomHTMLAttributes(to: tmpString)
     }
 
+    // mark floated content over the element's entire output so the layout can
+    // take it out of the flow; nested floats (e.g. a floated image inside a
+    // floated block) keep their own value
+    if _textAttachment == nil && _floatStyle != .none && tmpString.length > 0 {
+      _addAttributeToUnmarkedRanges(
+        DTFloatStyleAttribute, value: NSNumber(value: _floatStyle.rawValue), of: tmpString)
+
+      if _size.width > 0 {
+        _addAttributeToUnmarkedRanges(
+          DTFloatWidthAttribute, value: NSNumber(value: Double(_size.width)), of: tmpString)
+      }
+    }
+
+    if _clearStyle != .none && tmpString.length > 0 {
+      _addAttributeToUnmarkedRanges(
+        DTClearFloatsAttribute, value: NSNumber(value: _clearStyle.rawValue), of: tmpString)
+    }
+
     return tmpString
+  }
+
+  /// Adds an attribute over all ranges of the string that do not carry it yet.
+  private func _addAttributeToUnmarkedRanges(
+    _ name: String, value: Any, of attributedString: NSMutableAttributedString
+  ) {
+    let key = NSAttributedString.Key(rawValue: name)
+    let fullRange = NSRange(location: 0, length: attributedString.length)
+
+    attributedString.enumerateAttribute(key, in: fullRange, options: []) { existing, range, _ in
+      if existing == nil {
+        attributedString.addAttribute(key, value: value, range: range)
+      }
+    }
   }
 
   // MARK: - Working with CSS Styles
@@ -600,6 +644,17 @@ open class HTMLElement: HTMLParserNode {
       case "left": _floatStyle = .left
       case "right": _floatStyle = .right
       case "none": _floatStyle = .none
+      default: break
+      }
+    }
+
+    // clear
+    if let clearString = styles["clear"] as? String {
+      switch clearString {
+      case "left": _clearStyle = .left
+      case "right": _clearStyle = .right
+      case "both": _clearStyle = .both
+      case "none": _clearStyle = .none
       default: break
       }
     }
@@ -1134,6 +1189,10 @@ open class HTMLElement: HTMLParserNode {
 
   open var floatStyle: DTHTMLElementFloatStyle {
     return _floatStyle
+  }
+
+  open var clearStyle: DTHTMLElementClearStyle {
+    return _clearStyle
   }
 
   open var isColorInherited: Bool {

--- a/Sources/DTCoreText/HTMLWriter.swift
+++ b/Sources/DTCoreText/HTMLWriter.swift
@@ -304,6 +304,9 @@ public class HTMLWriter: NSObject {
     var openTableBlocks = [TextTableBlock]()
     var openEmittedTables = 0
 
+    // the end of the floated block range the output is currently inside, if any
+    var openFloatEnd: Int? = nil
+
     for i in 0..<paragraphs.count {
       let oneParagraph = paragraphs[i]
       let paragraphRange = NSRange(location: location, length: (oneParagraph as NSString).length)
@@ -363,8 +366,38 @@ public class HTMLWriter: NSObject {
         commonTableDepth += 1
       }
 
-      if openTableBlocks.count > commonTableDepth || currentTableBlocks.count > commonTableDepth {
-        // lists never straddle a cell boundary — close any open lists first
+      // a floated block range becomes a wrapping <div style="float:...">; floated
+      // attachments are excluded, they get their float inline on the object tag
+      var paragraphFloatStyle: DTHTMLElementFloatStyle? = nil
+      var paragraphFloatRange = NSRange(location: NSNotFound, length: 0)
+
+      if paragraphRange.location < attributedStringStorage.length {
+        var floatEffectiveRange = NSRange()
+        if let floatNumber = attributedStringStorage.attribute(
+          NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: paragraphRange.location,
+          longestEffectiveRange: &floatEffectiveRange,
+          in: NSRange(location: 0, length: attributedStringStorage.length)) as? NSNumber,
+          let floatStyle = DTHTMLElementFloatStyle(rawValue: floatNumber.uintValue),
+          floatStyle != .none,
+          attributedStringStorage.attribute(
+            .attachment, at: paragraphRange.location, effectiveRange: nil) == nil
+        {
+          paragraphFloatStyle = floatStyle
+          paragraphFloatRange = floatEffectiveRange
+        }
+      }
+
+      let floatBoundaryCrossed: Bool
+      if let endOfFloat = openFloatEnd {
+        floatBoundaryCrossed = paragraphRange.location >= endOfFloat
+      } else {
+        floatBoundaryCrossed = (paragraphFloatStyle != nil)
+      }
+
+      if openTableBlocks.count > commonTableDepth || currentTableBlocks.count > commonTableDepth
+        || floatBoundaryCrossed
+      {
+        // lists never straddle a cell or float boundary — close any open lists first
         if let prevStyles = previousListStyles, !prevStyles.isEmpty {
           for closingStyle in prevStyles.reversed() {
             retString += _tagRepresentation(
@@ -392,6 +425,27 @@ public class HTMLWriter: NSObject {
           retString += "</tr>\n</table>\n"
           openEmittedTables -= 1
         }
+      }
+
+      // close a floated group that ended before this paragraph
+      if let endOfFloat = openFloatEnd, paragraphRange.location >= endOfFloat {
+        retString += "</div>\n"
+        openFloatEnd = nil
+      }
+
+      // open a floated group beginning at this paragraph
+      if openFloatEnd == nil, let floatStyle = paragraphFloatStyle {
+        var divStyle = (floatStyle == .right) ? "float:right;" : "float:left;"
+
+        if let widthNumber = attributedStringStorage.attribute(
+          NSAttributedString.Key(rawValue: DTFloatWidthAttribute), at: paragraphRange.location,
+          effectiveRange: nil) as? NSNumber, widthNumber.doubleValue > 0
+        {
+          divStyle += String(format: "width:%.0fpx;", widthNumber.doubleValue)
+        }
+
+        retString += "<div style=\"\(divStyle)\">\n"
+        openFloatEnd = NSMaxRange(paragraphFloatRange)
       }
 
       // open new tables and cells down to the current paragraph's cell
@@ -450,6 +504,21 @@ public class HTMLWriter: NSObject {
             paraStyleString = (paraStyleString ?? "") + paraFontStyle
           }
         }
+      }
+
+      if let clearNumber = paraAttributesDict.object(forKey: DTClearFloatsAttribute) as? NSNumber,
+        let clearStyle = DTHTMLElementClearStyle(rawValue: clearNumber.uintValue),
+        clearStyle != .none
+      {
+        let clearValue: String
+        switch clearStyle {
+        case .left: clearValue = "left"
+        case .right: clearValue = "right"
+        case .both: clearValue = "both"
+        case .none: clearValue = "none"
+        }
+
+        paraStyleString = (paraStyleString ?? "") + "clear:\(clearValue);"
       }
 
       var blockElement: String
@@ -699,15 +768,33 @@ public class HTMLWriter: NSObject {
         }
 
         if let attachment = attachment {
+          // a floated attachment carries its float on a wrapping span so any
+          // attachment type round-trips
+          var floatCSS: String? = nil
+
+          if let floatNumber = attributesDict.object(forKey: DTFloatStyleAttribute) as? NSNumber {
+            switch DTHTMLElementFloatStyle(rawValue: floatNumber.uintValue) {
+            case .left: floatCSS = "float:left;"
+            case .right: floatCSS = "float:right;"
+            default: break
+            }
+          }
+
           if let persistableAttachment = attachment as? TextAttachmentHTMLPersistence {
-            retString += persistableAttachment.stringByEncodingAsHTML()
+            let encodedString = persistableAttachment.stringByEncodingAsHTML()
+
+            if let floatCSS = floatCSS {
+              retString += "<span style=\"\(floatCSS)\">\(encodedString)</span>"
+            } else {
+              retString += encodedString
+            }
           } else if let image = attachment.image,
                     let pngData = image.dataForPNGRepresentation() {
             // Plain `NSTextAttachment` with an image — emit a data-URL <img>.
             let encoded = pngData.base64EncodedString()
             let size = image.size
             retString +=
-              "<img style=\"width:\(Int(size.width))px;height:\(Int(size.height))px;\" "
+              "<img style=\"width:\(Int(size.width))px;height:\(Int(size.height))px;\(floatCSS ?? "")\" "
               + "src=\"data:image/png;base64,\(encoded)\" />"
           }
 
@@ -955,6 +1042,11 @@ public class HTMLWriter: NSObject {
       openTableBlocks.removeLast()
       retString += "</td></tr>\n</table>\n"
       openEmittedTables -= 1
+    }
+
+    // close a floated group still open at the end of the string
+    if openFloatEnd != nil {
+      retString += "</div>\n"
     }
 
     var output = ""

--- a/Sources/DTCoreText/TextAttachmentHTMLElement.swift
+++ b/Sources/DTCoreText/TextAttachmentHTMLElement.swift
@@ -66,19 +66,6 @@ open class TextAttachmentHTMLElement: HTMLElement {
     return tmpString
   }
 
-  // workaround, because we don't support float yet. float causes the image to be its own block
-  open override var displayStyle: DTHTMLElementDisplayStyle {
-    get {
-      if super.floatStyle == .none {
-        return super.displayStyle
-      }
-      return .block
-    }
-    set {
-      super.displayStyle = newValue
-    }
-  }
-
   open override func applyStyles(_ styles: [String: Any]) {
     // element size is determined in super (tag attribute and style)
     super.applyStyles(styles)

--- a/Tests/DTCoreTextTests/FloatLayoutTests.swift
+++ b/Tests/DTCoreTextTests/FloatLayoutTests.swift
@@ -317,6 +317,28 @@ struct FloatLayoutTests {
 		#expect(result.frame.frame.height >= 200)
 	}
 
+	// MARK: - Line Limits
+
+	@Test("numberOfLines counts flow lines, not float lines")
+	func numberOfLinesWithLeadingFloat() throws {
+		let html = "<p style=\"margin:0\"><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:left\">\(wrapText)</p>"
+		let attributedString = try #require(TestHelpers.attributedString(fromHTML: html))
+		let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+
+		let maxRect = CGRect(x: 0, y: 0, width: 400, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+		let entireString = NSRange(location: 0, length: attributedString.length)
+		let frame = try #require(layouter.layoutFrame(with: maxRect, range: entireString))
+		frame.numberOfLines = 2
+
+		let allLines = lines(of: frame)
+		let flowLines = allLines.filter { $0.attachments == nil }
+		let imageLines = allLines.filter { $0.attachments != nil }
+
+		// the float still shows, and the limit applies to the text lines beside it
+		#expect(imageLines.count == 1)
+		#expect(flowLines.count == 2)
+	}
+
 	// MARK: - Pagination
 
 	@Test("A float that does not fit moves to the continuation frame")

--- a/Tests/DTCoreTextTests/FloatLayoutTests.swift
+++ b/Tests/DTCoreTextTests/FloatLayoutTests.swift
@@ -1,0 +1,420 @@
+import Testing
+import Foundation
+import CoreText
+@testable import DTCoreText
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+@Suite("Float Layout", .serialized)
+struct FloatLayoutTests {
+
+	// MARK: - Helpers
+
+	private func layoutFrame(forHTML html: String, width: CGFloat = 400) throws -> (frame: CoreTextLayoutFrame, string: NSAttributedString) {
+		let attributedString = try #require(TestHelpers.attributedString(fromHTML: html))
+		let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+
+		let maxRect = CGRect(x: 0, y: 0, width: width, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
+		let entireString = NSRange(location: 0, length: attributedString.length)
+		let frame = try #require(layouter.layoutFrame(with: maxRect, range: entireString))
+
+		return (frame, attributedString)
+	}
+
+	private func lines(of frame: CoreTextLayoutFrame) -> [CoreTextLayoutLine] {
+		return (frame.lines as? [CoreTextLayoutLine]) ?? []
+	}
+
+	private func attachmentLines(of frame: CoreTextLayoutFrame) -> [CoreTextLayoutLine] {
+		return lines(of: frame).filter { $0.attachments != nil }
+	}
+
+	private func textLines(of frame: CoreTextLayoutFrame) -> [CoreTextLayoutLine] {
+		return lines(of: frame).filter { $0.attachments == nil }
+	}
+
+	/// The right edge of the line's real content, ignoring hanging trailing whitespace.
+	private func contentMaxX(of line: CoreTextLayoutLine) -> CGFloat {
+		return line.frame.maxX - line.trailingWhitespaceWidth
+	}
+
+	private let wrapText = String(repeating: "lorem ipsum dolor sit amet consetetur sadipscing elitr sed diam nonumy eirmod tempor ", count: 12)
+
+	// MARK: - Attribute Emission
+
+	@Test("Floated image carries the float style attribute")
+	func floatAttributeOnImage() throws {
+		let output = try #require(TestHelpers.attributedString(fromHTML: "<p><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:right\">text</p>"))
+
+		let plainString = output.string as NSString
+		let placeholderRange = plainString.range(of: UNICODE_OBJECT_PLACEHOLDER)
+		#expect(placeholderRange.location != NSNotFound)
+
+		let value = output.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: placeholderRange.location, effectiveRange: nil) as? NSNumber
+		#expect(value?.uintValue == DTHTMLElementFloatStyle.right.rawValue)
+	}
+
+	@Test("Floated image stays inline within its paragraph")
+	func floatedImageStaysInline() throws {
+		let output = try #require(TestHelpers.attributedString(fromHTML: "<p><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:left\">text</p>"))
+
+		// before float support, a floated image was forced to be its own block;
+		// now the placeholder must be directly followed by the text
+		#expect(output.string.hasPrefix("\u{FFFC}text"))
+	}
+
+	@Test("Floated block carries float style and width over its whole range")
+	func floatAttributesOnBlock() throws {
+		let output = try #require(TestHelpers.attributedString(fromHTML: "<div style=\"float:right; width:150px\">floated</div><p>main</p>"))
+
+		let plainString = output.string as NSString
+		let floatedRange = plainString.range(of: "floated")
+		#expect(floatedRange.location != NSNotFound)
+
+		var effectiveRange = NSRange()
+		let style = output.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: floatedRange.location, longestEffectiveRange: &effectiveRange, in: NSRange(location: 0, length: output.length)) as? NSNumber
+		#expect(style?.uintValue == DTHTMLElementFloatStyle.right.rawValue)
+
+		// the attribute spans the entire div output including its paragraph break
+		#expect(effectiveRange.location == floatedRange.location)
+		#expect(NSMaxRange(effectiveRange) >= NSMaxRange(floatedRange) + 1)
+
+		let width = output.attribute(NSAttributedString.Key(rawValue: DTFloatWidthAttribute), at: floatedRange.location, effectiveRange: nil) as? NSNumber
+		#expect(width?.doubleValue == 150)
+
+		// the main paragraph is not floated
+		let mainRange = plainString.range(of: "main")
+		let mainStyle = output.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: mainRange.location, effectiveRange: nil)
+		#expect(mainStyle == nil)
+	}
+
+	@Test("Clear style is emitted on the paragraph")
+	func clearAttributeOnParagraph() throws {
+		let output = try #require(TestHelpers.attributedString(fromHTML: "<p style=\"clear:both\">text</p>"))
+
+		let value = output.attribute(NSAttributedString.Key(rawValue: DTClearFloatsAttribute), at: 0, effectiveRange: nil) as? NSNumber
+		#expect(value?.uintValue == DTHTMLElementClearStyle.both.rawValue)
+	}
+
+	// MARK: - Image Float Layout
+
+	@Test("Image floated right sits at the right edge and text wraps around it")
+	func imageFloatRightGeometry() throws {
+		let html = "<p style=\"margin:0\"><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:right\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let imageLines = attachmentLines(of: result.frame)
+		#expect(imageLines.count == 1)
+
+		let imageLine = try #require(imageLines.first)
+
+		// at the right edge of the 400pt frame
+		#expect(abs(imageLine.frame.origin.x - 300) < 0.5)
+		#expect(abs(imageLine.frame.origin.y - 0) < 0.5)
+		#expect(abs(imageLine.frame.height - 100) < 1)
+
+		let flowLines = textLines(of: result.frame)
+		#expect(flowLines.count > 3)
+
+		var sawNarrowLine = false
+		var sawFullWidthLine = false
+
+		for line in flowLines {
+			#expect(abs(line.frame.origin.x - 0) < 0.5)
+
+			if line.frame.minY < 100 {
+				// beside the image: must end before the float
+				#expect(contentMaxX(of: line) <= 300.5)
+				sawNarrowLine = true
+			}
+
+			if line.frame.minY >= 100 && contentMaxX(of: line) > 305 {
+				// below the image: full width available again
+				sawFullWidthLine = true
+			}
+		}
+
+		#expect(sawNarrowLine)
+		#expect(sawFullWidthLine)
+	}
+
+	@Test("Image floated left indents the text beside it")
+	func imageFloatLeftGeometry() throws {
+		let html = "<p style=\"margin:0\"><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:left\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let imageLine = try #require(attachmentLines(of: result.frame).first)
+		#expect(abs(imageLine.frame.origin.x - 0) < 0.5)
+		#expect(abs(imageLine.frame.origin.y - 0) < 0.5)
+
+		var sawIndentedLine = false
+		var sawFullWidthLine = false
+
+		for line in textLines(of: result.frame) {
+			if line.frame.minY < 100 {
+				#expect(abs(line.frame.origin.x - 100) < 0.5)
+				sawIndentedLine = true
+			} else {
+				#expect(abs(line.frame.origin.x - 0) < 0.5)
+				sawFullWidthLine = true
+			}
+		}
+
+		#expect(sawIndentedLine)
+		#expect(sawFullWidthLine)
+	}
+
+	@Test("Standalone floated image does not leave an empty line in the flow")
+	func standaloneFloatedImage() throws {
+		let html = "<p style=\"margin:0\">First.</p><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:right\"><p style=\"margin:0\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let imageLine = try #require(attachmentLines(of: result.frame).first)
+		let flowLines = textLines(of: result.frame)
+
+		let firstParagraphLine = try #require(flowLines.first)
+		let secondParagraphFirstLine = try #require(flowLines.dropFirst().first)
+
+		// the image's top is where the second paragraph starts, right below the first
+		#expect(abs(imageLine.frame.minY - firstParagraphLine.frame.maxY) < 3)
+
+		// the second paragraph flows beside the image, not below it
+		#expect(secondParagraphFirstLine.frame.minY < imageLine.frame.maxY)
+		#expect(contentMaxX(of: secondParagraphFirstLine) <= 300.5)
+	}
+
+	@Test("Two right floats sit side by side")
+	func twoRightFloatsSideBySide() throws {
+		let html = "<p style=\"margin:0\"><img src=\"Oliver.jpg\" width=\"80\" height=\"80\" style=\"float:right\"><img src=\"Oliver.jpg\" width=\"60\" height=\"60\" style=\"float:right\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let imageLines = attachmentLines(of: result.frame)
+		#expect(imageLines.count == 2)
+
+		let first = try #require(imageLines.first)
+		let second = try #require(imageLines.dropFirst().first)
+
+		// first at the right edge, second to its left
+		#expect(abs(first.frame.origin.x - 320) < 0.5)
+		#expect(abs(second.frame.origin.x - 260) < 0.5)
+		#expect(abs(first.frame.minY - second.frame.minY) < 0.5)
+
+		// text beside both floats ends before the leftmost one
+		for line in textLines(of: result.frame) where line.frame.minY < 60 {
+			#expect(contentMaxX(of: line) <= 260.5)
+		}
+	}
+
+	// MARK: - Block Float Layout
+
+	@Test("Block floated right becomes a column that text wraps around")
+	func blockFloatRight() throws {
+		let html = "<div style=\"float:right; width:150px; margin:0\">floated content that wraps inside the column over several lines</div><p style=\"margin:0\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let output = result.string
+		var floatRange = NSRange()
+		let floatLocation = (output.string as NSString).range(of: "floated").location
+		_ = output.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: floatLocation, longestEffectiveRange: &floatRange, in: NSRange(location: 0, length: output.length))
+
+		var columnLineCount = 0
+
+		for line in lines(of: result.frame) {
+			let lineRange = line.stringRange()
+
+			if NSLocationInRange(lineRange.location, floatRange) {
+				// column lines live within the right-hand 150pt column
+				columnLineCount += 1
+				#expect(line.frame.origin.x >= 249.5)
+				#expect(contentMaxX(of: line) <= 400.5)
+			} else {
+				// main text starts at the left edge
+				#expect(abs(line.frame.origin.x - 0) < 0.5)
+			}
+		}
+
+		// the column content wraps into multiple lines
+		#expect(columnLineCount > 1)
+
+		// main text lines beside the column are narrowed
+		let columnBottom = lines(of: result.frame)
+			.filter { NSLocationInRange($0.stringRange().location, floatRange) }
+			.map { $0.frame.maxY }.max() ?? 0
+
+		var sawNarrowLine = false
+		for line in lines(of: result.frame) where !NSLocationInRange(line.stringRange().location, floatRange) {
+			if line.frame.minY < columnBottom {
+				#expect(contentMaxX(of: line) <= 250.5)
+				sawNarrowLine = true
+			}
+		}
+		#expect(sawNarrowLine)
+	}
+
+	@Test("Block float without width shrinks to fit its content")
+	func blockFloatShrinkToFit() throws {
+		let html = "<div style=\"float:left\">short</div><p style=\"margin:0\">\(wrapText)</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let output = result.string
+		var floatRange = NSRange()
+		let floatLocation = (output.string as NSString).range(of: "short").location
+		_ = output.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: floatLocation, longestEffectiveRange: &floatRange, in: NSRange(location: 0, length: output.length))
+
+		let columnLines = lines(of: result.frame).filter { NSLocationInRange($0.stringRange().location, floatRange) }
+		let columnLine = try #require(columnLines.first)
+
+		// the column hugs the word at the left edge
+		#expect(abs(columnLine.frame.origin.x - 0) < 0.5)
+		let columnWidth = contentMaxX(of: columnLine)
+		#expect(columnWidth < 100)
+
+		// text beside the column is indented past it
+		var sawIndentedLine = false
+		for line in lines(of: result.frame) where !NSLocationInRange(line.stringRange().location, floatRange) {
+			if line.frame.minY < columnLine.frame.maxY {
+				#expect(line.frame.origin.x >= columnWidth - 0.5)
+				sawIndentedLine = true
+			}
+		}
+		#expect(sawIndentedLine)
+	}
+
+	// MARK: - Clear
+
+	@Test("Clear makes a paragraph start below the float")
+	func clearStartsBelowFloat() throws {
+		let html = "<img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:left\"><p style=\"margin:0\">beside</p><p style=\"margin:0; clear:left\">below</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		let imageLine = try #require(attachmentLines(of: result.frame).first)
+		let flowLines = textLines(of: result.frame)
+
+		let besideLine = try #require(flowLines.first)
+		let clearedLine = try #require(flowLines.dropFirst().first)
+
+		// first paragraph flows beside the float, indented
+		#expect(abs(besideLine.frame.origin.x - 100) < 0.5)
+		#expect(besideLine.frame.minY < imageLine.frame.maxY)
+
+		// cleared paragraph starts below the float's bottom at full width
+		#expect(clearedLine.frame.minY >= imageLine.frame.maxY - 0.5)
+		#expect(abs(clearedLine.frame.origin.x - 0) < 0.5)
+	}
+
+	// MARK: - Frame Metrics
+
+	@Test("A float taller than the text extends the frame height")
+	func floatExtendsFrameHeight() throws {
+		let html = "<p style=\"margin:0\"><img src=\"Oliver.jpg\" width=\"100\" height=\"200\" style=\"float:right\">short</p>"
+		let result = try layoutFrame(forHTML: html)
+
+		// the frame must be at least as tall as the floated image
+		#expect(result.frame.frame.height >= 200)
+	}
+
+	// MARK: - Pagination
+
+	@Test("A float that does not fit moves to the continuation frame")
+	func floatPaginatesToNextFrame() throws {
+		let html = "<p style=\"margin:0\">\(wrapText)</p><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:left\"><p style=\"margin:0\">after the image</p>"
+		let attributedString = try #require(TestHelpers.attributedString(fromHTML: html))
+		let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+		let fullRange = NSRange(location: 0, length: attributedString.length)
+
+		// a frame that holds part of the text but has no room for the float
+		let firstFrame = try #require(
+			layouter.layoutFrame(with: CGRect(x: 0, y: 0, width: 400, height: 80), range: fullRange))
+
+		let firstVisible = firstFrame.visibleStringRange()
+		#expect(firstVisible.length > 0)
+		#expect(firstVisible.length < attributedString.length)
+		#expect(attachmentLines(of: firstFrame).isEmpty)
+
+		// the continuation frame starts with the float and keeps all remaining content
+		let continuationStart = NSMaxRange(firstVisible)
+		let secondFrame = try #require(
+			layouter.layoutFrame(
+				with: CGRect(x: 0, y: 0, width: 400, height: 600),
+				range: NSRange(
+					location: continuationStart, length: attributedString.length - continuationStart)))
+
+		let secondVisible = secondFrame.visibleStringRange()
+		#expect(NSMaxRange(secondVisible) == attributedString.length)
+
+		let imageLine = try #require(attachmentLines(of: secondFrame).first)
+		#expect(abs(imageLine.frame.origin.x - 0) < 0.5)
+
+		// the trailing paragraph flows beside the image in the second frame
+		let afterRange = (attributedString.string as NSString).range(of: "after")
+		let afterLine = try #require(secondFrame.lineContaining(index: UInt(afterRange.location)))
+		#expect(afterLine.frame.origin.x >= 99.5)
+	}
+
+	// MARK: - HTML Writer Round-Trip
+
+	@Test("Floated image round-trips through HTML writing")
+	func floatedImageRoundTrip() throws {
+		let html = "<p><img src=\"Oliver.jpg\" width=\"100\" height=\"100\" style=\"float:right\">text beside the image</p>"
+		let string1 = try #require(TestHelpers.attributedString(fromHTML: html))
+
+		let writer = HTMLWriter(attributedString: string1)
+		let writtenHTML = writer.htmlFragment()
+
+		#expect(writtenHTML.contains("float:right"))
+
+		let string2 = try #require(TestHelpers.attributedString(fromHTML: writtenHTML))
+		let placeholderRange = (string2.string as NSString).range(of: UNICODE_OBJECT_PLACEHOLDER)
+		#expect(placeholderRange.location != NSNotFound)
+
+		let value = string2.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: placeholderRange.location, effectiveRange: nil) as? NSNumber
+		#expect(value?.uintValue == DTHTMLElementFloatStyle.right.rawValue)
+	}
+
+	@Test("Floated block round-trips through HTML writing")
+	func floatedBlockRoundTrip() throws {
+		let html = "<div style=\"float:left; width:120px\">floated column</div><p>main text</p>"
+		let string1 = try #require(TestHelpers.attributedString(fromHTML: html))
+
+		let writer = HTMLWriter(attributedString: string1)
+		let writtenHTML = writer.htmlFragment()
+
+		#expect(writtenHTML.contains("float:left"))
+		#expect(writtenHTML.contains("width:120px"))
+
+		let string2 = try #require(TestHelpers.attributedString(fromHTML: writtenHTML))
+
+		let floatedLocation = (string2.string as NSString).range(of: "floated").location
+		#expect(floatedLocation != NSNotFound)
+
+		let style = string2.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: floatedLocation, effectiveRange: nil) as? NSNumber
+		#expect(style?.uintValue == DTHTMLElementFloatStyle.left.rawValue)
+
+		let width = string2.attribute(NSAttributedString.Key(rawValue: DTFloatWidthAttribute), at: floatedLocation, effectiveRange: nil) as? NSNumber
+		#expect(width?.doubleValue == 120)
+
+		// the main text must not be inside the float
+		let mainLocation = (string2.string as NSString).range(of: "main").location
+		let mainStyle = string2.attribute(NSAttributedString.Key(rawValue: DTFloatStyleAttribute), at: mainLocation, effectiveRange: nil)
+		#expect(mainStyle == nil)
+	}
+
+	@Test("Clear round-trips through HTML writing")
+	func clearRoundTrip() throws {
+		let html = "<p style=\"clear:both\">below the floats</p>"
+		let string1 = try #require(TestHelpers.attributedString(fromHTML: html))
+
+		let writer = HTMLWriter(attributedString: string1)
+		let writtenHTML = writer.htmlFragment()
+
+		#expect(writtenHTML.contains("clear:both"))
+
+		let string2 = try #require(TestHelpers.attributedString(fromHTML: writtenHTML))
+		let value = string2.attribute(NSAttributedString.Key(rawValue: DTClearFloatsAttribute), at: 0, effectiveRange: nil) as? NSNumber
+		#expect(value?.uintValue == DTHTMLElementClearStyle.both.rawValue)
+	}
+}


### PR DESCRIPTION
## What

Implements real CSS float layout. `float` was parsed into `DTHTMLElementFloatStyle` but never used — floated images were forced to be their own block as a workaround (the old comment in `TextAttachmentHTMLElement` said "we don't support float yet"). Now:

- **Floated images** become a box at the left/right content edge and the paragraph text wraps around them, returning to full width below the float.
- **Floated blocks** (`div`, `span`, even `table`) become a column — explicit CSS `width` or shrink-to-fit — laid out via the existing table-cell flow, including their backgrounds, padding and nested tables.
- **`clear:left/right/both`** makes paragraphs and floats start below earlier floated content.
- **HTML writer round-trip**: floated attachments get a wrapping `<span style="float:…">`, floated block ranges become `<div style="float:…;width:…px">`, `clear` is emitted on paragraph styles.

## How

- Elements emit `DTFloatStyleAttribute` (and `DTFloatWidthAttribute` for an explicit width, `DTClearFloatsAttribute` for clear) over their output range; the attachment workaround that forced floated images to be blocks is removed so they stay inline.
- `CoreTextLayoutFrame._buildLinesWithTypesetter` takes marked content out of the flow before the table check (so floated tables become columns), tracks float regions, and narrows the lines that vertically intersect them. Since a line's height is only known after typesetting, each line is re-typeset until the assumed float insets match its real vertical extent.
- Several floats on one side stack next to each other and move down when out of room; a float that does not fit a finite frame moves whole to the continuation frame (pagination); a standalone floated image absorbs its paragraph break so the flow gets no empty line.
- The float region (not the line metrics) drives the wrap, so this works on macOS too where attachments have no CT run delegate; the float line's ascent/descent are set from the attachment so its frame matches the image box on both platforms.

## Notes for review

- The native AppKit HTML importer was checked for parity: it carries **no** float information into attributed strings (a floated img/span is merely promoted to its own paragraph; float/width on a div are dropped, `clear` ignored). So unlike tables/`NSTextTable` there was nothing native to mirror, and DT-specific attributes are the only encoding option.
- Degradation: rendering a DT string in a plain `NSTextView` now shows a floated image inline in its paragraph (previously: own line). The wrap itself only happens in DT's own layout engine.
- Known limits (unchanged scope): floats inside table cells are ignored, and a float marker mid-line starts wrapping on the following line instead of splitting the current line box. Width-unknown frames disable floats.
- Tests: new `FloatLayoutTests` suite (16 tests: attribute emission, wrap geometry left/right, side-by-side floats, shrink-to-fit, clear, frame height, pagination, writer round-trips) plus a `Floats.html` demo snippet. Full suite passes: 315 tests on macOS, 307 on the iOS simulator (CI-equivalent invocations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)