### PR TITLE
Support CSS border-spacing on tables

### DIFF
--- a/Sources/DTCoreText/BuilderState+Tables.swift
+++ b/Sources/DTCoreText/BuilderState+Tables.swift
@@ -39,8 +39,11 @@ internal final class TableBuildContext {
   /// Cell padding from the `cellpadding` attribute, when present.
   var cellPaddingAttribute: CGFloat?
 
-  /// Margin to apply to every cell edge (half of the cell spacing).
-  var cellMargin: CGFloat = 0.5
+  /// Margin to apply to the left and right cell edges (half of the horizontal spacing).
+  var cellMarginHorizontal: CGFloat = 0.5
+
+  /// Margin to apply to the top and bottom cell edges (half of the vertical spacing).
+  var cellMarginVertical: CGFloat = 0.5
 
   /// Border width each cell gets when the table has a `border` attribute.
   var impliedCellBorderWidth: CGFloat = 0
@@ -135,12 +138,19 @@ extension BuilderState {
 
     if table.collapsesBorders {
       // collapsed tables have no spacing between cells
-      context.cellMargin = 0
+      context.cellMarginHorizontal = 0
+      context.cellMarginVertical = 0
+    } else if let spacingValue = styles["border-spacing"] as? String,
+      let spacing = borderSpacing(fromValue: spacingValue, element: tag)
+    {
+      // the spacing is split between the two adjacent cells
+      context.cellMarginHorizontal = spacing.horizontal / 2
+      context.cellMarginVertical = spacing.vertical / 2
     } else if let cellSpacingString = tag.attributeForKey("cellspacing"),
       let cellSpacing = Double(cellSpacingString)
     {
-      // the spacing is split between the two adjacent cells
-      context.cellMargin = CGFloat(cellSpacing) / 2
+      context.cellMarginHorizontal = CGFloat(cellSpacing) / 2
+      context.cellMarginVertical = CGFloat(cellSpacing) / 2
     }
 
     tableStack.append(context)
@@ -252,8 +262,13 @@ extension BuilderState {
     }
 
     // margins express the cell spacing, split between neighbors
-    if context.cellMargin > 0 {
-      cell.setWidth(context.cellMargin, type: .absoluteValueType, for: .margin)
+    if context.cellMarginHorizontal > 0 {
+      cell.setWidth(context.cellMarginHorizontal, type: .absoluteValueType, for: .margin, edge: .minXEdge)
+      cell.setWidth(context.cellMarginHorizontal, type: .absoluteValueType, for: .margin, edge: .maxXEdge)
+    }
+    if context.cellMarginVertical > 0 {
+      cell.setWidth(context.cellMarginVertical, type: .absoluteValueType, for: .margin, edge: .minYEdge)
+      cell.setWidth(context.cellMarginVertical, type: .absoluteValueType, for: .margin, edge: .maxYEdge)
     }
 
     // borders: black by default, 1 pt when the table has a border attribute, CSS overrides
@@ -404,6 +419,31 @@ extension BuilderState {
     case "solid", "groove", "ridge", "inset", "outset": return .solid
     default: return nil  // none, hidden
     }
+  }
+
+  /// Parses a CSS `border-spacing` value: one length for both axes, or two lengths in
+  /// horizontal/vertical order. Negative or non-length values are invalid.
+  private func borderSpacing(fromValue value: String, element: HTMLElement)
+    -> (horizontal: CGFloat, vertical: CGFloat)?
+  {
+    func length(fromComponent component: String) -> CGFloat? {
+      guard let firstCharacter = component.first, firstCharacter.isNumber || firstCharacter == "."
+      else { return nil }
+      return (component as NSString).pixelSizeOfCSSMeasure(
+        relativeToCurrentTextSize: element.fontDescriptor.pointSize, textScale: element.textScale)
+    }
+
+    let components = value.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+
+    guard let first = components.first, let horizontal = length(fromComponent: first) else {
+      return nil
+    }
+
+    if components.count > 1, let vertical = length(fromComponent: components[1]) {
+      return (horizontal, vertical)
+    }
+
+    return (horizontal, horizontal)
   }
 
   /// Resolves a CSS border width component, including the keyword widths.

--- a/Sources/DTCoreText/HTMLWriter.swift
+++ b/Sources/DTCoreText/HTMLWriter.swift
@@ -207,8 +207,9 @@ public class HTMLWriter: NSObject {
     return styles
   }
 
-  /// The opening tag for a table.
-  private func _openingTableTag(for table: TextTable) -> String {
+  /// The opening tag for a table. The cell spacing rides on the cells as margins of
+  /// half the spacing, so it is read off the table's first cell.
+  private func _openingTableTag(for table: TextTable, firstCell: TextTableBlock) -> String {
     var styles = _widthStyles(for: table)
 
     if let backgroundColor = table.backgroundColor, let hex = DTHexStringFromDTColor(backgroundColor) {
@@ -217,6 +218,18 @@ public class HTMLWriter: NSObject {
 
     if table.collapsesBorders {
       styles += "border-collapse:collapse;"
+    } else {
+      // only when it differs from the 0.5pt margin (1px spacing) importer default
+      let horizontal = firstCell.width(for: .margin, edge: .minXEdge) * 2
+      let vertical = firstCell.width(for: .margin, edge: .minYEdge) * 2
+
+      if horizontal != 1 || vertical != 1 {
+        if horizontal == vertical {
+          styles += "border-spacing:\(_pixelString(horizontal));"
+        } else {
+          styles += "border-spacing:\(_pixelString(horizontal)) \(_pixelString(vertical));"
+        }
+      }
     }
     if table.hidesEmptyCells {
       styles += "empty-cells:hide;"
@@ -401,7 +414,7 @@ public class HTMLWriter: NSObject {
 
         if openEmittedTables <= depth {
           // entering a new table
-          retString += _openingTableTag(for: openingCell.table)
+          retString += _openingTableTag(for: openingCell.table, firstCell: openingCell)
           retString += "\n<tr>"
           openEmittedTables = depth + 1
         }

--- a/Sources/DTCoreText/default.css
+++ b/Sources/DTCoreText/default.css
@@ -262,7 +262,6 @@ hr {
 table {
    display: table;
    border-collapse: separate;
-   border-spacing: 2px;
 }
 
 caption {

--- a/Tests/DTCoreTextTests/TableParsingTests.swift
+++ b/Tests/DTCoreTextTests/TableParsingTests.swift
@@ -320,6 +320,43 @@ struct TableParsingTests {
     #expect(cells[1].verticalAlignment == .middleAlignment)
   }
 
+  @Test("CSS border-spacing maps onto cell margins")
+  func cssBorderSpacing() throws {
+    // one value applies to both axes
+    let uniform = try parse("<table style=\"border-spacing: 8px\"><tr><td>A</td></tr></table>")
+    let uniformCells = tableCells(of: uniform)
+    try #require(uniformCells.count == 1)
+    for edge in allEdges {
+      #expect(uniformCells[0].width(for: .margin, edge: edge) == 4)
+    }
+
+    // two values are horizontal then vertical
+    let twoValue = try parse(
+      "<table style=\"border-spacing: 8px 4px\"><tr><td>A</td></tr></table>")
+    let twoValueCells = tableCells(of: twoValue)
+    try #require(twoValueCells.count == 1)
+    #expect(twoValueCells[0].width(for: .margin, edge: .minXEdge) == 4)
+    #expect(twoValueCells[0].width(for: .margin, edge: .maxXEdge) == 4)
+    #expect(twoValueCells[0].width(for: .margin, edge: .minYEdge) == 2)
+    #expect(twoValueCells[0].width(for: .margin, edge: .maxYEdge) == 2)
+
+    // CSS wins over the legacy cellspacing attribute
+    let both = try parse(
+      "<table cellspacing=\"10\" style=\"border-spacing: 8px\"><tr><td>A</td></tr></table>")
+    let bothCells = tableCells(of: both)
+    try #require(bothCells.count == 1)
+    #expect(bothCells[0].width(for: .margin, edge: .minXEdge) == 4)
+
+    // border-collapse ignores any spacing
+    let collapsed = try parse(
+      "<table style=\"border-collapse: collapse; border-spacing: 8px\"><tr><td>A</td></tr></table>")
+    let collapsedCells = tableCells(of: collapsed)
+    try #require(collapsedCells.count == 1)
+    for edge in allEdges {
+      #expect(collapsedCells[0].width(for: .margin, edge: edge) == 0)
+    }
+  }
+
   @Test("Border styles, multi-value lists and width keywords parse")
   func borderStylesAndLists() throws {
     let attributedString = try parse(

--- a/Tests/DTCoreTextTests/TableWritingTests.swift
+++ b/Tests/DTCoreTextTests/TableWritingTests.swift
@@ -154,6 +154,43 @@ struct TableWritingTests {
     #expect(cells[1].borderStyle(for: .minYEdge) == .double)
   }
 
+  @Test("Cell spacing round-trips through border-spacing")
+  func cellSpacingRoundTrip() throws {
+    // legacy cellspacing attribute is normalized to CSS border-spacing
+    let (_, fragment, reparsed) = try roundTrip(
+      "<table cellspacing=\"10\"><tr><td>A</td><td>B</td></tr></table>")
+
+    #expect(fragment.contains("border-spacing:10px"))
+
+    let cells = tableCells(of: reparsed)
+    try #require(cells.count == 2)
+    #expect(cells[0].width(for: .margin, edge: .minXEdge) == 5)
+    #expect(cells[0].width(for: .margin, edge: .minYEdge) == 5)
+
+    // asymmetric spacing keeps both values
+    let (_, asymmetricFragment, asymmetricReparsed) = try roundTrip(
+      "<table style=\"border-spacing: 8px 4px\"><tr><td>A</td></tr></table>")
+
+    #expect(asymmetricFragment.contains("border-spacing:8px 4px"))
+
+    let asymmetricCells = tableCells(of: asymmetricReparsed)
+    try #require(asymmetricCells.count == 1)
+    #expect(asymmetricCells[0].width(for: .margin, edge: .minXEdge) == 4)
+    #expect(asymmetricCells[0].width(for: .margin, edge: .maxXEdge) == 4)
+    #expect(asymmetricCells[0].width(for: .margin, edge: .minYEdge) == 2)
+    #expect(asymmetricCells[0].width(for: .margin, edge: .maxYEdge) == 2)
+
+    // the default spacing stays implicit
+    let (_, defaultFragment, defaultReparsed) = try roundTrip(
+      "<table><tr><td>A</td></tr></table>")
+
+    #expect(!defaultFragment.contains("border-spacing"))
+
+    let defaultCells = tableCells(of: defaultReparsed)
+    try #require(defaultCells.count == 1)
+    #expect(defaultCells[0].width(for: .margin, edge: .minXEdge) == 0.5)
+  }
+
   @Test("Percentage widths round-trip")
   func percentageWidthRoundTrip() throws {
     let (_, fragment, reparsed) = try roundTrip(


### PR DESCRIPTION
## Summary

`border-spacing` was declared in default.css but never consumed by the table parser — only the legacy `cellspacing` attribute worked — and the HTML writer never emitted cell spacing, so any spacing was silently lost on an HTML → attributed string → HTML round trip (e.g. `cellspacing="10"` came back as the 1px default).

- **Parser** (`BuilderState+Tables.swift`): `handleTableStart` now reads `border-spacing` from the CSS cascade (inline styles and stylesheets), supporting the one-value and two-value (`horizontal vertical`) forms. Precedence follows browsers: `border-collapse: collapse` forces zero spacing, CSS `border-spacing` beats the `cellspacing` attribute, and the 0.5pt-margin importer default applies otherwise. Cell margins are tracked per axis, so asymmetric spacing lays out correctly (layout already reads margins per edge).
- **Writer** (`HTMLWriter.swift`): the `<table>` tag emits `border-spacing` (first cell's margins × 2) whenever it differs from the 1px default, collapsed to one value when both axes match. Collapsed tables skip it.
- **default.css**: removed the dead `border-spacing: 2px` declaration. Now that the property is honored, the merged cascade cannot distinguish UA-origin from author-origin styles, so keeping it would override every `cellspacing` attribute and change the plain-table default away from the Apple-importer-parity 0.5pt margin pinned by `TextBlockAppKitParityTests`.

## Test plan

- New parsing test: one-value and two-value `border-spacing`, CSS-over-attribute precedence, and collapse-ignores-spacing.
- New round-trip test: `cellspacing="10"` is written as `border-spacing:10px` and reparses to 5pt margins; `border-spacing: 8px 4px` survives asymmetrically; default tables emit no `border-spacing`.
- Full suite: 301 tests in 30 suites pass, including the AppKit parity and system-importer comparison suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)