### PR TITLE
Synthesize missing UIKit font traits

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -38,14 +38,17 @@ jobs:
           xcode-version: "26.0"
       - name: Verify Swift version
         run: swift --version
-      # The runner image only ships the iOS platform for its default Xcode; after
-      # selecting a pinned Xcode that installation may have no simulator SDK.
-      - name: Ensure the iOS Simulator platform is present
+      # The runner image only ships runtimes for its default Xcode; after selecting
+      # a pinned Xcode there may be no compatible iOS Simulator runtime.
+      - name: Ensure a compatible iOS Simulator runtime is present
         run: |
-          if ! xcodebuild -showsdks | grep -q "iphonesimulator"; then
-            sudo xcodebuild -downloadPlatform iOS
+          ios_version="$(xcodebuild -version | awk '/^Xcode / { split($2, v, "."); print v[1] "." v[2] }')"
+          if ! xcrun simctl list runtimes available | grep -q "iOS ${ios_version} "; then
+            sudo xcodebuild -downloadPlatform iOS \
+              -buildVersion "${ios_version}" \
+              -architectureVariant arm64
           fi
-          xcrun simctl list devices available | grep "iPhone" || exit 1
+          xcrun simctl list runtimes available | grep "iOS ${ios_version} "
       - name: Build for iOS Simulator
         run: |
           xcodebuild build \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -38,11 +38,11 @@ jobs:
           xcode-version: "26.0"
       - name: Verify Swift version
         run: swift --version
-      # The runner image only ships simulator runtimes for its default Xcode; after
-      # selecting a pinned Xcode there may be no iOS runtime (and thus no devices).
-      - name: Ensure an iOS Simulator runtime is present
+      # The runner image only ships the iOS platform for its default Xcode; after
+      # selecting a pinned Xcode that installation may have no simulator SDK.
+      - name: Ensure the iOS Simulator platform is present
         run: |
-          if ! xcrun simctl list devices available | grep -q "iPhone"; then
+          if ! xcodebuild -showsdks | grep -q "iphonesimulator"; then
             sudo xcodebuild -downloadPlatform iOS
           fi
           xcrun simctl list devices available | grep "iPhone" || exit 1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -38,12 +38,6 @@ jobs:
           xcode-version: "26.0"
       - name: Verify Swift version
         run: swift --version
-      - name: Build for iOS Simulator
-        run: |
-          xcodebuild build \
-            -scheme DTCoreText-Package \
-            -destination "generic/platform=iOS Simulator" \
-            -skipPackagePluginValidation
       # The runner image only ships simulator runtimes for its default Xcode; after
       # selecting a pinned Xcode there may be no iOS runtime (and thus no devices).
       - name: Ensure an iOS Simulator runtime is present
@@ -52,6 +46,12 @@ jobs:
             sudo xcodebuild -downloadPlatform iOS
           fi
           xcrun simctl list devices available | grep "iPhone" || exit 1
+      - name: Build for iOS Simulator
+        run: |
+          xcodebuild build \
+            -scheme DTCoreText-Package \
+            -destination "generic/platform=iOS Simulator" \
+            -skipPackagePluginValidation
       - name: Test on iOS Simulator
         run: |
           xcodebuild test \

--- a/Sources/DTCoreText/HTMLElement.swift
+++ b/Sources/DTCoreText/HTMLElement.swift
@@ -165,8 +165,20 @@ open class HTMLElement: HTMLParserNode {
 
       if let font = font {
         #if canImport(UIKit)
-          let uiFont = UIFont.font(with: font)
-          tmpDict[NSAttributedString.Key.font] = uiFont
+          if let uiFont = UIFont.font(with: font) {
+            tmpDict[NSAttributedString.Key.font] = uiFont
+
+            let symbolicTraits = uiFont.fontDescriptor.symbolicTraits
+
+            if fontDescriptor.italicTrait && !symbolicTraits.contains(.traitItalic) {
+              tmpDict[NSAttributedString.Key.obliqueness] = NSNumber(value: 0.2)
+            }
+
+            if fontDescriptor.boldTrait && !symbolicTraits.contains(.traitBold) {
+              // Negative stroke widths fill and stroke glyphs, producing faux bold.
+              tmpDict[NSAttributedString.Key.strokeWidth] = NSNumber(value: -3.0)
+            }
+          }
         #else
           tmpDict[NSAttributedString.Key.font] = font
         #endif

--- a/Sources/DTCoreText/HTMLElement.swift
+++ b/Sources/DTCoreText/HTMLElement.swift
@@ -170,7 +170,9 @@ open class HTMLElement: HTMLParserNode {
 
             let symbolicTraits = uiFont.fontDescriptor.symbolicTraits
 
-            if fontDescriptor.italicTrait && !symbolicTraits.contains(.traitItalic) {
+            if fontDescriptor.italicTrait && !symbolicTraits.contains(.traitItalic)
+              && CTFontGetMatrix(font).isIdentity
+            {
               tmpDict[NSAttributedString.Key.obliqueness] = NSNumber(value: 0.2)
             }
 

--- a/Sources/DTCoreText/UIFont+DTCoreText.swift
+++ b/Sources/DTCoreText/UIFont+DTCoreText.swift
@@ -20,6 +20,15 @@ import Foundation
         font = UIFont(name: "HelveticaNeue-LightItalic", size: fontSize)
       }
 
+      let matrix = CTFontGetMatrix(ctFont)
+      if let font, !matrix.isIdentity {
+        // Preserve synthetic transforms for both UIKit and Core Text runs.
+        let descriptor = font.fontDescriptor.addingAttributes([
+          UIFontDescriptor.AttributeName.matrix: NSValue(cgAffineTransform: matrix)
+        ])
+        return UIFont(descriptor: descriptor, size: fontSize)
+      }
+
       return font
     }
   }

--- a/Tests/DTCoreTextTests/HTMLElementTests.swift
+++ b/Tests/DTCoreTextTests/HTMLElementTests.swift
@@ -102,4 +102,38 @@ struct HTMLElementTests {
 		#expect(attachment.textAttachment!.displaySize.width == 455)
 		#expect(attachment.textAttachment!.displaySize.height == 500)
 	}
+
+	#if canImport(UIKit)
+	@Test("Missing UIKit font traits are synthesized")
+	func missingUIKitFontTraitsAreSynthesized() throws {
+		_ = try #require(UIFont(name: "Zapfino", size: 20))
+		let attributedString = try #require(TestHelpers.attributedString(
+			fromHTML: "<span style=\"font-family:'Zapfino'\"><b><i>text</i></b></span>"))
+		let attributes = attributedString.attributes(at: 0, effectiveRange: nil) as NSDictionary
+		let resolvedFont = try #require(attributes[NSAttributedString.Key.font] as? UIFont)
+
+		#expect(!resolvedFont.fontDescriptor.symbolicTraits.contains(.traitBold))
+		#expect(!resolvedFont.fontDescriptor.symbolicTraits.contains(.traitItalic))
+		#expect(attributes[NSAttributedString.Key.obliqueness] as? NSNumber == 0.2)
+		#expect(attributes[NSAttributedString.Key.strokeWidth] as? NSNumber == -3.0)
+	}
+
+	@Test("Existing UIKit font traits are not synthesized")
+	func existingUIKitFontTraitsAreNotSynthesized() throws {
+		let requestedFonts = [
+			("Helvetica-Bold", NSAttributedString.Key.strokeWidth),
+			("Helvetica-Oblique", NSAttributedString.Key.obliqueness),
+		]
+
+		for (fontName, syntheticAttribute) in requestedFonts {
+			let font = try #require(UIFont(name: fontName, size: 20))
+			let element = HTMLElement(name: "span", attributes: nil)
+			element.fontDescriptor = CoreTextFontDescriptor(
+				ctFont: CTFontCreateWithName(font.fontName as CFString, font.pointSize, nil))
+
+			let attributes = element.attributesForAttributedStringRepresentation()
+			#expect(attributes[syntheticAttribute] == nil)
+		}
+	}
+	#endif
 }

--- a/Tests/DTCoreTextTests/HTMLElementTests.swift
+++ b/Tests/DTCoreTextTests/HTMLElementTests.swift
@@ -104,7 +104,7 @@ struct HTMLElementTests {
 	}
 
 	#if canImport(UIKit)
-	@Test("Missing UIKit font traits are synthesized")
+	@Test("Missing UIKit font traits are synthesized for UIKit and Core Text")
 	func missingUIKitFontTraitsAreSynthesized() throws {
 		_ = try #require(UIFont(name: "Zapfino", size: 20))
 		let attributedString = try #require(TestHelpers.attributedString(
@@ -114,8 +114,20 @@ struct HTMLElementTests {
 
 		#expect(!resolvedFont.fontDescriptor.symbolicTraits.contains(.traitBold))
 		#expect(!resolvedFont.fontDescriptor.symbolicTraits.contains(.traitItalic))
-		#expect(attributes[NSAttributedString.Key.obliqueness] as? NSNumber == 0.2)
+		#expect(attributes[NSAttributedString.Key.obliqueness] == nil)
 		#expect(attributes[NSAttributedString.Key.strokeWidth] as? NSNumber == -3.0)
+
+		let layouter = try #require(CoreTextLayouter(attributedString: attributedString))
+		let layoutFrame = try #require(layouter.layoutFrame(
+			with: CGRect(x: 0, y: 0, width: 200, height: 100),
+			range: NSRange(location: 0, length: attributedString.length)))
+		let line = try #require((layoutFrame.lines as? [CoreTextLayoutLine])?.first)
+		let run = try #require((line.glyphRuns as? [CoreTextGlyphRun])?.first)
+		let runFont = try #require(
+			run.attributes[NSAttributedString.Key(rawValue: kCTFontAttributeName as String)]
+				as! CTFont?)
+
+		#expect(CTFontGetMatrix(runFont).c == 0.25)
 	}
 
 	@Test("Existing UIKit font traits are not synthesized")


### PR DESCRIPTION
Resolves #1323.

## Summary
- add UIKit-native obliqueness when an italic request resolves to a non-italic `UIFont`
- add a negative stroke width when a bold request resolves to a non-bold `UIFont`
- preserve real bold and italic faces without synthetic attributes
- cover faux bold/italic composition through the HTML attributed-string path

## Verification
- `swift build --build-tests --scratch-path /Volumes/SSD/SwiftPM/DTCoreText-issue-1323`
- `swift test --skip-build --scratch-path /Volumes/SSD/SwiftPM/DTCoreText-issue-1323` (318 tests)
- `xcodebuild test -project DTCoreText.xcodeproj -scheme DTCoreText-Package -destination 'platform=iOS Simulator,id=6805ED2E-71F6-4BF1-A104-5F76C340A250' -derivedDataPath /Volumes/SSD/SwiftPM/DTCoreText-issue-1323/DerivedData -only-testing:DTCoreTextTests/HTMLElementTests` (6 tests)